### PR TITLE
log.warn deprecated for log.warning

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -546,7 +546,7 @@ class Application(SingletonConfigurable):
         if len(loaded) > 1:
             collisions = loaded[0].collisions(loaded[1])
             if collisions:
-                self.log.warn("Collisions detected in {0}.py and {0}.json config files."
+                self.log.warning("Collisions detected in {0}.py and {0}.json config files."
                               " {0}.json has higher priority: {1}".format(
                               filename, json.dumps(collisions, indent=2),
                 ))

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -407,7 +407,7 @@ class JSONFileConfigLoader(FileConfigLoader):
             version = dictionary.pop('version')
         else:
             version = 1
-            self.log.warn("Unrecognized JSON config file version, assuming version {}".format(version))
+            self.log.warning("Unrecognized JSON config file version, assuming version {}".format(version))
 
         if version == 1:
             return Config(dictionary)
@@ -636,7 +636,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
                     lhs = aliases[lhs]
                 if '.' not in lhs:
                     # probably a mistyped alias, but not technically illegal
-                    self.log.warn("Unrecognized alias: '%s', it will probably have no effect.", raw)
+                    self.log.warning("Unrecognized alias: '%s', it will probably have no effect.", raw)
                 try:
                     self._exec_config_str(lhs, rhs)
                 except Exception:


### PR DESCRIPTION
Alias exists since at least 2.7