### PR TITLE
warn on misstyped config options

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -178,7 +178,6 @@ class Application(SingletonConfigurable):
         _log_handler.setFormatter(_log_formatter)
     
 
-    log = Instance(logging.Logger)
     def _log_default(self):
         """Start logging for this application.
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -152,6 +152,16 @@ class Configurable(HasTraits):
                     # config object. If we don't, a mutable config_value will be
                     # shared by all instances, effectively making it a class attribute.
                     setattr(self, name, deepcopy(config_value))
+                elif isinstance(self, LoggingConfigurable):
+                    from difflib import get_close_matches
+                    matches = get_close_matches(name, traits)
+                    if len(matches) == 1:
+                        self.log.warn("Config option `{option}` not recognized by `{klass}`, do you mean : `{matches}`"
+                                .format(option=name, klass=type(self).__name__, matches=matches[0]))
+                    elif len(matches) >= 1:
+                        self.log.warn("Config option `{option}` not recognized by `{klass}`, do you mean one of : `{matches}`"
+                                .format(option=name, klass=type(self).__name__, matches=' ,'.join(matches)))
+
 
     def _config_changed(self, name, old, new):
         """Update all the class traits having ``config=True`` in metadata.
@@ -311,7 +321,20 @@ class Configurable(HasTraits):
 
 
 
-class SingletonConfigurable(Configurable):
+class LoggingConfigurable(Configurable):
+    """A parent class for Configurables that log.
+
+    Subclasses have a log trait, and the default behavior
+    is to get the logger from the currently running Application.
+    """
+
+    log = Instance('logging.Logger')
+    def _log_default(self):
+        from traitlets import log
+        return log.get_logger()
+
+
+class SingletonConfigurable(LoggingConfigurable):
     """A configurable that only allows one instance.
 
     This class is for classes that should only have one instance of itself
@@ -396,17 +419,5 @@ class SingletonConfigurable(Configurable):
         """Has an instance been created?"""
         return hasattr(cls, "_instance") and cls._instance is not None
 
-
-class LoggingConfigurable(Configurable):
-    """A parent class for Configurables that log.
-
-    Subclasses have a log trait, and the default behavior
-    is to get the logger from the currently running Application.
-    """
-
-    log = Instance('logging.Logger')
-    def _log_default(self):
-        from traitlets import log
-        return log.get_logger()
 
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -156,10 +156,10 @@ class Configurable(HasTraits):
                     from difflib import get_close_matches
                     matches = get_close_matches(name, traits)
                     if len(matches) == 1:
-                        self.log.warn("Config option `{option}` not recognized by `{klass}`, do you mean : `{matches}`"
+                        self.log.warning(u"Config option `{option}` not recognized by `{klass}`, do you mean : `{matches}`"
                                 .format(option=name, klass=type(self).__name__, matches=matches[0]))
                     elif len(matches) >= 1:
-                        self.log.warn("Config option `{option}` not recognized by `{klass}`, do you mean one of : `{matches}`"
+                        self.log.warning(u"Config option `{option}` not recognized by `{klass}`, do you mean one of : `{matches}`"
                                 .format(option=name, klass=type(self).__name__, matches=' ,'.join(matches)))
 
 

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -48,6 +48,9 @@ class MyApp(Application):
     classes = List([Bar, Foo])
     config_file = Unicode(u'', help="Load this config file").tag(config=True)
 
+    warn_tpyo = Unicode(u"yes the name is wrong on purpose", config=True,
+            help="Should print a warning if `MyApp.warn-typo=...` command is passed")
+
     aliases = Dict({
                     'i' : 'Foo.i',
                     'j' : 'Foo.j',
@@ -135,6 +138,19 @@ class TestApplication(TestCase):
         app.init_bar()
         self.assertEqual(app.bar.enabled, True)
         self.assertEqual(app.bar.b, 10)
+
+    def test_warn_autocorrect(self):
+        stream = StringIO()
+        app = MyApp(log_level=logging.INFO)
+        app.log.handlers = [logging.StreamHandler(stream)]
+
+        cfg = Config()
+        cfg.MyApp.warn_typo = "WOOOO"
+        app.config = cfg
+
+        nt.assert_in("warn_typo", stream.getvalue())
+        nt.assert_in("warn_tpyo", stream.getvalue())
+        
     
     def test_flatten_flags(self):
         cfg = Config()


### PR DESCRIPTION
That have annoyed me for too long: 

```
$ ipython notebook --NotebookApp.ignoreMinifiedJs=True
[W 10:15:45.741 NotebookApp] Config option `ignoreMinifiedJs` not recognized by `NotebookApp`, do you mean : `ignore_minified_js`
[W 10:15:45.742 NotebookApp] Unrecognized JSON config file version, assuming version 1
[W 10:15:45.743 NotebookApp] Config option `ignoreMinifiedJs` not recognized by `NotebookApp`, do you mean : `ignore_minified_js`
[W 10:15:45.744 NotebookApp] Config option `ignoreMinifiedJs` not recognized by `NotebookApp`, do you mean : `ignore_minified_js`
[I 10:15:45.787 NotebookApp] The port 8888 is already in use, trying another random port.
[I 10:15:45.793 NotebookApp] Serving notebooks from local directory: /Users/bussonniermatthias/dev/notebook
[I 10:15:45.793 NotebookApp] 0 active kernels
```

```
$ ipython --InteractiveShell.color=linux
[TerminalIPythonApp] WARNING | Config option `color` not recognized by `TerminalInteractiveShell`, do you mean one of : `colors ,color_info`
Python 3.5.0 |Continuum Analytics, Inc.| (default, Oct 20 2015, 14:39:26)
Type "copyright", "credits" or "license" for more information.

IPython 4.1.0-dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]:
```

It does warn only if if find an option which is **close** by standard definition of **close** from difflib.

This **does** make  `SingletonConfigurable` a `LoggingConfigurable`.

I'd like @fperez input on this one, as there might be historical reasons not to do it. 