### PR TITLE
_setup_dynamic_initializer simplified

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -435,7 +435,6 @@ class TraitType(BaseDescriptor):
                 if self.name in obj._trait_dyn_inits:
                     method = getattr(obj, obj._trait_dyn_inits[self.name])
                     value = method()
-                    # FIXME: Do we really validate here?
                     value = self._validate(obj, value)
                     obj._trait_values[self.name] = value
                     return value


### PR DESCRIPTION
`_setup_dynamic_initializer ` used to return a boolean on whether there is a dynamic initializer for a given trait. It does not anymore.

Two remarks though:
- `instance_init` is supposed to correspond to the part or the initialization that depends on the `HasTraits` instance. 
    All of what is currently in the implementation of `instance_init` for our trait types does not actually depend on `obj`. It could simply be part of `__init__`. There is no real reason to keep it there.
- After we move this, the call to `_setup_dynamic_initializer` could be moved to `TraitType.instance_init`. 
