### PR TITLE
ensure stable order of config output

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -255,8 +255,8 @@ class Configurable(HasTraits):
             lines.append(c(desc))
             lines.append('')
 
-        for name, trait in iteritems(cls.class_own_traits(config=True)):
-            lines.append(c(trait.help))
+        for name, trait in sorted(cls.class_own_traits(config=True).items()):
+            lines.append(c.help)
             lines.append('# c.%s.%s = %r'%(cls.__name__, name, trait.default_value))
             lines.append('')
         return '\n'.join(lines)


### PR DESCRIPTION
config file output was subject to dict ordering, resulting in reordering config file content.

closes ipython/ipython#8702