### PR TITLE
Pass Trait to Validator Method

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1436,7 +1436,7 @@ class TestValidationHook(TestCase):
 
             @validate('value')
             def _value_validate(self, proposal):
-                name, value = proposal['name'], proposal['value']
+                value = proposal['value']
                 if self.parity == 'even' and value % 2:
                     raise TraitError('Expected an even number')
                 if self.parity == 'odd' and (value % 2 == 0):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -489,7 +489,7 @@ class TraitType(BaseDescriptor):
 
     def _cross_validate(self, obj, value):
         if self.name in obj._trait_validators:
-            proposal = {'name': self.name, 'value': value, 'owner': obj}
+            proposal = {'trait': self, 'value': value, 'owner': obj}
             value = obj._trait_validators[self.name](proposal)
         elif hasattr(obj, '_%s_validate' % self.name):
             warn("_[traitname]_validate handlers are deprecated: use validate"


### PR DESCRIPTION
Keeps with the old validator signature by including the corresponding TraitType in the proposal dict instead of the trait name. Accessing the metadata on a particular TraitType seems more important than passing the trait name which you can get from `trait.name` anyway.