### PR TITLE
trait_medatada exception

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -841,13 +841,16 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
 
         return result
 
-    def trait_metadata(self, traitname, key, default=None):
+    def trait_metadata(self, traitname, key, default=None, allow_raise=True):
         """Get metadata values for trait by key."""
         try:
             trait = getattr(self.__class__, traitname)
         except AttributeError:
-            raise TraitError("Class %s does not have a trait named %s" %
-                                (self.__class__.__name__, traitname))
+            if allow_raise:
+                raise TraitError("Class %s does not have a trait named %s" %
+                                    (self.__class__.__name__, traitname))
+            else:
+                return default
         else:
             return trait.get_metadata(key, default)
 


### PR DESCRIPTION
If `allow_raise` is set to `False`, the method `trait_metadata` will return the default value even if `traitname` is not a valid trait name.

The goal is to optimize things like

```Python
if name in Foo.traits(bar=True):
```
which creates a dictionary and then checks if `name` is in it. Now one can simply do

```Python
if Foo.trait_metadata(name, 'bar', allow_raise=False):
```
