### PR TITLE
Notification types

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -176,7 +176,7 @@ class Configurable(HasTraits):
         # merge new config
         self.config.merge(config)
         # unconditionally notify trait change, which triggers load of new config
-        self._notify_trait('config', oldconfig, self.config)
+        self._notify_trait('config', oldconfig, self.config, 'trait_change')
 
     @classmethod
     def class_get_help(cls, inst=None):

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -176,7 +176,13 @@ class Configurable(HasTraits):
         # merge new config
         self.config.merge(config)
         # unconditionally notify trait change, which triggers load of new config
-        self._notify_trait('config', oldconfig, self.config, 'trait_change')
+        self._notify_change('config', 'trait_change', {
+            'name': 'config',
+            'old': oldconfig,
+            'new': self.config,
+            'owner': self,
+            'type': 'trait_change', 
+        })
 
     @classmethod
     def class_get_help(cls, inst=None):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -37,10 +37,11 @@ def change_dict(*ordered_values):
 
 class HasTraitsStub(HasTraits):
 
-    def _notify_trait(self, name, old, new):
+    def _notify_trait(self, name, old, new, type):
         self._notify_name = name
         self._notify_old = old
         self._notify_new = new
+        self._notify_type = type
 
 
 #-----------------------------------------------------------------------------
@@ -380,10 +381,10 @@ class TestHasTraitsNotify(TestCase):
         a.on_trait_change(callback4, 'a')
         a.a = 100000
         self.assertEqual(self.cb,('a',10000,100000,a))
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
+        self.assertEqual(len(a._trait_notifiers['a'][None]), 1)
         a.on_trait_change(callback4, 'a', remove=True)
 
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
+        self.assertEqual(len(a._trait_notifiers['a'][None]), 0)
 
     def test_notify_only_once(self):
 
@@ -566,10 +567,10 @@ class TestObserveDecorator(TestCase):
         a.a = 100
         change = change_dict('a', 10, 100, a, 'trait_change')
         self.assertEqual(self.cb, change)
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
+        self.assertEqual(len(a._trait_notifiers['a'][None]), 1)
         a.unobserve(callback1, 'a')
 
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
+        self.assertEqual(len(a._trait_notifiers['a'][None]), 0)
 
     def test_notify_only_once(self):
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -37,11 +37,11 @@ def change_dict(*ordered_values):
 
 class HasTraitsStub(HasTraits):
 
-    def _notify_trait(self, name, old, new, type):
-        self._notify_name = name
-        self._notify_old = old
-        self._notify_new = new
-        self._notify_type = type
+    def _notify_change(self, name, type, change):
+        self._notify_name = change['name']
+        self._notify_old = change['old']
+        self._notify_new = change['new']
+        self._notify_type = change['type']
 
 
 #-----------------------------------------------------------------------------

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -380,9 +380,10 @@ class TestHasTraitsNotify(TestCase):
         a.on_trait_change(callback4, 'a')
         a.a = 100000
         self.assertEqual(self.cb,('a',10000,100000,a))
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
         a.on_trait_change(callback4, 'a', remove=True)
 
-        self.assertEqual(len(a._trait_notifiers['a']),0)
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
 
     def test_notify_only_once(self):
 
@@ -565,9 +566,10 @@ class TestObserveDecorator(TestCase):
         a.a = 100
         change = change_dict('a', 10, 100, a, 'trait_change')
         self.assertEqual(self.cb, change)
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
         a.unobserve(callback1, 'a')
 
-        self.assertEqual(len(a._trait_notifiers['a']),0)
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
 
     def test_notify_only_once(self):
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -19,7 +19,7 @@ from nose import SkipTest
 from traitlets import (
     HasTraits, MetaHasDescriptors, TraitType, Any, Bool, CBytes, Dict, Enum,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
-    Union, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
+    Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe
 )
@@ -381,10 +381,10 @@ class TestHasTraitsNotify(TestCase):
         a.on_trait_change(callback4, 'a')
         a.a = 100000
         self.assertEqual(self.cb,('a',10000,100000,a))
-        self.assertEqual(len(a._trait_notifiers['a'][None]), 1)
+        self.assertEqual(len(a._trait_notifiers['a'][All]), 1)
         a.on_trait_change(callback4, 'a', remove=True)
 
-        self.assertEqual(len(a._trait_notifiers['a'][None]), 0)
+        self.assertEqual(len(a._trait_notifiers['a'][All]), 0)
 
     def test_notify_only_once(self):
 
@@ -567,10 +567,10 @@ class TestObserveDecorator(TestCase):
         a.a = 100
         change = change_dict('a', 10, 100, a, 'trait_change')
         self.assertEqual(self.cb, change)
-        self.assertEqual(len(a._trait_notifiers['a'][None]), 1)
+        self.assertEqual(len(a._trait_notifiers['a'][All]), 1)
         a.unobserve(callback1, 'a')
 
-        self.assertEqual(len(a._trait_notifiers['a'][None]), 0)
+        self.assertEqual(len(a._trait_notifiers['a'][All]), 0)
 
     def test_notify_only_once(self):
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -381,10 +381,10 @@ class TestHasTraitsNotify(TestCase):
         a.on_trait_change(callback4, 'a')
         a.a = 100000
         self.assertEqual(self.cb,('a',10000,100000,a))
-        self.assertEqual(len(a._trait_notifiers['a'][All]), 1)
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
         a.on_trait_change(callback4, 'a', remove=True)
 
-        self.assertEqual(len(a._trait_notifiers['a'][All]), 0)
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
 
     def test_notify_only_once(self):
 
@@ -567,10 +567,10 @@ class TestObserveDecorator(TestCase):
         a.a = 100
         change = change_dict('a', 10, 100, a, 'trait_change')
         self.assertEqual(self.cb, change)
-        self.assertEqual(len(a._trait_notifiers['a'][All]), 1)
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
         a.unobserve(callback1, 'a')
 
-        self.assertEqual(len(a._trait_notifiers['a'][All]), 0)
+        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
 
     def test_notify_only_once(self):
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -27,7 +27,7 @@ from ipython_genutils import py3compat
 from ipython_genutils.testing.decorators import skipif
 
 def change_dict(*ordered_values):
-    change_names = ('name','old','new','owner')
+    change_names = ('name', 'old', 'new', 'owner', 'type')
     return dict(zip(change_names, ordered_values))
 
 #-----------------------------------------------------------------------------
@@ -447,10 +447,10 @@ class TestObserveDecorator(TestCase):
         a.b = 0.0
         self.assertEqual(len(self._notify1),0)
         a.a = 10
-        change = change_dict('a',0,10,a)
+        change = change_dict('a', 0, 10, a, 'trait_change')
         self.assertTrue(change in self._notify1)
         a.b = 10.0
-        change = change_dict('b',0.0,10.0,a)
+        change = change_dict('b', 0.0, 10.0, a, 'trait_change')
         self.assertTrue(change in self._notify1)
         self.assertRaises(TraitError,setattr,a,'a','bad string')
         self.assertRaises(TraitError,setattr,a,'b','bad string')
@@ -471,7 +471,7 @@ class TestObserveDecorator(TestCase):
         a.a = 0
         self.assertEqual(len(self._notify1),0)
         a.a = 10
-        change = change_dict('a',0,10,a)
+        change = change_dict('a', 0, 10, a, 'trait_change')
         self.assertTrue(change in self._notify1)
         self.assertRaises(TraitError,setattr,a,'a','bad string')
 
@@ -508,9 +508,9 @@ class TestObserveDecorator(TestCase):
         self.assertEqual(len(self._notify2),0)
         b.a = 10
         b.b = 10.0
-        change = change_dict('a',0,10,b)
+        change = change_dict('a', 0, 10, b, 'trait_change')
         self.assertTrue(change in self._notify1)
-        change = change_dict('b',0.0,10.0,b)
+        change = change_dict('b', 0.0, 10.0, b, 'trait_change')
         self.assertTrue(change in self._notify2)
 
     def test_static_notify(self):
@@ -527,7 +527,7 @@ class TestObserveDecorator(TestCase):
         # This is broken!!!
         self.assertEqual(len(a._notify1),0)
         a.a = 10
-        change = change_dict('a',0,10,a)
+        change = change_dict('a', 0, 10, a, 'trait_change')
         self.assertTrue(change in a._notify1)
 
         class B(A):
@@ -540,9 +540,9 @@ class TestObserveDecorator(TestCase):
         b = B()
         b.a = 10
         b.b = 10.0
-        change = change_dict('a',0,10,b)
+        change = change_dict('a', 0, 10, b, 'trait_change')
         self.assertTrue(change in b._notify1)
-        change = change_dict('b',0.0,10.0,b)
+        change = change_dict('b', 0.0, 10.0, b, 'trait_change')
         self.assertTrue(change in b._notify2)
 
     def test_notify_args(self):
@@ -563,8 +563,8 @@ class TestObserveDecorator(TestCase):
 
         a.observe(callback1, 'a')
         a.a = 100
-        change = change_dict('a',10,100,a)
-        self.assertEqual(self.cb,change)
+        change = change_dict('a', 10, 100, a, 'trait_change')
+        self.assertEqual(self.cb, change)
         a.unobserve(callback1, 'a')
 
         self.assertEqual(len(a._trait_notifiers['a']),0)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -668,7 +668,7 @@ def observe(*names, **kwargs):
     *names
         The str names of the Traits to observe on the object.
     """
-    return ObserveHandler(names, type=kwargs.get('type', All))
+    return ObserveHandler(names, type=kwargs.get('type', 'trait_change'))
 
 def validate(*names):
     """ A decorator which validates a HasTraits object's state when a Trait is set.
@@ -963,7 +963,7 @@ class HasTraits(HasDescriptors):
         else:
             self.observe(_callback_wrapper(handler), names=name)
 
-    def observe(self, handler, names=All, type=All):
+    def observe(self, handler, names=All, type='trait_change'):
         """Setup a handler to be called when a trait changes.
 
         This is used to setup dynamic notifications of trait changes.
@@ -985,7 +985,7 @@ class HasTraits(HasDescriptors):
             If names is All, the handler will apply to all traits.  If a list
             of str, handler will apply to all names in the list.  If a
             str, the handler will apply just to that name.
-        type : str, All
+        type : str, All (default: 'trait_change')
             The type of notification to filter by. If equal to All, then all
             notifications are passed to the observe handler.
         """
@@ -993,7 +993,7 @@ class HasTraits(HasDescriptors):
         for n in names:
             self._add_notifiers(handler, n, type)
 
-    def unobserve(self, handler, names=All, type=All):
+    def unobserve(self, handler, names=All, type='trait_change'):
         """Remove a trait change handler.
 
         This is used to unregister handlers to trait change notificiations.
@@ -1006,7 +1006,7 @@ class HasTraits(HasDescriptors):
             The names of the traits for which the specified handler should be
             uninstalled. If names is All, the specified handler is uninstalled
             from the list of notifiers corresponding to all changes.
-        type : str or All (default: All)
+        type : str or All (default: 'trait_change')
             The type of notification to filter by. If All, the specified handler
             is uninstalled from the list of notifiers corresponding to all types.
         """

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -700,7 +700,7 @@ class EventHandler(BaseDescriptor):
 
 class ObserveHandler(EventHandler):
 
-    def __init__(self, names=All, type=All):
+    def __init__(self, names, type):
         if names is All:
             self.names = [All]
         else:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -476,7 +476,7 @@ class TraitType(BaseDescriptor):
         if silent is not True:
             # we explicitly compare silent to True just in case the equality
             # comparison above returns something other than True/False
-            obj._notify_trait(self.name, old_value, new_value)
+            obj._notify_trait(self.name, old_value, new_value, 'trait_change')
 
     def __set__(self, obj, value):
         if self.read_only:
@@ -655,7 +655,7 @@ def observe(*names, **kwargs):
     *names
         The str names of the Traits to observe on the object.
     """
-    return ObserveHandler(names, type=kwargs.get('type', 'trait_change'))
+    return ObserveHandler(names, type=kwargs.get('type', None))
 
 def validate(*names):
     """ A decorator which validates a HasTraits object's state when a Trait is set.
@@ -687,7 +687,7 @@ class EventHandler(BaseDescriptor):
 
 class ObserveHandler(EventHandler):
 
-    def __init__(self, names=None, type='trait_change'):
+    def __init__(self, names=None, type=None):
         if names is None:
             self.names = [None]
         else:
@@ -808,7 +808,7 @@ class HasTraits(HasDescriptors):
                 if previous is None:
                     return current
                 else:
-                    return (current[0], previous[1], current[2])
+                    return (current[0], previous[1], current[2], current[3])
 
             def hold(*a):
                 cache[a[0]] = merge(cache.get(a[0]), a)
@@ -837,7 +837,7 @@ class HasTraits(HasDescriptors):
                 for v in cache.values():
                     self._notify_trait(*v)
 
-    def _notify_trait(self, name, old_value, new_value, type='trait_change'):
+    def _notify_trait(self, name, old_value, new_value, type):
 
         # First dynamic ones
         callables = []
@@ -878,7 +878,7 @@ class HasTraits(HasDescriptors):
                     'old': old_value,
                     'new': new_value,
                     'owner': self,
-                    'type': 'trait_change'
+                    'type': type, 
                 })
             else:
                 raise TraitError('an observe change callback '
@@ -941,7 +941,7 @@ class HasTraits(HasDescriptors):
         else:
             self.observe(_callback_wrapper(handler), names=name)
 
-    def observe(self, handler, names=None, type='trait_change'):
+    def observe(self, handler, names=None, type=None):
         """Setup a handler to be called when a trait changes.
 
         This is used to setup dynamic notifications of trait changes.
@@ -971,7 +971,7 @@ class HasTraits(HasDescriptors):
         for n in names:
             self._add_notifiers(handler, n, type)
 
-    def unobserve(self, handler, names=None, type='trait_change'):
+    def unobserve(self, handler, names=None, type=None):
         """Remove a trait change handler.
 
         This is used to unregister handlers to trait change notificiations.


### PR DESCRIPTION
As per discussion in #48, this enables multiple notification types in traitlets.
___
First, the `change` dictionary passed to registered observers
- must contain a `'type'` key
- potentially other keys depending on the value for `type`. For example, when the value for the `'type'` key is `'trait_change'`, we must provide the usual `'owner'`, `'old'`, `'new'`, and `'name'`.

The goal is to enable other types of notifications potentially implementing events for changes of elements in containers like `List` and `Dict`. For each type, we may have a different protocol.
___
The second thing that is implemented is the ability to filter by notification type when registering an observer. See the following example

```Python
class Foo(HasTraits):
    bar = Int()
    baz = EventfulList()

    @observe('bar', type='trait_change')  # Filter to only observe trait changes
    def handler_bar(self, change):
        pass

    @observe('baz ', type='element_change')  # Register to element change notifications for baz
    def handler_baz(self, change):
        pass

    @observe('bar', 'baz')  # Register to all notification types for `bar` and `baz` 
    def handler_all(self, change):
        pass
```

Similarly, the `observe` method also takes a `type` keyword argument defaulting to `None`, which corresponds to all types of notifications.

In terms of implementation, the `_trait_notifiers` dict is now a dict of dict, the top-level key being the trait name and the second-level being the notification type.
___
`_notify_trait` was refactored into a generic `_notify_change` that is valid for any type of notification, and the `_hold_trait_notifications` context manager was updated accordingly.
___
Another minor change is that the `observe` method' s argument `name` is renamed to `names`, which is more consistent with what it does.

