### PR TITLE
fix dynamic reprs for some trait types

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1944,3 +1944,20 @@ def test_enum_no_default():
 
     c = C(t='b')
     assert c.t == 'b'
+
+
+def test_default_value_repr():
+    class C(HasTraits):
+        t = Type('traitlets.HasTraits')
+        t2 = Type(HasTraits)
+        n = Integer(0)
+        lis = List()
+        d = Dict()
+    
+    nt.assert_equal(C.t.default_value_repr(), "'traitlets.HasTraits'")
+    nt.assert_equal(C.t2.default_value_repr(), "'traitlets.traitlets.HasTraits'")
+    nt.assert_equal(C.n.default_value_repr(), '0')
+    nt.assert_equal(C.lis.default_value_repr(), '[]')
+    nt.assert_equal(C.d.default_value_repr(), '{}')
+
+        

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1194,7 +1194,7 @@ class Type(ClassBasedTraitType):
         if not (inspect.isclass(klass) or isinstance(klass, py3compat.string_types)):
             raise TraitError("A Type trait must specify a class.")
 
-        self.klass       = klass
+        self.klass = klass
 
         super(Type, self).__init__(new_default_value, **metadata)
 
@@ -1236,7 +1236,11 @@ class Type(ClassBasedTraitType):
             self.default_value = self._resolve_string(self.default_value)
 
     def default_value_repr(self):
-        return repr('{}.{}'.format(self.default_value.__module__, self.default_value.__name__))
+        value = self.default_value
+        if isinstance(value, py3compat.string_types):
+            return repr(value)
+        else:
+            return repr('{}.{}'.format(value.__module__, value.__name__))
 
 
 class Instance(ClassBasedTraitType):
@@ -1325,6 +1329,9 @@ class Instance(ClassBasedTraitType):
             return None
         return self.klass(*(self.default_args or ()),
                           **(self.default_kwargs or {}))
+
+    def default_value_repr(self):
+        return repr(self.make_dynamic_default())
 
 
 class ForwardDeclaredMixin(object):
@@ -1825,9 +1832,6 @@ class Container(Instance):
             self._trait.this_class = self.this_class
             self._trait.instance_init(obj)
         super(Container, self).instance_init(obj)
-
-    def default_value_repr(self):
-        return repr(self.make_dynamic_default())
 
 
 class List(Container):


### PR DESCRIPTION
these are needed when generating config files, and had been broken by some deferred default generation changes.