### PR TITLE
type "trait_change" to "change"

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -381,10 +381,10 @@ class TestHasTraitsNotify(TestCase):
         a.on_trait_change(callback4, 'a')
         a.a = 100000
         self.assertEqual(self.cb,('a',10000,100000,a))
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
+        self.assertEqual(len(a._trait_notifiers['a']['change']), 1)
         a.on_trait_change(callback4, 'a', remove=True)
 
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
+        self.assertEqual(len(a._trait_notifiers['a']['change']), 0)
 
     def test_notify_only_once(self):
 
@@ -449,10 +449,10 @@ class TestObserveDecorator(TestCase):
         a.b = 0.0
         self.assertEqual(len(self._notify1),0)
         a.a = 10
-        change = change_dict('a', 0, 10, a, 'trait_change')
+        change = change_dict('a', 0, 10, a, 'change')
         self.assertTrue(change in self._notify1)
         a.b = 10.0
-        change = change_dict('b', 0.0, 10.0, a, 'trait_change')
+        change = change_dict('b', 0.0, 10.0, a, 'change')
         self.assertTrue(change in self._notify1)
         self.assertRaises(TraitError,setattr,a,'a','bad string')
         self.assertRaises(TraitError,setattr,a,'b','bad string')
@@ -473,7 +473,7 @@ class TestObserveDecorator(TestCase):
         a.a = 0
         self.assertEqual(len(self._notify1),0)
         a.a = 10
-        change = change_dict('a', 0, 10, a, 'trait_change')
+        change = change_dict('a', 0, 10, a, 'change')
         self.assertTrue(change in self._notify1)
         self.assertRaises(TraitError,setattr,a,'a','bad string')
 
@@ -510,9 +510,9 @@ class TestObserveDecorator(TestCase):
         self.assertEqual(len(self._notify2),0)
         b.a = 10
         b.b = 10.0
-        change = change_dict('a', 0, 10, b, 'trait_change')
+        change = change_dict('a', 0, 10, b, 'change')
         self.assertTrue(change in self._notify1)
-        change = change_dict('b', 0.0, 10.0, b, 'trait_change')
+        change = change_dict('b', 0.0, 10.0, b, 'change')
         self.assertTrue(change in self._notify2)
 
     def test_static_notify(self):
@@ -529,7 +529,7 @@ class TestObserveDecorator(TestCase):
         # This is broken!!!
         self.assertEqual(len(a._notify1),0)
         a.a = 10
-        change = change_dict('a', 0, 10, a, 'trait_change')
+        change = change_dict('a', 0, 10, a, 'change')
         self.assertTrue(change in a._notify1)
 
         class B(A):
@@ -542,9 +542,9 @@ class TestObserveDecorator(TestCase):
         b = B()
         b.a = 10
         b.b = 10.0
-        change = change_dict('a', 0, 10, b, 'trait_change')
+        change = change_dict('a', 0, 10, b, 'change')
         self.assertTrue(change in b._notify1)
-        change = change_dict('b', 0.0, 10.0, b, 'trait_change')
+        change = change_dict('b', 0.0, 10.0, b, 'change')
         self.assertTrue(change in b._notify2)
 
     def test_notify_args(self):
@@ -565,12 +565,12 @@ class TestObserveDecorator(TestCase):
 
         a.observe(callback1, 'a')
         a.a = 100
-        change = change_dict('a', 10, 100, a, 'trait_change')
+        change = change_dict('a', 10, 100, a, 'change')
         self.assertEqual(self.cb, change)
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 1)
+        self.assertEqual(len(a._trait_notifiers['a']['change']), 1)
         a.unobserve(callback1, 'a')
 
-        self.assertEqual(len(a._trait_notifiers['a']['trait_change']), 0)
+        self.assertEqual(len(a._trait_notifiers['a']['change']), 0)
 
     def test_notify_only_once(self):
 
@@ -1987,5 +1987,3 @@ def test_default_value_repr():
     nt.assert_equal(C.n.default_value_repr(), '0')
     nt.assert_equal(C.lis.default_value_repr(), '[]')
     nt.assert_equal(C.d.default_value_repr(), '{}')
-
-        

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -667,7 +667,7 @@ def observe(*names, **kwargs):
     *names
         The str names of the Traits to observe on the object.
     """
-    return ObserveHandler(names, type=kwargs.get('type', 'trait_change'))
+    return ObserveHandler(names, type=kwargs.get('type', 'change'))
 
 def validate(*names):
     """ A decorator which validates a HasTraits object's state when a Trait is set.
@@ -813,10 +813,10 @@ class HasTraits(HasDescriptors):
                 if past_changes is None:
                     return [change]
                 else:
-                    if past_changes[-1]['type'] == 'trait_change' and change['type'] == 'trait_change':
+                    if past_changes[-1]['type'] == 'change' and change['type'] == 'change':
                         past_changes[-1]['new'] = change['new']
                     else:
-                        # In case of changes other than 'trait_change', append the notification.
+                        # In case of changes other than 'change', append the notification.
                         past_changes.append(change)
                     return past_changes
 
@@ -840,7 +840,7 @@ class HasTraits(HasDescriptors):
                 for name, changes in cache.items():
                     for change in changes[::-1]:
                         # TODO: Separate in a rollback function per notification type.
-                        if change['type'] == 'trait_change':
+                        if change['type'] == 'change':
                             if change['old'] is not Undefined:
                                 setattr(self, name, change['old'])
                             else:
@@ -864,12 +864,12 @@ class HasTraits(HasDescriptors):
                         self._notify_change(change['name'], change['type'], change)
 
     def _notify_trait(self, name, old_value, new_value):
-        self._notify_change(name, 'trait_change', {
+        self._notify_change(name, 'change', {
             'name': name,
             'old': old_value,
             'new': new_value,
             'owner': self,
-            'type': 'trait_change',
+            'type': 'change',
         })
 
     def _notify_change(self, name, type, change):
@@ -972,7 +972,7 @@ class HasTraits(HasDescriptors):
         else:
             self.observe(_callback_wrapper(handler), names=name)
 
-    def observe(self, handler, names=All, type='trait_change'):
+    def observe(self, handler, names=All, type='change'):
         """Setup a handler to be called when a trait changes.
 
         This is used to setup dynamic notifications of trait changes.
@@ -985,7 +985,7 @@ class HasTraits(HasDescriptors):
             dictionary. The change dictionary at least holds a 'type' key
                 - type : the type of notification.
             Other keys may be passed depending on the value of 'type'. In the
-            case where type is 'trait_change', we also have the following keys:
+            case where type is 'change', we also have the following keys:
                 - owner : the HasTraits instance
                 - old : the old value of the modified trait attribute
                 - new : the new value of the modified trait attribute
@@ -994,7 +994,7 @@ class HasTraits(HasDescriptors):
             If names is All, the handler will apply to all traits.  If a list
             of str, handler will apply to all names in the list.  If a
             str, the handler will apply just to that name.
-        type : str, All (default: 'trait_change')
+        type : str, All (default: 'change')
             The type of notification to filter by. If equal to All, then all
             notifications are passed to the observe handler.
         """
@@ -1002,7 +1002,7 @@ class HasTraits(HasDescriptors):
         for n in names:
             self._add_notifiers(handler, n, type)
 
-    def unobserve(self, handler, names=All, type='trait_change'):
+    def unobserve(self, handler, names=All, type='change'):
         """Remove a trait change handler.
 
         This is used to unregister handlers to trait change notificiations.
@@ -1015,7 +1015,7 @@ class HasTraits(HasDescriptors):
             The names of the traits for which the specified handler should be
             uninstalled. If names is All, the specified handler is uninstalled
             from the list of notifiers corresponding to all changes.
-        type : str or All (default: 'trait_change')
+        type : str or All (default: 'change')
             The type of notification to filter by. If All, the specified handler
             is uninstalled from the list of notifiers corresponding to all types.
         """


### PR DESCRIPTION
Changing the name of the notifier type "trait_change" to just "change" was suggested by @ellisonbg in #83, but wasn't really addressed.