### PR TITLE
use makedirs to ensure config directory exists

### DIFF
--- a/traitlets/config/manager.py
+++ b/traitlets/config/manager.py
@@ -43,7 +43,7 @@ class BaseJSONConfigManager(LoggingConfigurable):
 
     def ensure_config_dir_exists(self):
         try:
-            os.mkdir(self.config_dir, 0o755)
+            os.makedirs(self.config_dir, 0o755)
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise


### PR DESCRIPTION
rather than mkdir, which only creates a single dir

Should ConfigManager be part of traitlets? It doesn't seem like it's related to traitlets-based config at all, and only used for frontend config (nbconfig), which hasn't anything to do with traitlets.

cc @takluyver, @Carreau