### PR TITLE
Use full qualified name in traitlet error.

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -943,8 +943,8 @@ class Type(ClassBasedTraitType):
         if isinstance(self.klass, py3compat.string_types):
             klass = self.klass
         else:
-            klass = self.klass.__name__
-        result = 'a subclass of ' + klass
+            klass = self.klass.__module__+'.'+self.klass.__name__
+        result = "a subclass of '%s'" % klass
         if self.allow_none:
             return result + ' or None'
         return result


### PR DESCRIPTION
Because knowing that

> The 'contents_manager_class' trait of a NotebookApp instance must be a
> subclass of ContentsManager

is not helpful, if I don't know where to find the new implementation of
`ContentsManager`.

> The 'contents_manager_class' trait of a NotebookApp instance must be a
> subclass of 'jupyter_notebook.services.contents.manager.ContentsManager'

is much more useful.