### PR TITLE
API to generate rST docs for configurable options

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -372,44 +372,11 @@ class Application(SingletonConfigurable):
 
         Returns a multiline string.
         """
-        lines = []
-        for cls in self.classes:
-            classname = cls.__name__
-            for k, trait in sorted(cls.class_traits(config=True).items()):
-                ttype = trait.__class__.__name__
+        chunks = []
+        for cls in self._classes_inc_parents():
+            chunks.append(cls.class_config_rst_doc())
 
-                termline = classname + '.' + trait.name
-
-                # Choices or type
-                if 'Enum' in ttype:
-                    # include Enum choices
-                    termline += ' : ' + '|'.join(repr(x) for x in trait.values)
-                else:
-                    termline += ' : ' + ttype
-                lines.append(termline)
-
-                # Default value
-                try:
-                    dv = trait.get_default_value()
-                    dvr = repr(dv)
-                except Exception:
-                    dvr = dv = None # ignore defaults we can't construct
-                if (dv is not None) and (dvr is not None):
-                    if len(dvr) > 64:
-                        dvr = dvr[:61]+'...'
-                    # Double up backslashes, so they get to the rendered docs
-                    dvr = dvr.replace('\\n', '\\\\n')
-                    lines.append('    Default: `%s`' % dvr)
-                    lines.append('')
-
-                help = trait.get_metadata('help')
-                if help is not None:
-                    lines.append(indent(dedent(help), 4))
-                else:
-                    lines.append('    No description')
-
-                lines.append('')
-        return '\n'.join(lines)
+        return '\n'.join(chunks)
 
 
     def print_description(self):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -572,7 +572,7 @@ class Application(SingletonConfigurable):
         """generate default config file from Configurables"""
         lines = ["# Configuration file for %s." % self.name]
         lines.append('')
-        for cls in self.classes:
+        for cls in self._classes_inc_parents():
             lines.append(cls.class_config_section())
         return '\n'.join(lines)
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -372,11 +372,8 @@ class Application(SingletonConfigurable):
 
         Returns a multiline string.
         """
-        chunks = []
-        for cls in self._classes_inc_parents():
-            chunks.append(cls.class_config_rst_doc())
-
-        return '\n'.join(chunks)
+        return '\n'.join(c.class_config_rst_doc()
+                         for c in self._classes_inc_parents())
 
 
     def print_description(self):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -128,15 +128,6 @@ class Application(SingletonConfigurable):
     # A sequence of Configurable subclasses whose config=True attributes will
     # be exposed at the command line.
     classes = []
-    @property
-    def _help_classes(self):
-        """Define `App.help_classes` if CLI classes should differ from config file classes"""
-        return getattr(self, 'help_classes', self.classes)
-    
-    @property
-    def _config_classes(self):
-        """Define `App.config_classes` if config file classes should differ from CLI classes."""
-        return getattr(self, 'config_classes', self.classes)
 
     def _classes_inc_parents(self):
         """Iterate through configurable classes, including configurable parents
@@ -283,7 +274,7 @@ class Application(SingletonConfigurable):
 
         lines = []
         classdict = {}
-        for cls in self._help_classes:
+        for cls in self.classes:
             # include all parents (up to, but excluding Configurable) in available names
             for c in cls.mro()[:-3]:
                 classdict[c.__name__] = c
@@ -358,7 +349,7 @@ class Application(SingletonConfigurable):
         self.print_options()
 
         if classes:
-            help_classes = self._help_classes
+            help_classes = self.classes
             if help_classes:
                 print("Class parameters")
                 print("----------------")
@@ -382,7 +373,7 @@ class Application(SingletonConfigurable):
         Returns a multiline string.
         """
         lines = []
-        for cls in self._config_classes:
+        for cls in self.classes:
             classname = cls.__name__
             for k, trait in sorted(cls.class_traits(config=True).items()):
                 ttype = trait.__class__.__name__
@@ -484,7 +475,7 @@ class Application(SingletonConfigurable):
         # it will be a dict by parent classname of classes in our list
         # that are descendents
         mro_tree = defaultdict(list)
-        for cls in self._help_classes:
+        for cls in self.classes:
             clsname = cls.__name__
             for parent in cls.mro()[1:-3]:
                 # exclude cls itself and Configurable,HasTraits,object
@@ -614,7 +605,7 @@ class Application(SingletonConfigurable):
         """generate default config file from Configurables"""
         lines = ["# Configuration file for %s." % self.name]
         lines.append('')
-        for cls in self._config_classes:
+        for cls in self.classes:
             lines.append(cls.class_config_section())
         return '\n'.join(lines)
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 
 from .loader import Config, LazyConfigValue
 from traitlets.traitlets import HasTraits, Instance
-from ipython_genutils.text import indent, wrap_paragraphs
+from ipython_genutils.text import indent, dedent, wrap_paragraphs
 from ipython_genutils.py3compat import iteritems
 
 
@@ -275,6 +275,52 @@ class Configurable(HasTraits):
             lines.append(c(help))
             lines.append('# c.%s.%s = %r'%(cls.__name__, name, trait.get_default_value()))
             lines.append('')
+        return '\n'.join(lines)
+
+    @classmethod
+    def class_config_rst_doc(cls):
+        """Generate rST documentation for this class' config options.
+
+        Excludes traits defined on parent classes.
+        """
+        lines = []
+        classname = cls.__name__
+        for k, trait in sorted(cls.class_own_traits(config=True).items()):
+            ttype = trait.__class__.__name__
+
+            termline = classname + '.' + trait.name
+
+            # Choices or type
+            if 'Enum' in ttype:
+                # include Enum choices
+                termline += ' : ' + '|'.join(repr(x) for x in trait.values)
+            else:
+                termline += ' : ' + ttype
+            lines.append(termline)
+
+            # Default value
+            try:
+                dv = trait.get_default_value()
+                dvr = repr(dv)
+            except Exception:
+                dvr = dv = None # ignore defaults we can't construct
+            if (dv is not None) and (dvr is not None):
+                if len(dvr) > 64:
+                    dvr = dvr[:61]+'...'
+                # Double up backslashes, so they get to the rendered docs
+                dvr = dvr.replace('\\n', '\\\\n')
+                lines.append('    Default: ``%s``' % dvr)
+                lines.append('')
+
+            help = trait.get_metadata('help')
+            if help is not None:
+                lines.append(indent(dedent(help), 4))
+            else:
+                lines.append('    No description')
+
+            # Blank line
+            lines.append('')
+
         return '\n'.join(lines)
 
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -256,21 +256,7 @@ class Configurable(HasTraits):
             lines.append(c(desc))
             lines.append('')
 
-        parents = []
-        for parent in cls.mro():
-            # only include parents that are not base classes
-            # and are not the class itself
-            # and have some configurable traits to inherit
-            if parent is not cls and issubclass(parent, Configurable) and \
-                    parent.class_traits(config=True):
-                parents.append(parent)
-
-        if parents:
-            pstr = ', '.join([ p.__name__ for p in parents ])
-            lines.append(c('%s will inherit config from: %s'%(cls.__name__, pstr)))
-            lines.append('')
-
-        for name, trait in iteritems(cls.class_traits(config=True)):
+        for name, trait in iteritems(cls.class_own_traits(config=True)):
             help = trait.get_metadata('help') or ''
             lines.append(c(help))
             lines.append('# c.%s.%s = %r'%(cls.__name__, name, trait.get_default_value()))

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -814,16 +814,9 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
 
         Works like `class_traits`, except for excluding traits from parents.
         """
-        class_traits = cls.class_traits(**metadata)
-
-        result = {}
         sup = super(cls, cls)
-        for name, trait in class_traits.items():
-            if getattr(sup, name, None) is not trait:
-                # Trait is missing or different in hierarchy above this class
-                result[name] = trait
-
-        return result
+        return {n: t for (n, t) in cls.class_traits(**metadata).items()
+                if getattr(sup, n, None) is not t}
 
     def trait_names(self, **metadata):
         """Get a list of all the names of this class' traits."""

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -808,6 +808,23 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
 
         return result
 
+    @classmethod
+    def class_own_traits(cls, **metadata):
+        """Get a dict of all the traitlets defined on this class, not a parent.
+
+        Works like `class_traits`, except for excluding traits from parents.
+        """
+        class_traits = cls.class_traits(**metadata)
+
+        result = {}
+        sup = super(cls, cls)
+        for name, trait in class_traits.items():
+            if getattr(sup, name, None) is not trait:
+                # Trait is missing or different in hierarchy above this class
+                result[name] = trait
+
+        return result
+
     def trait_names(self, **metadata):
         """Get a list of all the names of this class' traits."""
         return self.traits(**metadata).keys()


### PR DESCRIPTION
Corresponding PR to ipython/ipython coming up.

I discussed this yesterday with @minrk , and I think that each config option should only be described once, on the most general class that it applies to, and neither the config documentation nor the generated default config file should try to describe inheritance relationships. To this end, there are a couple of new methods:

- `Application._classes_inc_parents()` walks through the list of configurable classes for the application, yielding them along with all configurable parents.
- `HasTraits.class_own_traits()` is like `.class_traits()`, but only takes the traits defined on this class, not on its parents.

Also gets rid of help_classes and config_classes (#20).