### PR TITLE
make trait name references in event handlers explicit

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -804,33 +804,33 @@ class ObserveHandler(EventHandler):
 
     def __init__(self, names, type):
         if names is All:
-            self.names = [All]
+            self.trait_names = [All]
         else:
-            self.names = names
+            self.trait_names = names
         self.type = type
 
     def instance_init(self, inst):
         meth = types.MethodType(self.func, inst)
-        inst.observe(self, self.names, type=self.type)
+        inst.observe(self, self.trait_names, type=self.type)
 
 
 class ValidateHandler(EventHandler):
 
     def __init__(self, names):
-        self.names = names
+        self.trait_names = names
 
     def instance_init(self, inst):
         meth = types.MethodType(self.func, inst)
-        inst._register_validator(self, self.names)
+        inst._register_validator(self, self.trait_names)
 
 
 class DefaultHandler(EventHandler):
 
     def __init__(self, name):
-        self._name = name
+        self.trait_name = name
 
     def class_init(self, cls):
-        cls._trait_default_generators[self._name] = self
+        cls._trait_default_generators[self.trait_name] = self
 
 
 class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):


### PR DESCRIPTION
Currently the attribute `name` on an event handler would conflict with the one assigned during setup in the metaclass. The workaround has just been to use `_name`, so to reduce confusion I've just extended that attribute to be `trait_name` (and `trait_names` plural).