### PR TITLE
Avoid modifications in dictionary during iteration

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1394,6 +1394,24 @@ class TestRollback(TestCase):
         self.assertRaises(TraitError, assign_rollback)
 
 
+class CacheModification(HasTraits):
+    foo = Int()
+    bar = Int()
+
+    def _bar_validate(self, value, trait):
+        self.foo = value
+        return value
+
+    def _foo_validate(self, value, trait):
+        self.bar = value
+        return value
+
+
+def test_cache_modification():
+    CacheModification(foo=1)
+    CacheModification(bar=1)
+
+
 class OrderTraits(HasTraits):
     notified = Dict()
     

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -613,7 +613,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
                 self._notify_trait = hold
                 self._cross_validation_lock = True
                 yield
-                for name in cache.keys():
+                for name in list(cache.keys()):
                     if hasattr(self, '_%s_validate' % name):
                         cross_validate = getattr(self, '_%s_validate' % name)
                         setattr(self, name, cross_validate(getattr(self, name), self))

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -613,15 +613,15 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
                 self._notify_trait = hold
                 self._cross_validation_lock = True
                 yield
-                for name in cache:
+                for name in cache.keys():
                     if hasattr(self, '_%s_validate' % name):
                         cross_validate = getattr(self, '_%s_validate' % name)
                         setattr(self, name, cross_validate(getattr(self, name), self))
             except TraitError as e:
                 self._notify_trait = lambda *x: None
-                for name in cache:
-                    if cache[name][1] is not Undefined:
-                        setattr(self, name, cache[name][1])
+                for name, value in cache.items():
+                    if value[1] is not Undefined:
+                        setattr(self, name, value[1])
                     else:
                         self._trait_values.pop(name)
                 cache = {}


### PR DESCRIPTION
Calls to monkey-patched _notify_trait resulting from cross validation may cause the `cache` dictionary to be modified.