### PR TITLE
move login from jupyter_core

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -524,7 +524,9 @@ class Application(SingletonConfigurable):
         for path in path[::-1]:
             # path list is in descending priority order, so load files backwards:
             pyloader = cls.python_config_loader_class(basefilename+'.py', path=path, log=log)
+            log.debug("Attempting to load config file %s.py in path %s", basefilename, path)
             jsonloader = cls.json_config_loader_class(basefilename+'.json', path=path, log=log)
+            log.debug("Attempting to load config file %s.json in path %s", basefilename, path)
             config = None
             for loader in [pyloader, jsonloader]:
                 try:


### PR DESCRIPTION
To keep file_name in sync and correct.

cc @takluyver sharp-eye