### PR TITLE
Add default_value_repr method

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -209,7 +209,7 @@ class Configurable(HasTraits):
             lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))
         else:
             try:
-                dvr = repr(trait.default_value)
+                dvr = trait.default_value_repr()
             except Exception:
                 dvr = None # ignore defaults we can't construct
             if dvr is not None:
@@ -257,7 +257,7 @@ class Configurable(HasTraits):
 
         for name, trait in sorted(cls.class_own_traits(config=True).items()):
             lines.append(c(trait.help))
-            lines.append('# c.%s.%s = %r'%(cls.__name__, name, trait.default_value))
+            lines.append('# c.%s.%s = %s' % (cls.__name__, name, trait.default_value_repr()))
             lines.append('')
         return '\n'.join(lines)
 
@@ -284,11 +284,10 @@ class Configurable(HasTraits):
 
             # Default value
             try:
-                dv = trait.default_value
-                dvr = repr(dv)
+                dvr = trait.default_value_repr()
             except Exception:
-                dvr = dv = None # ignore defaults we can't construct
-            if (dv is not None) and (dvr is not None):
+                dvr = None # ignore defaults we can't construct
+            if dvr is not None:
                 if len(dvr) > 64:
                     dvr = dvr[:61]+'...'
                 # Double up backslashes, so they get to the rendered docs

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -548,6 +548,9 @@ class TraitType(BaseDescriptor):
         self.metadata.update(metadata)
         return self
 
+    def default_value_repr(self):
+        return repr(self.default_value)
+
 #-----------------------------------------------------------------------------
 # The HasTraits implementation
 #-----------------------------------------------------------------------------
@@ -1037,6 +1040,9 @@ class Type(ClassBasedTraitType):
             self.klass = self._resolve_string(self.klass)
         if isinstance(self.default_value, py3compat.string_types):
             self.default_value = self._resolve_string(self.default_value)
+
+    def default_value_repr(self):
+        return repr('{}.{}'.format(self.default_value.__module__, self.default_value.__name__))
 
 
 class Instance(ClassBasedTraitType):
@@ -1625,6 +1631,9 @@ class Container(Instance):
             self._trait.this_class = self.this_class
             self._trait.instance_init(obj)
         super(Container, self).instance_init(obj)
+
+    def default_value_repr(self):
+        return repr(self.make_dynamic_default())
 
 
 class List(Container):


### PR DESCRIPTION
Fixes #65 and fixes #64 

See also #66 

This adds a `default_value_repr` method that by default just returns the repr of `default_value`, but which can be overridden for traits that need special casing (e.g. dotted object names, or containers).