### PR TITLE
Streamline Class Setup Logic in MetaHasDescriptors

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -90,7 +90,7 @@ class TraitError(Exception):
 #-----------------------------------------------------------------------------
 
 
-def class_of ( object ):
+def class_of( object ):
     """ Returns a string containing the class name of an object with the
     correct indefinite article ('a' or 'an') preceding it (e.g., 'an Image',
     'a PlotValue').
@@ -101,7 +101,7 @@ def class_of ( object ):
     return add_article( object.__class__.__name__ )
 
 
-def add_article ( name ):
+def add_article( name ):
     """ Returns a string containing the correct indefinite article ('a' or 'an')
     prefixed to the specified string.
     """
@@ -302,6 +302,7 @@ dlink = directional_link
 # Base Descriptor Class 
 #-----------------------------------------------------------------------------
 
+
 class BaseDescriptor(object):
     """Base descriptor class
 
@@ -324,15 +325,18 @@ class BaseDescriptor(object):
     name = None
     this_class = None
 
-    def class_init(self, cls):
+    def class_init(self, cls, name):
         """Part of the initialization which may depend on the underlying
         HasDescriptors class.
 
         It is typically overloaded for specific types.
 
-        This method is called by :meth:`MetaHasDescriptors.__init__`.
+        This method is called by :meth:`MetaHasDescriptors.__init__`
+        passing the class (`cls`) and `name` under which the descriptor
+        has been assigned.
         """
-        pass
+        self.this_class = cls
+        self.name = name
 
     def instance_init(self, obj):
         """Part of the initialization which may depend on the underlying
@@ -677,9 +681,7 @@ class MetaHasDescriptors(type):
         """
         for k, v in iteritems(cls.__dict__.copy()):
             if isinstance(v, BaseDescriptor):
-                v.name = k
-                v.this_class = cls
-                v.class_init(cls)
+                v.class_init(cls, k)
 
 
 class MetaHasTraits(MetaHasDescriptors):
@@ -822,7 +824,8 @@ class DefaultHandler(EventHandler):
     def __init__(self, name):
         self.trait_name = name
 
-    def class_init(self, cls):
+    def class_init(self, cls, name):
+        super(DefaultHandler, self).class_init(cls, name)
         cls._trait_default_generators[self.trait_name] = self
 
 
@@ -1596,11 +1599,11 @@ class Union(TraitType):
         self.default_value = self.trait_types[0].default_value
         super(Union, self).__init__(**metadata)
 
-    def class_init(self, cls):
+    def class_init(self, cls, name):
         for trait_type in self.trait_types:
             trait_type.this_class = self.this_class
-            trait_type.class_init(cls)
-        super(Union, self).class_init(cls)
+            trait_type.class_init(cls, name)
+        super(Union, self).class_init(cls, name)
 
     def instance_init(self, obj):
         for trait_type in self.trait_types:
@@ -2025,11 +2028,11 @@ class Container(Instance):
                 validated.append(v)
         return self.klass(validated)
 
-    def class_init(self, cls):
+    def class_init(self, cls, name):
         if isinstance(self._trait, TraitType):
             self._trait.this_class = self.this_class
-            self._trait.class_init(cls)
-        super(Container, self).class_init(cls)
+            self._trait.class_init(cls, name)
+        super(Container, self).class_init(cls, name)
 
     def instance_init(self, obj):
         if isinstance(self._trait, TraitType):
@@ -2217,12 +2220,12 @@ class Tuple(Container):
                 validated.append(v)
         return tuple(validated)
 
-    def class_init(self, cls):
+    def class_init(self, cls, name):
         for trait in self._traits:
             if isinstance(trait, TraitType):
                 trait.this_class = self.this_class
-                trait.class_init(cls)
-        super(Container, self).class_init(cls)
+                trait.class_init(cls, name)
+        super(Container, self).class_init(cls, name)
 
     def instance_init(self, obj):
         for trait in self._traits:
@@ -2321,15 +2324,15 @@ class Dict(Instance):
                 validated[key] = v
         return self.klass(validated)
 
-    def class_init(self, cls):
+    def class_init(self, cls, name):
         if isinstance(self._trait, TraitType):
             self._trait.this_class = self.this_class
-            self._trait.class_init(cls)
+            self._trait.class_init(cls, name)
         if self._traits is not None:
             for trait in self._traits.values():
                 trait.this_class = self.this_class
-                trait.class_init(cls)
-        super(Dict, self).class_init(cls)
+                trait.class_init(cls, name)
+        super(Dict, self).class_init(cls, name)
 
     def instance_init(self, obj):
         if isinstance(self._trait, TraitType):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -90,7 +90,7 @@ class TraitError(Exception):
 #-----------------------------------------------------------------------------
 
 
-def class_of( object ):
+def class_of(object):
     """ Returns a string containing the class name of an object with the
     correct indefinite article ('a' or 'an') preceding it (e.g., 'an Image',
     'a PlotValue').
@@ -101,7 +101,7 @@ def class_of( object ):
     return add_article( object.__class__.__name__ )
 
 
-def add_article( name ):
+def add_article(name):
     """ Returns a string containing the correct indefinite article ('a' or 'an')
     prefixed to the specified string.
     """
@@ -670,16 +670,16 @@ class MetaHasDescriptors(type):
     def __init__(cls, name, bases, classdict):
         """Finish initializing the HasDescriptors class."""
         super(MetaHasDescriptors, cls).__init__(name, bases, classdict)
-        cls.setup_class()
+        cls.setup_class(classdict)
 
-    def setup_class(cls):
+    def setup_class(cls, classdict):
         """Setup descriptor instance on the class
 
         This sets the :attr:`this_class` and :attr:`name` attributes of each
         BaseDescriptor in the class dict of the newly created ``cls`` before
         calling their :attr:`class_init` method.
         """
-        for k, v in iteritems(cls.__dict__.copy()):
+        for k, v in iteritems(classdict):
             if isinstance(v, BaseDescriptor):
                 v.class_init(cls, k)
 
@@ -687,9 +687,9 @@ class MetaHasDescriptors(type):
 class MetaHasTraits(MetaHasDescriptors):
     """A metaclass for HasTraits."""
 
-    def setup_class(cls):
+    def setup_class(cls, classdict):
         cls._trait_default_generators = {}
-        super(MetaHasTraits, cls).setup_class()
+        super(MetaHasTraits, cls).setup_class(classdict)
 
 
 def observe(*names, **kwargs):


### PR DESCRIPTION
Reduces the number of times the metaclass must iterate over the classdict, and uses a copy of `cls.__dict__` when iterating in `setup_class` so that changes in the size of the dict, which could potentially be caused by the `class_init` methods of descriptors, won't throw errors.