### PR TITLE
Take default value for Enum from allowed values

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1419,9 +1419,15 @@ class CBool(Bool):
 class Enum(TraitType):
     """An enum that whose value must be in a given sequence."""
 
-    def __init__(self, values, default_value=None, **metadata):
+    def __init__(self, values, default_value=NoDefaultSpecified, allow_none=False,  **metadata):
         self.values = values
-        super(Enum, self).__init__(default_value, **metadata)
+        if default_value is NoDefaultSpecified:
+            if (not allow_none) and values:
+                # The first value in a list/tuple, or an arbitrary value from a set
+                default_value = next(iter(values))
+            else:
+                default_value = None
+        super(Enum, self).__init__(default_value, allow_none=allow_none, **metadata)
 
     def validate(self, obj, value):
         if value in self.values:


### PR DESCRIPTION
If no default is explicitly specified and allow_none is False (the default), Enum currently causes an error if you instantiate the object owning it without supplying a value for it. E.g.

```python
class ExecuteReply(Reference):
    execution_count = Integer()
    status = Enum((u'ok', u'error'))
    ...

ExecuteReply()  # TraitError
```

This changes makes it take the first of the possible values as the default instead. If you still want to force the code instantiating the class to supply a value, you can create the Enum with `default_value=None`.