### PR TITLE
Allow adding multiple traits at once

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1576,12 +1576,12 @@ class TestDynamicTraits(TestCase):
         self.assertTrue(not hasattr(a, 'y'))
 
         # Dynamically add trait x.
-        a.add_trait('x', Int())
+        a.add_traits(x=Int())
         self.assertTrue(hasattr(a, 'x'))
         self.assertTrue(isinstance(a, (A, )))
 
         # Dynamically add trait y.
-        a.add_trait('y', Float())
+        a.add_traits(y=Float())
         self.assertTrue(hasattr(a, 'y'))
         self.assertTrue(isinstance(a, (A, )))
         self.assertEqual(a.__class__.__name__, A.__name__)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -845,11 +845,12 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         else:
             return trait.get_metadata(key, default)
 
-    def add_trait(self, name, trait):
-        """Dynamically add a trait attribute to the HasTraits instance."""
+    def add_traits(self, **traits):
+        """Dynamically add trait attributes to the HasTraits instance."""
         self.__class__ = type(self.__class__.__name__, (self.__class__,),
-                              {name: trait})
-        trait.instance_init(self)
+                              traits)
+        for trait in traits.values():
+            trait.instance_init(self)
 
 #-----------------------------------------------------------------------------
 # Actual TraitTypes implementations/subclasses


### PR DESCRIPTION
As suggested by @sccolbert, allow adding multiple traits at once. This avoids creating too many new types when adding multiple decorators, since every call to add_trait was creating a new one.