### PR TITLE
Create BaseDescriptor parent class to TraitType and add obj argument to instance_init

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -303,17 +303,12 @@ dlink = directional_link
 class BaseTraitType(object):
     """Base class for TraitType
 
-    This allows other classes than TraitType to hook into the MetaHasTraits
-    metaclass machinery.
-    """
-
-class TraitType(BaseTraitType):
-    """A base class for all trait descriptors.
-
     Notes
     -----
     Our implementation of traits is based on Python's descriptor
-    prototol.  This class is the base class for all such descriptors.  The
+    prototol.  
+
+    This class is the base class for all such descriptors.  The
     only magic we use is a custom metaclass for the main :class:`HasTraits`
     class that does the following:
 
@@ -323,6 +318,23 @@ class TraitType(BaseTraitType):
        instance in the class dict to the *class* that declared the trait.
        This is used by the :class:`This` trait to allow subclasses to
        accept superclasses for :class:`This` values.
+    """
+
+    def instance_init(self, obj):
+        """Part of the initialization which may depend on the underlying
+        HasTraits instance.
+
+        It is typically overloaded for specific types.
+
+        This method is called by :meth:`HasTraits.__new__` and in the
+        :meth:`TraitType.instance_init` method of trait types holding
+        other trait types.
+        """
+        pass
+
+
+class TraitType(BaseTraitType):
+    """A base class for all trait types.
     """
 
     metadata = {}
@@ -370,18 +382,6 @@ class TraitType(BaseTraitType):
     def get_default_value(self):
         """Create a new instance of the default value."""
         return self.default_value
-
-    def instance_init(self, obj):
-        """Part of the initialization which may depend on the underlying
-        HasTraits instance.
-
-        It is typically overloaded for specific trait types.
-
-        This method is called by :meth:`HasTraits.__new__` and in the
-        :meth:`TraitType.instance_init` method of trait types holding
-        other trait types.
-        """
-        pass
 
     def init_default_value(self, obj):
         """Instantiate the default value for the trait type.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -297,28 +297,30 @@ dlink = directional_link
 
 
 #-----------------------------------------------------------------------------
-# Base TraitType for all traits
+# Base Descriptor Class 
 #-----------------------------------------------------------------------------
 
-class BaseTraitType(object):
-    """Base class for TraitType
+class BaseDescriptor(object):
+    """Base descriptor class
 
     Notes
     -----
-    Our implementation of traits is based on Python's descriptor
-    prototol.  
+    This implements Python's descriptor prototol.  
 
     This class is the base class for all such descriptors.  The
     only magic we use is a custom metaclass for the main :class:`HasTraits`
     class that does the following:
 
-    1. Sets the :attr:`name` attribute of every :class:`TraitType`
+    1. Sets the :attr:`name` attribute of every :class:`BaseDescriptor`
        instance in the class dict to the name of the attribute.
-    2. Sets the :attr:`this_class` attribute of every :class:`TraitType`
+    2. Sets the :attr:`this_class` attribute of every :class:`BaseDescriptor`
        instance in the class dict to the *class* that declared the trait.
        This is used by the :class:`This` trait to allow subclasses to
        accept superclasses for :class:`This` values.
     """
+
+    name = None
+    this_class = None
 
     def instance_init(self, obj):
         """Part of the initialization which may depend on the underlying
@@ -327,13 +329,13 @@ class BaseTraitType(object):
         It is typically overloaded for specific types.
 
         This method is called by :meth:`HasTraits.__new__` and in the
-        :meth:`TraitType.instance_init` method of trait types holding
-        other trait types.
+        :meth:`BaseDescriptor.instance_init` method of descriptors holding
+        other descriptors.
         """
         pass
 
 
-class TraitType(BaseTraitType):
+class TraitType(BaseDescriptor):
     """A base class for all trait types.
     """
 
@@ -548,7 +550,7 @@ class MetaHasTraits(type):
         # print "MetaHasTraitlets (bases): ", bases
         # print "MetaHasTraitlets (classdict): ", classdict
         for k,v in iteritems(classdict):
-            if isinstance(v, BaseTraitType):
+            if isinstance(v, BaseDescriptor):
                 v.name = k
             elif inspect.isclass(v):
                 if issubclass(v, TraitType):
@@ -596,7 +598,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
             except AttributeError:
                 pass
             else:
-                if isinstance(value, BaseTraitType):
+                if isinstance(value, BaseDescriptor):
                     value.instance_init(inst)
                     if isinstance(value, TraitType) and key not in kw:
                         value._set_default_value_at_instance_init(inst)


### PR DESCRIPTION
As I am working on widget signals and slots, this is meant to simplify the extension of traitlets in widgets.

- created a `BaseDescriptor` class, a parent to TraitType which is used in the metaclass - so that one does not need to subclass the metaclass for signals and slots.
- `instance_init` now takes an `obj` argument, that is the underlying `HasTraits` instance. On this regard, the documentation was already saying:

    ```
    Part of the initialization which may depend on the underlying HasTrait instance
    ```

    and it was not the case anymore.