### PR TITLE
Adding key-specific dict validation

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1093,15 +1093,17 @@ def test_dict_assignment():
 
 class ValidatedDictTrait(HasTraits):
 
-    value = Dict(Unicode())
+    value = Dict(trait=Unicode(),
+                 traits={'foo': Int(required=True)},
+                 default_value={'foo': 1})
 
 class TestInstanceDict(TraitTestBase):
 
     obj = ValidatedDictTrait()
 
-    _default_value = {}
-    _good_values = [{'0': 'foo'}, {'1': 'bar'}]
-    _bad_values = [{'0': 0}, {'1': 1}]
+    _default_value = {'foo': 1}
+    _good_values = [{'0': 'foo', 'foo': 1}, {'1': 'bar', 'foo': 2}]
+    _bad_values = [{'0': 0, 'foo': 1}, {'1': 'bar', 'foo': 'bar'}]
 
 
 def test_dict_default_value():

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1094,7 +1094,7 @@ def test_dict_assignment():
 class ValidatedDictTrait(HasTraits):
 
     value = Dict(trait=Unicode(),
-                 traits={'foo': Int(required=True)},
+                 traits={'foo': Int()},
                  default_value={'foo': 1})
 
 class TestInstanceDict(TraitTestBase):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1731,8 +1731,6 @@ class Dict(Instance):
         traits : Dictionary of trait types [optional]
             The type for restricting the content of the Dictionary for certain
             keys.
-            If the trait types are marked as `required`, the validation stage
-            will check that a value is present for that key.
 
         default_value : SequenceType [ optional ]
             The default value for the Dict.  Must be dict, tuple, or None, and
@@ -1761,7 +1759,7 @@ class Dict(Instance):
         else:
             raise TypeError('default value of Dict was %s' % default_value)
 
-        # Case where a type of TraitType is provided eather than an instance
+        # Case where a type of TraitType is provided rather than an instance
         if is_trait(trait):
             self._trait = trait() if isinstance(trait, type) else trait
             self._trait.name = 'element'
@@ -1772,9 +1770,6 @@ class Dict(Instance):
         if traits is not None:
             for t in traits.values():
                 t.name = 'element'
-            self._required = [key for key in traits if traits[key]._metadata.get('required')]
-        else:
-            self._required = None
 
         super(Dict, self).__init__(klass=dict, args=args, **metadata)
 
@@ -1791,8 +1786,8 @@ class Dict(Instance):
         return value
 
     def validate_elements(self, obj, value):
-        if self._required is not None:
-            for key in self._required:
+        if self._traits is not None:
+            for key in self._traits:
                 if key not in value:
                     raise TraitError("Missing required '%s' key for the '%s' trait of %s instance"
                                      % (key, self.name, class_of(obj)))


### PR DESCRIPTION
Now, Dict trait type's ctor has an additional optional argument, `traits`. `traits` is a dictionary of trait types. 
When provided, the element validation stage first checks for the traittype of the corresponding key, before defaulting to the general `trait` used for other keys.
Moreover, the corresponding trait type may have a `required` metadata. If True, the corresponding key will be required. 
