### PR TITLE
Add the `@default` decorator

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -21,7 +21,7 @@ from traitlets import (
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
-    ForwardDeclaredType, ForwardDeclaredInstance, validate, observe
+    ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default
 )
 from ipython_genutils import py3compat
 from ipython_genutils.testing.decorators import skipif
@@ -108,7 +108,7 @@ class TestTraitType(TestCase):
         a = A()
         self.assertRaises(TraitError, A.tt.error, a, 10)
 
-    def test_dynamic_initializer(self):
+    def test_deprecated_dynamic_initializer(self):
         class A(HasTraits):
             x = Int(10)
             def _x_default(self):
@@ -117,6 +117,43 @@ class TestTraitType(TestCase):
             x = Int(20)
         class C(A):
             def _x_default(self):
+                return 21
+
+        a = A()
+        self.assertEqual(a._trait_values, {})
+        self.assertEqual(a.x, 11)
+        self.assertEqual(a._trait_values, {'x': 11})
+        b = B()
+        self.assertEqual(b.x, 20)
+        self.assertEqual(b._trait_values, {'x': 20})
+        c = C()
+        self.assertEqual(c._trait_values, {})
+        self.assertEqual(c.x, 21)
+        self.assertEqual(c._trait_values, {'x': 21})
+        # Ensure that the base class remains unmolested when the _default
+        # initializer gets overridden in a subclass.
+        a = A()
+        c = C()
+        self.assertEqual(a._trait_values, {})
+        self.assertEqual(a.x, 11)
+        self.assertEqual(a._trait_values, {'x': 11})
+
+    def test_dynamic_initializer(self):
+
+        class A(HasTraits):
+            x = Int(10)
+
+            @default('x')
+            def _default_x(self):
+                return 11
+
+        class B(A):
+            x = Int(20)
+
+        class C(A):
+
+            @default('x')
+            def _default_x(self):
                 return 21
 
         a = A()

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -17,7 +17,7 @@ import nose.tools as nt
 from nose import SkipTest
 
 from traitlets import (
-    HasTraits, MetaHasDescriptors, TraitType, Any, Bool, CBytes, Dict, Enum,
+    HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
@@ -226,13 +226,13 @@ class TestTraitType(TestCase):
 class TestHasDescriptorsMeta(TestCase):
 
     def test_metaclass(self):
-        self.assertEqual(type(HasTraits), MetaHasDescriptors)
+        self.assertEqual(type(HasTraits), MetaHasTraits)
 
         class A(HasTraits):
             a = Int()
 
         a = A()
-        self.assertEqual(type(a.__class__), MetaHasDescriptors)
+        self.assertEqual(type(a.__class__), MetaHasTraits)
         self.assertEqual(a.a,0)
         a.a = 10
         self.assertEqual(a.a,10)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -298,7 +298,7 @@ class BaseDescriptor(object):
 
     Notes
     -----
-    This implements Python's descriptor prototol.  
+    This implements Python's descriptor prototol.
 
     This class is the base class for all such descriptors.  The
     only magic we use is a custom metaclass for the main :class:`HasTraits`
@@ -317,19 +317,17 @@ class BaseDescriptor(object):
 
     def class_init(self, obj):
         """Part of the initialization which may depend on the underlying
-        HasTraits class.
+        HasDescriptors class.
 
         It is typically overloaded for specific types.
 
-        This method is called by :meth:`HasTraits.__new__` and in the
-        :meth:`BaseDescriptor.instance_init` method of descriptors holding
-        other descriptors.
+        This method is called by :meth:`MetaHasDescriptors.__init__`.
         """
         pass
 
     def instance_init(self, obj):
         """Part of the initialization which may depend on the underlying
-        HasTraits instance.
+        HasDescriptors instance.
 
         It is typically overloaded for specific types.
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -674,10 +674,10 @@ class MetaHasDescriptors(type):
         for k, v in iteritems(classdict):
             if isinstance(v, BaseDescriptor):
                 v.this_class = cls
-        cls.install_class_descriptors()
+        cls.install_class()
         super(MetaHasDescriptors, cls).__init__(name, bases, classdict)
 
-    def install_class_descriptors(cls):
+    def install_class(cls):
         for k, v in iteritems(cls.__dict__):
             if isinstance(v, BaseDescriptor):
                 v.class_init(cls)
@@ -686,9 +686,9 @@ class MetaHasDescriptors(type):
 class MetaHasTraits(MetaHasDescriptors):
     """A metaclass for HasTraits."""
 
-    def install_class_descriptors(cls):
+    def install_class(cls):
         cls._trait_default_generators = {}
-        super(MetaHasTraits, cls).install_class_descriptors()
+        super(MetaHasTraits, cls).install_class()
 
 
 def observe(*names, **kwargs):
@@ -816,10 +816,10 @@ class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
             inst = new_meth(cls)
         else:
             inst = new_meth(cls, **kw)
-        inst.install_descriptors(cls)
+        inst.install_instance(cls)
         return inst
 
-    def install_descriptors(self, cls):
+    def install_instance(self, cls):
         for key in dir(cls):
             # Some descriptors raise AttributeError like zope.interface's
             # __provides__ attributes even though they exist.  This causes
@@ -835,11 +835,11 @@ class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
 
 class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
 
-    def install_descriptors(self, cls):
+    def install_instance(self, cls):
         self._trait_values = {}
         self._trait_notifiers = {}
         self._trait_validators = {}
-        super(HasTraits, self).install_descriptors(cls)
+        super(HasTraits, self).install_instance(cls)
 
     def __init__(self, *args, **kw):
         # Allow trait values to be set using keyword arguments.


### PR DESCRIPTION
Another shot at implementing the `@default` decorator. The reasoning is the following.

-----
 - Unlike observers and validators (which are registered at the instance-level), default value generators are class-level things. Hence `_trait_default_generators ` attribute is class-level.

    - `_trait_values`
    - `_trait_notifiers`
    - `_trait_decorators`  

    all belong to the trait **instance**.

    - `_trait_default_generators`

    belongs are **class-level** attributes of the class derived from HasTraits.

----
The `_trait_default_generators` must be created *before* any `instance_init` is called (otherwise, a TraitType may miss its default initializer).

Therefore, populating `_trait_default_generator` cannot be done at the `instance_init` but before.

This means that the meta-class magic must register all the default value generators in `_trait_default_generators` *before* any `instance_init` is run. 

This is why, in the same way we have an `instance_init` containing the part of the initialization of trait types which depends on the HasTraits instance, I added a `class_init` trait type method containing the part of the initialization depending on the HasTraits class.

-----
The expected behavior wrt inheritance is the following: 

*Default generators should only be called if they are registered in subclasses of `trait.this_type`.*

```Python
class A(HasTraits):
    bar = Int()

    @default('bar')
    def get_bar_default(self):
        return 11


class B(A):
    bar = Float()  # This should ignore the default generator defined in the base class A


class C(B):

    @default('bar')
    def some_other_default(self):  # This default generator should not be ignored since 
        return 3.0                 # it is defined in a class derived from B.a.this_class.
```

Btw, we should put this in the documentation.
