### PR TITLE
Clean up traitlets.config docs

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -2,6 +2,8 @@
 Configurable objects with traitlets.config
 ==========================================
 
+.. module:: traitlets.config
+
 This document describes :mod:`traitlets.config`,
 the traitlets-based configuration system used by IPython and Jupyter.
 


### PR DESCRIPTION
* Remove references to IPython (except in examples) and profiles
* Canonical locations for most objects is the traitlets.config package
* Other misc. cleanups

There's still some way to go on documenting how someone would actually build a new application using this machinery, but I think this gets it to a state where it would be reasonable to release and add information later.

Also working on a corresponding PR for IPython itself.