### PR TITLE
Allow observing All with @observe

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -556,18 +556,28 @@ class TestObserveDecorator(TestCase):
 
         class A(HasTraits):
             a = Int()
+            b = Int()
             _notify1 = []
+            _notify_any = []
+            
             @observe('a')
             def _a_changed(self, change):
                 self._notify1.append(change)
 
+            @observe(All)
+            def _any_changed(self, change):
+                self._notify_any.append(change)
+
         a = A()
         a.a = 0
-        # This is broken!!!
         self.assertEqual(len(a._notify1),0)
         a.a = 10
         change = change_dict('a', 0, 10, a, 'change')
         self.assertTrue(change in a._notify1)
+        a.b = 1
+        self.assertEqual(len(a._notify_any), 2)
+        change = change_dict('b', 0, 1, a, 'change')
+        self.assertTrue(change in a._notify_any)
 
         class B(A):
             b = Float()

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -136,6 +136,8 @@ def parse_notifier_name(names):
     Examples
     --------
 
+    >>> parse_notifier_name([])
+    [All]
     >>> parse_notifier_name('a')
     ['a']
     >>> parse_notifier_name(['a', 'b'])
@@ -146,6 +148,8 @@ def parse_notifier_name(names):
     if names is All or isinstance(names, string_types):
         return [names]
     elif isinstance(names, (list, tuple)):
+        if not names or All in names:
+            return [All]
         for n in names:
             assert isinstance(n, string_types), "names must be strings"
         return names
@@ -803,10 +807,7 @@ class EventHandler(BaseDescriptor):
 class ObserveHandler(EventHandler):
 
     def __init__(self, names, type):
-        if names is All:
-            self.trait_names = [All]
-        else:
-            self.trait_names = names
+        self.trait_names = names
         self.type = type
 
     def instance_init(self, inst):


### PR DESCRIPTION
This is a bugfix for the new `@observe` decorator, which did not allow observing all trait names at once.