### PR TITLE
Add HasTraits instance to the signature of trait changed handler

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -299,6 +299,8 @@ class TestHasTraitsNotify(TestCase):
             self.cb = (name, new)
         def callback3(name, old, new):
             self.cb = (name, old, new)
+        def callback4(name, old, new, obj):
+            self.cb = (name, old, new, obj)
 
         class A(HasTraits):
             a = Int
@@ -323,6 +325,11 @@ class TestHasTraitsNotify(TestCase):
         a.a = 10000
         self.assertEqual(self.cb,('a',1000,10000))
         a.on_trait_change(callback3, 'a', remove=True)
+
+        a.on_trait_change(callback4, 'a')
+        a.a = 100000
+        self.assertEqual(self.cb,('a',10000,100000,a))
+        a.on_trait_change(callback4, 'a', remove=True)
 
         self.assertEqual(len(a._trait_notifiers['a']),0)
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -681,9 +681,11 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
                     c(name, new_value)
                 elif nargs + offset == 3:
                     c(name, old_value, new_value)
+                elif nargs + offset == 4:
+                    c(self, name, old_value, new_value)
                 else:
                     raise TraitError('a trait changed callback '
-                                        'must have 0-3 arguments.')
+                                        'must have 0-4 arguments.')
             else:
                 raise TraitError('a trait changed callback '
                                     'must be callable.')
@@ -722,8 +724,8 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         ----------
         handler : callable
             A callable that is called when a trait changes.  Its
-            signature can be handler(), handler(name), handler(name, new)
-            or handler(name, old, new).
+            signature can be handler(), handler(name), handler(name, new),
+            handler(name, old, new), or handler(self, name, old, new).
         name : list, str, None
             If None, the handler will apply to all traits.  If a list
             of str, handler will apply to all names in the list.  If a

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -682,7 +682,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
                 elif nargs + offset == 3:
                     c(name, old_value, new_value)
                 elif nargs + offset == 4:
-                    c(self, name, old_value, new_value)
+                    c(name, old_value, new_value, self)
                 else:
                     raise TraitError('a trait changed callback '
                                         'must have 0-4 arguments.')
@@ -725,7 +725,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         handler : callable
             A callable that is called when a trait changes.  Its
             signature can be handler(), handler(name), handler(name, new),
-            handler(name, old, new), or handler(self, name, old, new).
+            handler(name, old, new), or handler(name, old, new, self).
         name : list, str, None
             If None, the handler will apply to all traits.  If a list
             of str, handler will apply to all names in the list.  If a


### PR DESCRIPTION
It happened a few times that I had to create a closure to access the HasTrait instance in the trait change handler.