### PR TITLE
only pass a change dict to `_notify_change`

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -186,7 +186,7 @@ class Configurable(HasTraits):
         # merge new config
         self.config.merge(config)
         # unconditionally notify trait change, which triggers load of new config
-        self._notify_change('config', 'trait_change', {
+        self._notify_change({
             'name': 'config',
             'old': oldconfig,
             'new': self.config,

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -37,7 +37,7 @@ def change_dict(*ordered_values):
 
 class HasTraitsStub(HasTraits):
 
-    def _notify_change(self, name, type, change):
+    def _notify_change(self, change):
         self._notify_name = change['name']
         self._notify_old = change['old']
         self._notify_new = change['new']


### PR DESCRIPTION
Changes the calls signature for `_notify_change` from `(name, type, change)` to `(change)` since both the trait name and the change type are data that should already be given in the change dict.