### PR TITLE
Make HasTraits._notify_change public

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -176,7 +176,7 @@ class Configurable(HasTraits):
         # merge new config
         self.config.merge(config)
         # unconditionally notify trait change, which triggers load of new config
-        self._notify_change('config', 'trait_change', {
+        self.notify_change('config', 'trait_change', {
             'name': 'config',
             'old': oldconfig,
             'new': self.config,

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -37,7 +37,7 @@ def change_dict(*ordered_values):
 
 class HasTraitsStub(HasTraits):
 
-    def _notify_change(self, name, type, change):
+    def notify_change(self, name, type, change):
         self._notify_name = change['name']
         self._notify_old = change['old']
         self._notify_new = change['new']


### PR DESCRIPTION
This simply makes `HasTraits.notify_change` public. Indeed, ipywidgets currently makes direct use of the deprecated (and private) `_notify_trait`, and should rather call the new `_notify_change`. 

This PR acknowledges that this is public API.