### PR TITLE
FIX : convert function to method during `instance_init`

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -664,6 +664,7 @@ class ObserveHandler(BaseDescriptor):
         return self
 
     def instance_init(self, inst):
+        self.func = typse.MethodType(self.func, inst)
         setattr(inst, self.name, self.func)
         for name in self.names:
             inst.observe(self.func, name=name)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -664,7 +664,7 @@ class ObserveHandler(BaseDescriptor):
         return self
 
     def instance_init(self, inst):
-        self.func = typse.MethodType(self.func, inst)
+        self.func = types.MethodType(self.func, inst)
         setattr(inst, self.name, self.func)
         for name in self.names:
             inst.observe(self.func, name=name)


### PR DESCRIPTION
Update to #61 

Since the function being passed to the `observe` decorator is being captured, and then replaced by the `ObserveHandler`, it's never registered as a method at runtime. `instance_init` has been changed accordingly.