### PR TITLE
ensure update_config triggers _config_changed

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -399,16 +399,6 @@ class Application(SingletonConfigurable):
         """Print the version string."""
         print(self.version)
 
-    def update_config(self, config):
-        """Fire the traits events when the config is updated."""
-        # Save a copy of the current config.
-        newconfig = deepcopy(self.config)
-        # Merge the new config into the current one.
-        newconfig.merge(config)
-        # Save the combined config as self.config, which triggers the traits
-        # events.
-        self.config = newconfig
-
     @catch_config_error
     def initialize_subcommand(self, subc, argv=None):
         """Initialize a subcommand with argv."""

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -170,14 +170,13 @@ class Configurable(HasTraits):
         self._load_config(new, traits=traits, section_names=section_names)
 
     def update_config(self, config):
-        """Fire the traits events when the config is updated."""
-        # Save a copy of the current config.
-        newconfig = deepcopy(self.config)
-        # Merge the new config into the current one.
-        newconfig.merge(config)
-        # Save the combined config as self.config, which triggers the traits
-        # events.
-        self.config = newconfig
+        """Update config and trigger reload of config via trait events"""
+        # Save a copy of the old config
+        oldconfig = deepcopy(self.config)
+        # merge new config
+        self.config.merge(config)
+        # unconditionally notify trait change, which triggers load of new config
+        self._notify_trait('config', oldconfig, self.config)
 
     @classmethod
     def class_get_help(cls, inst=None):

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -353,6 +353,16 @@ class TestConfigContainers(TestCase):
         m.update_config(c2)
         self.assertEqual(m.a, 15)
     
+    def test_update_self(self):
+        """update_config with same config object still triggers config_changed"""
+        c = Config()
+        c.MyConfigurable.a = 5
+        m = MyConfigurable(config=c)
+        self.assertEqual(m.a, 5)
+        c.MyConfigurable.a = 10
+        m.update_config(c)
+        self.assertEqual(m.a, 10)
+    
     def test_config_default(self):
         class SomeSingleton(SingletonConfigurable):
             pass


### PR DESCRIPTION
While there, I noticed that Application had an identical implementation of update_config, which wasn't doing anything since it's inherited from Configurable already.