### PR TITLE
Fixed Instance docstring to reflect new allow_none=False default

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1009,7 +1009,7 @@ class Instance(ClassBasedTraitType):
             Positional arguments for generating the default value.
         kw : dict
             Keyword arguments for generating the default value.
-        allow_none : bool [default True]
+        allow_none : bool [ default False ]
             Indicates whether None is allowed as a value.
 
         Notes


### PR DESCRIPTION
I had gotten confused by the docstring, since the default value isn't explicit in the signature of ```__init__```.