### PR TITLE
Revert change from #79 due to memory leak

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -854,6 +854,12 @@ class HasTraits(HasDescriptors):
                 # and fire resulting change notifications.
                 self._notify_change = _notify_change
                 self._cross_validation_lock = False
+
+                if isinstance(_notify_trait, types.MethodType):
+                    # Presence of the method _notify_trait
+                    # on __dict__ can cause memory leaks
+                    # and prevents pickleability
+                    self.__dict__.pop('_notify_trait')
                 # trigger delayed notifications
                 for changes in cache.values():
                     for change in changes:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -848,11 +848,11 @@ class HasTraits(HasDescriptors):
                 self._notify_change = _notify_change
                 self._cross_validation_lock = False
 
-                if isinstance(_notify_trait, types.MethodType):
+                if isinstance(_notify_change, types.MethodType):
                     # Presence of the method _notify_trait
                     # on __dict__ can cause memory leaks
                     # and prevents pickleability
-                    self.__dict__.pop('_notify_trait')
+                    self.__dict__.pop('_notify_change')
                 # trigger delayed notifications
                 for changes in cache.values():
                     for change in changes:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -763,13 +763,6 @@ class HasTraits(HasDescriptors):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        # FIXME: remove when support is bumped to 3.4.
-        # hold_trait_notifications sets and resets
-        # _notify_change forcing it onto __dict__
-        # the reference to the class made during
-        # load will reinstantiate the method
-        # (only used to preserve pickleability on Python < 3.4)
-        d.pop('_notify_change', None)
         # event handlers stored on an instance are
         # expected to be reinstantiated during a
         # recall of instance_init during __setstate__


### PR DESCRIPTION
Popping `_notify_trait` off `__dict__` after `hold_trait_notifers` must occur inside the context manager to prevent memory leaks. This reverts a change which was made in #79, where popping was done in `__getstate__`, and edits the comment to reflect this potential memory leak. Previously it'd been marked for removal after dropping support for Python < 3.4.