### PR TITLE
Deprecate on_trait_change and magic change handlers

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -209,8 +209,8 @@ class link(object):
         try:
             setattr(target[0], target[1], getattr(source[0], source[1]))
         finally:
-            source[0].on_trait_change(self._update_target, source[1])
-            target[0].on_trait_change(self._update_source, target[1])
+            source[0].observe(self._update_target, name=source[1])
+            target[0].observe(self._update_source, name=target[1])
 
     @contextlib.contextmanager
     def _busy_updating(self):
@@ -220,21 +220,21 @@ class link(object):
         finally:
             self.updating = False
 
-    def _update_target(self, name, old, new):
+    def _update_target(self, change):
         if self.updating:
             return
         with self._busy_updating():
-            setattr(self.target[0], self.target[1], new)
+            setattr(self.target[0], self.target[1], change['new'])
 
-    def _update_source(self, name, old, new):
+    def _update_source(self, change):
         if self.updating:
             return
         with self._busy_updating():
-            setattr(self.source[0], self.source[1], new)
+            setattr(self.source[0], self.source[1], change['new'])
 
     def unlink(self):
-        self.source[0].on_trait_change(self._update_target, self.source[1], remove=True)
-        self.target[0].on_trait_change(self._update_source, self.target[1], remove=True)
+        self.source[0].observe(self._update_target, name=self.source[1], remove=True)
+        self.target[0].observe(self._update_source, name=self.target[1], remove=True)
         self.source, self.target = None, None
 
 
@@ -261,7 +261,7 @@ class directional_link(object):
         try:
             setattr(target[0], target[1], getattr(source[0], source[1]))
         finally:
-            self.source[0].on_trait_change(self._update, self.source[1])
+            self.source[0].observe(self._update, name=self.source[1])
 
     @contextlib.contextmanager
     def _busy_updating(self):
@@ -271,14 +271,14 @@ class directional_link(object):
         finally:
             self.updating = False
 
-    def _update(self, name, old, new):
+    def _update(self, change):
         if self.updating:
             return
         with self._busy_updating():
-            setattr(self.target[0], self.target[1], new)
+            setattr(self.target[0], self.target[1], change['new'])
 
     def unlink(self):
-        self.source[0].on_trait_change(self._update, self.source[1], remove=True)
+        self.source[0].observe(self._update, name=self.source[1], remove=True)
         self.source, self.target = None, None
 
 dlink = directional_link

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -634,6 +634,28 @@ class MetaHasTraits(type):
         super(MetaHasTraits, cls).__init__(name, bases, classdict)
 
 
+def observe(*names):
+    return ObserveHandler(names)
+
+
+class ObserveHandler(BaseDescriptor):
+
+    def __init__(self, names=None):
+        if names is None:
+            self.names=[None]
+        else:
+            self.names = names
+
+    def __call__(self, func):
+        self.func = func
+        return self
+
+    def instance_init(self, inst):
+        setattr(inst, self.name, self.func)
+        for name in self.names:
+            inst.observe(self.func, name=name)
+
+
 class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
     """The base class for all classes that have traitlets.
     """

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -597,7 +597,6 @@ def _callback_wrapper(cb):
         return _CallbackWrapper(cb)
 
 
-
 class MetaHasTraits(type):
     """A metaclass for HasTraits.
 
@@ -823,10 +822,6 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
             except ValueError:
                 pass
 
-    def remove_all_notifiers(self):
-        """Remove all trait change handlers."""
-        self._trait_notifiers = {}
-
     def on_trait_change(self, handler=None, name=None, remove=False):
         """DEPRECATED: Setup a handler to be called when a trait changes.
 
@@ -908,6 +903,10 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         names = parse_notifier_name(name)
         for n in names:
             self._remove_notifiers(handler, n)
+
+    def unobserve_all(self):
+        """Remove all trait change handlers."""
+        self._trait_notifiers = {}
 
     @classmethod
     def class_trait_names(cls, **metadata):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -588,7 +588,7 @@ class _CallbackWrapper(object):
         elif self.nargs == 3:
             self.cb(change['name'], change['old'], change['new'])
         elif self.nargs == 4:
-            self.cb(change['name'], change['old'], change['new'], change['object'])
+            self.cb(change['name'], change['old'], change['new'], change['owner'])
 
 def _callback_wrapper(cb):
     if isinstance(cb, _CallbackWrapper):
@@ -795,7 +795,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
                 if nargs == 0:
                     c()
                 elif nargs == 1:
-                    c({'name': name, 'old': old_value, 'new': new_value, 'object': self})
+                    c({'name': name, 'old': old_value, 'new': new_value, 'owner': self})
                 else:
                     raise TraitError('an observe change callback '
                                         'must have 0-1 arguments.')
@@ -868,7 +868,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
             A callable that is called when a trait changes.  Its
             signature can be handler() or handler(change), where change is a
             dictionary with the following keys:
-                - object : the HasTraits instance
+                - owner : the HasTraits instance
                 - old : the old value of the modified trait attribute
                 - new : the new value of the modified trait attribute
                 - name : the name of the modified trait attribute.
@@ -889,13 +889,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         Parameters
         ----------
         handler : callable
-            A callable that is called when a trait changes.  Its
-            signature can be handler() or handler(change), where change is a
-            dictionary with the following keys:
-                - object : the HasTraits instance
-                - old : the old value of the modified trait attribute
-                - new : the new value of the modified trait attribute
-                - name : the name of the modified trait attribute.
+            The callable called when a trait attribute changes.
         name : list, str, None
             If None, all change handlers for the specified name are
             uninstalled.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -775,7 +775,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         except:
             pass
         else:
-            warn("_[traitname]_changed change handlers are deprecated: use observe instead", 
+            warn("_[traitname]_changed change handlers are deprecated: use observe and unobserve instead", 
                  DeprecationWarning, stacklevel=2)
             callables.append(_callback_wrapper(cb))
 


### PR DESCRIPTION
####  Deprecation of `on_trait_change` and the signature of change handlers

As of now, this PR deprecates `on_trait_change` and the magic `_*foo*_changed` handlers, to the benefit of new `observe` and `unobserve` method. The signature of the handlers passed to `observe` is either
 - no argument
 - a single `dict` argument containing  'name', 'old', 'new' and 'owner', the HasTraits instance emitting the event.

See the examples below.

```Python
from __future__ import print_function
from traitlets import *

class Foo(HasTraits):
    bar = Int()
    
    def test_bar(self):
        print('foobar')
    
foo = Foo()    

def cb(change):
    print(change)
    
foo.observe(cb)
foo.bar = 3
```

#### Implementation of an `observe` decorator like in [Atom](https://github.com/nucleic/atom):
On the other side, atom implements a `observe` decorator 

```Python
class Person(Atom):
    age = Int()

    @observe('age')
    def debug_print(self, change):
        print(change['object'].last_name)
```

The problem is that the registration of the callback requires access `self` attribute, which is not available when the decorator is called. The way it works in atom is that the `@observe('age')` decorator replaces the `debug_print` method with a placeholder object `ObserveHandler` holding the method to be registered, which is to be picked up and unwrapped by the `AtomMeta` metaclass when instantiating the instance of (the counterpart to) HasTraits.

Rather than augmenting the metaclass, I could achieve the same result by making our `ObserveHandler` inherit from `BaseDescriptor`, and implement the custom logic in `instance_init`.

#### Example with traitlets:

```Python
class Foo(HasTraits):
    bar = Int()
    
    @observe('bar')
    def test(self):
        print('foobar')

foo = Foo()
foo.bar = 2
```