### PR TITLE
Ignore unspecified default value until first access

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1607,3 +1607,20 @@ class TestDynamicTraits(TestCase):
         a.x = 20
         a.y = 20.0
         self.assertEqual(len(self._notify1), 0)
+
+
+def test_enum_no_default():
+    class C(HasTraits):
+        t = Enum(['a', 'b'])
+
+    c = C()
+    c.t  = 'a'
+    assert c.t == 'a'
+
+    c = C()
+
+    with nt.assert_raises(TraitError):
+        t = c.t
+
+    c = C(t='b')
+    assert c.t == 'b'

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1433,6 +1433,8 @@ class Enum(TraitType):
 
     def __init__(self, values, default_value=NoDefaultSpecified, **metadata):
         self.values = values
+        if metadata.get('allow_none', False) and default_value is NoDefaultSpecified:
+            default_value = None
         super(Enum, self).__init__(default_value, **metadata)
 
     def validate(self, obj, value):


### PR DESCRIPTION
Alternative to #13

Previously, if:

- The traitlet class does not specify a default value,
- The use of the traitlet does not provide a default value,
- The class using the traitlet does not have a _foo_default method, and
- The instantiation of that class does not provide a value for the
traitlet

then the traitlet would try to set its value to the undefined default, usually causing an error. With this change, it will skip that, so the traitlet will have no value. If it is accessed before a value has been
set, the error will occur then instead.

This allows Enums with no default value, which I want for kernelspec.

`Instance` traitlets are not affected - they will still create an instance of the specified class when the class using them is instantiated.

Ping @ssanderson @SylvainCorlay 