### PR TITLE
Promote help to be a constructor argument and a top-level member

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -220,8 +220,8 @@ class Configurable(HasTraits):
             # include Enum choices
             lines.append(indent('Choices: %r' % (trait.values,)))
 
-        help = trait.metadata.get('help', None)
-        if help is not None:
+        help = trait.help
+        if help != '':
             help = '\n'.join(wrap_paragraphs(help, 76))
             lines.append(indent(help, 4))
         return '\n'.join(lines)
@@ -256,8 +256,7 @@ class Configurable(HasTraits):
             lines.append('')
 
         for name, trait in iteritems(cls.class_own_traits(config=True)):
-            help = trait.metadata.get('help', '')
-            lines.append(c(help))
+            lines.append(c(trait.help))
             lines.append('# c.%s.%s = %r'%(cls.__name__, name, trait.default_value))
             lines.append('')
         return '\n'.join(lines)
@@ -297,11 +296,8 @@ class Configurable(HasTraits):
                 lines.append('    Default: ``%s``' % dvr)
                 lines.append('')
 
-            help = trait.metadata.get('help', None)
-            if help is not None:
-                lines.append(indent(dedent(help), 4))
-            else:
-                lines.append('    No description')
+            help = trait.help or 'No description'
+            lines.append(indent(dedent(help), 4))
 
             # Blank line
             lines.append('')

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -156,6 +156,10 @@ class TestTraitType(TestCase):
             a.set_metadata('key', 'value')
             v = a.get_metadata('key')
         self.assertEqual(v, 'value')
+        with expected_warnings(["use the instance .help string directly"]*2):
+            a.set_metadata('help', 'some help')
+            v = a.get_metadata('help')
+        self.assertEqual(v, 'some help')
 
     def test_trait_types_deprecated(self):
         with expected_warnings(["Traits should be given as instances"]):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-"""Tests for ipython_genutils.traitlets."""
+"""Tests for traitlets.traitlets."""
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -349,6 +349,7 @@ class TraitType(BaseDescriptor):
             self.allow_none = allow_none
         if read_only is not None:
             self.read_only = read_only
+        self.help = help if help is not None else ''
 
         if 'default' in metadata:
             # Warn the user that they probably meant default_value.
@@ -368,10 +369,8 @@ class TraitType(BaseDescriptor):
         else:
             self.metadata = self.metadata.copy()
 
-        # we plan to promote help to be a top-level traitlet thing, so we add it
-        # to the constructor signature above so that the metadata deprecation doesn't
-        # trigger when just setting the help.  However, tools still expect help to
-        # be in the metadata, so we add it here.
+        # We add help to the metadata during a deprecation period so that
+        # code that looks for the help string there can find it.
         if help is not None:
             self.metadata['help'] = help
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -519,8 +519,11 @@ class TraitType(BaseDescriptor):
 
         Use .metadata[key] or .metadata.get(key, default) instead.
         """
-        warn("use the instance .metadata dictionary directly, like x.metadata[key] or x.metadata.get(key, default)",
-             DeprecationWarning, stacklevel=2)
+        if key == 'help':
+            msg = "use the instance .help string directly, like x.help"
+        else:
+            msg = "use the instance .metadata dictionary directly, like x.metadata[key] or x.metadata.get(key, default)"
+        warn(msg, DeprecationWarning, stacklevel=2)
         return self.metadata.get(key, default)
 
     def set_metadata(self, key, value):
@@ -528,8 +531,11 @@ class TraitType(BaseDescriptor):
 
         Use .metadata[key] = value instead.
         """
-        warn("use the instance .metadata dictionary directly, like x.metadata[key] = value",
-             DeprecationWarning, stacklevel=2)
+        if key == 'help':
+            msg = "use the instance .help string directly, like x.help = value"
+        else:
+            msg = "use the instance .metadata dictionary directly, like x.metadata[key] = value"
+        warn(msg, DeprecationWarning, stacklevel=2)
         self.metadata[key] = value
 
     def tag(self, **metadata):


### PR DESCRIPTION
This continues the work in #53 (and includes it) to implement the decisions in #52.