### PR TITLE
On enabling other descriptors than TraitType

### DIFF
--- a/traitlets/deprecated.py
+++ b/traitlets/deprecated.py
@@ -1,0 +1,22 @@
+"""Decorator for warning about deprecated classes"""		
+		
+# Copyright (c) Jupyter Development Team.		
+# Distributed under the terms of the Modified BSD License.		
+		
+from warnings import warn		
+		
+		
+def DeprecatedClass(base, class_name):		
+    """Warn about a deprecated class on instantiation"""		
+    # Hook the init method of the base class.		
+    def init_hook(self, *pargs, **kwargs):		
+        base.__init__(self, *pargs, **kwargs)		
+		
+        # Warn once per class.		
+        if base not in DeprecatedClass._warned_classes:		
+            DeprecatedClass._warned_classes.append(base)		
+            warn('"{}" is deprecated, please use "{}" instead.'.format(		
+                class_name, base.__name__))		
+    return type(class_name, (base,), {'__init__': init_hook})		
+		
+DeprecatedClass._warned_classes = []

--- a/traitlets/deprecated.py
+++ b/traitlets/deprecated.py
@@ -1,22 +1,22 @@
-"""Decorator for warning about deprecated classes"""		
-		
-# Copyright (c) Jupyter Development Team.		
-# Distributed under the terms of the Modified BSD License.		
-		
-from warnings import warn		
-		
-		
-def DeprecatedClass(base, class_name):		
-    """Warn about a deprecated class on instantiation"""		
-    # Hook the init method of the base class.		
-    def init_hook(self, *pargs, **kwargs):		
-        base.__init__(self, *pargs, **kwargs)		
-		
-        # Warn once per class.		
-        if base not in DeprecatedClass._warned_classes:		
-            DeprecatedClass._warned_classes.append(base)		
-            warn('"{}" is deprecated, please use "{}" instead.'.format(		
-                class_name, base.__name__))		
-    return type(class_name, (base,), {'__init__': init_hook})		
-		
-DeprecatedClass._warned_classes = []
+"""Decorator for warning about deprecated classes"""	
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from warnings import warn
+
+
+def DeprecatedClass(base, class_name):
+    """Warn about a deprecated class on instantiation"""
+    # Hook the init method of the base class.
+    def init_hook(self, *pargs, **kwargs):
+        base.__init__(self, *pargs, **kwargs)
+
+        # Warn once per class.
+        if base not in DeprecatedClass._warned_classes:
+            DeprecatedClass._warned_classes.append(base)
+            warn('"{}" is deprecated, please use "{}" instead.'.format(
+                class_name, base.__name__), DeprecationWarning)
+    return type(class_name, (base,), {'__init__': init_hook})
+
+DeprecatedClass._warned_classes = set()

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -17,7 +17,7 @@ import nose.tools as nt
 from nose import SkipTest
 
 from traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
+    HasTraits, MetaHasDescriptors, TraitType, Any, Bool, CBytes, Dict, Enum,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Union, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
@@ -185,16 +185,16 @@ class TestTraitType(TestCase):
             class C(HasTraits):
                 t = Dict(Int)
 
-class TestHasTraitsMeta(TestCase):
+class TestHasDescriptorsMeta(TestCase):
 
     def test_metaclass(self):
-        self.assertEqual(type(HasTraits), MetaHasTraits)
+        self.assertEqual(type(HasTraits), MetaHasDescriptors)
 
         class A(HasTraits):
             a = Int()
 
         a = A()
-        self.assertEqual(type(a.__class__), MetaHasTraits)
+        self.assertEqual(type(a.__class__), MetaHasDescriptors)
         self.assertEqual(a.a,0)
         a.a = 10
         self.assertEqual(a.a,10)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -418,6 +418,10 @@ class TraitType(BaseDescriptor):
         return getattr(self, 'make_dynamic_default', None)
 
     def instance_init(self, obj):
+        if not hasattr(obj, '_trait_values'):
+            obj._trait_values = {}
+            obj._trait_notifiers = {}
+            obj._trait_validators = {}
         obj._cross_validation_lock = True
         # If no dynamic initialiser is present, and the trait implementation or
         # use provides a static default, transfer that to obj._trait_values.
@@ -694,6 +698,10 @@ class ObserveHandler(EventHandler):
             self.names = names
 
     def instance_init(self, inst):
+        if not hasattr(inst, '_trait_values'):
+            inst._trait_values = {}
+            inst._trait_notifiers = {}
+            inst._trait_validators = {}
         meth = types.MethodType(self.func, inst)
         for name in self.names:
             inst.observe(meth, name)
@@ -704,6 +712,10 @@ class ValidateHandler(EventHandler):
         self.names = names
     
     def instance_init(self, inst):
+        if not hasattr(inst, '_trait_values'):
+            inst._trait_values = {}
+            inst._trait_notifiers = {}
+            inst._trait_validators = {}
         meth = types.MethodType(self.func, inst)
         inst._register_validator(meth, self.names)
 
@@ -720,9 +732,6 @@ class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
             inst = new_meth(cls)
         else:
             inst = new_meth(cls, **kw)
-        inst._trait_values = {}
-        inst._trait_notifiers = {}
-        inst._trait_validators = {}
         for key in dir(cls):
             # Some descriptors raise AttributeError like zope.interface's
             # __provides__ attributes even though they exist.  This causes

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -604,14 +604,14 @@ def _callback_wrapper(cb):
 
 
 class MetaHasDescriptors(type):
-    """A metaclass for HasTraits.
+    """A metaclass for HasDescriptors.
 
     This metaclass makes sure that any TraitType class attributes are
     instantiated and sets their name attribute.
     """
 
     def __new__(mcls, name, bases, classdict):
-        """Create the HasTraits class.
+        """Create the HasDescriptors class.
 
         This sets :attr:`name` attribute of each descriptor in the class dict.
         """
@@ -630,7 +630,7 @@ class MetaHasDescriptors(type):
         return super(MetaHasDescriptors, mcls).__new__(mcls, name, bases, classdict)
 
     def __init__(cls, name, bases, classdict):
-        """Finish initializing the HasTraits class.
+        """Finish initializing the HasDescriptors class.
 
         This sets the :attr:`this_class` attribute of each BaseDescriptor in the
         class dict to the newly created class ``cls``.
@@ -705,14 +705,14 @@ class ValidateHandler(EventHandler):
         inst._register_validator(meth, self.names)
 
 
-class HasTraits(py3compat.with_metaclass(MetaHasDescriptors, object)):
-    """The base class for all classes that have traitlets.
+class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
+    """The base class for all classes that have descriptors.
     """
 
     def __new__(cls, *args, **kw):
         # This is needed because object.__new__ only accepts
         # the cls argument.
-        new_meth = super(HasTraits, cls).__new__
+        new_meth = super(HasDescriptors, cls).__new__
         if new_meth is object.__new__:
             inst = new_meth(cls)
         else:
@@ -734,6 +734,9 @@ class HasTraits(py3compat.with_metaclass(MetaHasDescriptors, object)):
                     value.instance_init(inst)
         inst._cross_validation_lock = False
         return inst
+
+
+class HasTraits(HasDescriptors):
 
     def __init__(self, *args, **kw):
         # Allow trait values to be set using keyword arguments.


### PR DESCRIPTION
The metaclass logic in traitlets is very simple, especially if we remove the deprecated portion of the code. All it does is to decorate the descriptor instances in the dictionary with a `name` attribute.

We recently introduced a [BaseDescriptor](https://github.com/ipython/traitlets/blob/master/traitlets/traitlets.py#L291) base class to `TraitType`. The requirement for the specialization to `BaseDescriptor` is to implement `instance_init`, which is called in the `__new__` method of `HasTraits`. This was meant to enable using other descriptors than `TraitType` to benefit from the metaclass magic.

Within traitlets, we already have another specialization of `BaseDescriptor`, that is`ObserveHandler`. In widgets, we used it for the work on signaling. @rmorshea is also implementing the registration of custom cross validators with the same mechanism.

The number of different descriptors that we will introduce is probably going to grow. (Signaling, event-full containers etc), hence I opened this PR, which separates the descriptor mechanics from HasTraits, to acknowledge the fact that other descriptors than `TraitType`.