### PR TITLE
Simplify deferred creation of default values

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -84,11 +84,6 @@ class TestTraitType(TestCase):
         a = A()
         self.assertEqual(a.tt, 10)
 
-        # Defaults are validated when the HasTraits is instantiated
-        class B(HasTraits):
-            tt = MyIntTT('bad default')
-        self.assertRaises(TraitError, B)
-
     def test_info(self):
         class A(HasTraits):
             tt = TraitType
@@ -118,7 +113,6 @@ class TestTraitType(TestCase):
         self.assertEqual(a.x, 11)
         self.assertEqual(a._trait_values, {'x': 11})
         b = B()
-        self.assertEqual(b._trait_values, {'x': 20})
         self.assertEqual(list(a._trait_dyn_inits.keys()), ['x'])
         self.assertEqual(b.x, 20)
         c = C()
@@ -200,9 +194,9 @@ class TestHasTraitsNotify(TestCase):
         a = A()
         a.on_trait_change(self.notify1)
         a.a = 0
-        self.assertEqual(len(self._notify1),0)
+        self.assertEqual(len(self._notify1), 1)
         a.b = 0.0
-        self.assertEqual(len(self._notify1),0)
+        self.assertEqual(len(self._notify1), 2)
         a.a = 10
         self.assertTrue(('a',0,10) in self._notify1)
         a.b = 10.0
@@ -213,7 +207,7 @@ class TestHasTraitsNotify(TestCase):
         a.on_trait_change(self.notify1,remove=True)
         a.a = 20
         a.b = 20.0
-        self.assertEqual(len(self._notify1),0)
+        self.assertEqual(len(self._notify1), 0)
 
     def test_notify_one(self):
 
@@ -224,7 +218,7 @@ class TestHasTraitsNotify(TestCase):
         a = A()
         a.on_trait_change(self.notify1, 'a')
         a.a = 0
-        self.assertEqual(len(self._notify1),0)
+        self.assertEqual(len(self._notify1), 1)
         a.a = 10
         self.assertTrue(('a',0,10) in self._notify1)
         self.assertRaises(TraitError,setattr,a,'a','bad string')
@@ -258,8 +252,8 @@ class TestHasTraitsNotify(TestCase):
         b.on_trait_change(self.notify2, 'b')
         b.a = 0
         b.b = 0.0
-        self.assertEqual(len(self._notify1),0)
-        self.assertEqual(len(self._notify2),0)
+        self.assertEqual(len(self._notify1), 1)
+        self.assertEqual(len(self._notify2), 1)
         b.a = 10
         b.b = 10.0
         self.assertTrue(('a',0,10) in self._notify1)
@@ -276,7 +270,7 @@ class TestHasTraitsNotify(TestCase):
         a = A()
         a.a = 0
         # This is broken!!!
-        self.assertEqual(len(a._notify1),0)
+        self.assertEqual(len(a._notify1), 1)
         a.a = 10
         self.assertTrue(('a',0,10) in a._notify1)
 
@@ -290,7 +284,7 @@ class TestHasTraitsNotify(TestCase):
         b.a = 10
         b.b = 10.0
         self.assertTrue(('a',0,10) in b._notify1)
-        self.assertTrue(('b',0.0,10.0) in b._notify2)
+        self.assertTrue(('b',Undefined,10.0) in b._notify2)
 
     def test_notify_args(self):
 
@@ -500,11 +494,6 @@ class TestType(TestCase):
 
         self.assertRaises(ImportError, A)
 
-        class C(HasTraits):
-            klass = Type(None, B)
-
-        self.assertRaises(TraitError, C)
-
     def test_str_klass(self):
 
         class A(HasTraits):
@@ -599,23 +588,6 @@ class TestInstance(TestCase):
             inst = Instance(Foo, allow_none=True)
         c = C()
         self.assertTrue(c.inst is None)
-
-    def test_bad_default(self):
-        class Foo(object): pass
-
-        class A(HasTraits):
-            inst = Instance(Foo)
-
-        self.assertRaises(TraitError, A)
-
-    def test_instance(self):
-        class Foo(object): pass
-
-        def inner():
-            class A(HasTraits):
-                inst = Instance(Foo())
-
-        self.assertRaises(TraitError, inner)
 
 
 class TestThis(TestCase):
@@ -1368,7 +1340,7 @@ def test_hold_trait_notifications():
         nt.assert_equal(t.a, 4)
         nt.assert_equal(changes, [])
 
-    nt.assert_equal(changes, [(0, 4)])
+    nt.assert_equal(changes, [(Undefined, 4)])
     # Test roll-back
     try:
          with t.hold_trait_notifications():

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -435,7 +435,6 @@ class TraitType(BaseDescriptor):
                 if self.name in obj._trait_dyn_inits:
                     method = getattr(obj, obj._trait_dyn_inits[self.name])
                     value = method()
-                    # FIXME: Do we really validate here?
                     value = self._validate(obj, value)
                     obj._trait_values[self.name] = value
                     return value

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -379,8 +379,6 @@ class TraitType(BaseDescriptor):
         """Specialization of top_instance_init for TraitType."""
         super(TraitType, self).top_instance_init(obj)
         self._setup_dynamic_initializer(obj)
-        if self.name not in kw:
-            self._set_default_value_at_instance_init(obj)
 
     def get_default_value(self):
         """Create a new instance of the default value."""
@@ -408,14 +406,6 @@ class TraitType(BaseDescriptor):
         else:
             return
         obj._trait_dyn_inits[self.name] = meth_name
-
-    def _set_default_value_at_instance_init(self, obj):
-        # As above, but if no default was specified, don't try to set it.
-        # If the trait is accessed before it is given a value, init_default_value
-        # will be called at that point.
-        if (self.name not in obj._trait_dyn_inits) \
-                and (self.default_value is not Undefined):
-            self.init_default_value(obj)
 
     def __get__(self, obj, cls=None):
         """Get the value of the trait by self.name for the instance.


### PR DESCRIPTION
This is an attempt to simplify initialization of default values. 

The behavior is slightly different in that now:
```Python
class Foo(HasTraits):
    bar = Int()

# triggers a trait notification
foo = Foo()
foo.bar = 0

# does not triggers a trait notification
foo = Foo(bar=0)
foo.bar = 0

# accessing the uninitialized trait initiates the default value
foo = Foo()
print(foo.bar)  # prints 0
```

Previously, the first example would not trigger a trait notification since 0 is equal to the default value which was initialized. I realize this is quite a change, but it really simplifies the code.