### PR TITLE
Don't deepcopy items when merging two config objects

### DIFF
--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -184,14 +184,14 @@ class Config(dict):
         to_update = {}
         for k, v in iteritems(other):
             if k not in self:
-                to_update[k] = copy.deepcopy(v)
+                to_update[k] = v
             else: # I have this key
                 if isinstance(v, Config) and isinstance(self[k], Config):
                     # Recursively merge common sub Configs
                     self[k].merge(v)
                 else:
                     # Plain updates for non-Configs
-                    to_update[k] = copy.deepcopy(v)
+                    to_update[k] = v
 
         self.update(to_update)
     

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -407,13 +407,13 @@ class TestConfig(TestCase):
         assert isinstance(foo, LazyConfigValue)
         self.assertIn('foo', cfg)
     
-    def test_merge_copies(self):
+    def test_merge_no_copies(self):
         c = Config()
         c2 = Config()
         c2.Foo.trait = []
         c.merge(c2)
         c2.Foo.trait.append(1)
-        self.assertIsNot(c.Foo, c2.Foo)
-        self.assertEqual(c.Foo.trait, [])
+        self.assertIs(c.Foo, c2.Foo)
+        self.assertEqual(c.Foo.trait, [1])
         self.assertEqual(c2.Foo.trait, [1])
 


### PR DESCRIPTION
creates unnecessary duplicates, and causes problems with LazyConfigValues