### PR TITLE
DEV: Handle both string types in import_item.

### DIFF
--- a/traitlets/utils/importstring.py
+++ b/traitlets/utils/importstring.py
@@ -2,9 +2,35 @@
 """
 A simple utility to import something by its string name.
 """
-
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
+from sys import version_info
+
+
+def _check_stringlike(s, types):
+    if not isinstance(s, types):
+        raise TypeError(
+            "import_item expected input of type "
+            "{0[0]} or {0[1]}, but got '{1}' instead.".format(
+                types, type(s),
+            )
+        )
+
+
+if version_info.major == 2:
+    # PY2 __import__ expects bytes
+    def _to_module_str(s):
+        _check_stringlike(s, (bytes, unicode))
+        if isinstance(s, unicode):
+            s = s.encode('utf-8')
+        return s
+elif version_info.major == 3:
+    # PY3 __import__ expects unicode
+    def _to_module_str(s):
+        _check_stringlike(s, (bytes, str))
+        if isinstance(s, bytes):
+            s = s.decode('utf-8')
+        return s
 
 
 def import_item(name):
@@ -23,7 +49,7 @@ def import_item(name):
     mod : module object
        The module that was imported.
     """
-    
+    name = _to_module_str(name)
     parts = name.rsplit('.', 1)
     if len(parts) == 2:
         # called with 'foo.bar....'

--- a/traitlets/utils/tests/test_importstring.py
+++ b/traitlets/utils/tests/test_importstring.py
@@ -1,0 +1,35 @@
+# encoding: utf-8
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+#
+# Adapted from enthought.traits, Copyright (c) Enthought, Inc.,
+# also under the terms of the Modified BSD License.
+"""Tests for traitlets.utils.importstring."""
+
+import os
+from unittest import TestCase
+
+from ..importstring import import_item
+
+
+class TestImportItem(TestCase):
+
+    def test_import_unicode(self):
+        self.assertIs(os, import_item(u'os'))
+        self.assertIs(os.path, import_item(u'os.path'))
+        self.assertIs(os.path.join, import_item(u'os.path.join'))
+
+    def test_import_bytes(self):
+        self.assertIs(os, import_item(b'os'))
+        self.assertIs(os.path, import_item(b'os.path'))
+        self.assertIs(os.path.join, import_item(b'os.path.join'))
+
+    def test_bad_input(self):
+        class NotAString(object):
+            pass
+        msg = (
+            "import_item expected input of type .*, "
+            "but got '%s' instead" % NotAString
+        )
+        with self.assertRaisesRegexp(TypeError, msg):
+            import_item(NotAString())


### PR DESCRIPTION
- In PY2, coerce unicode to bytes.
- In PY3, coerce bytes to unicode.
- Add tests for the above behavior.

Fixes https://github.com/ipython/traitlets/issues/57