### PR TITLE
dynamically generate HasTraits class documentation

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -295,7 +295,7 @@ class Application(SingletonConfigurable):
             classname, traitname = longname.split('.',1)
             cls = classdict[classname]
 
-            trait = cls.class_traits(config=True)[traitname]
+            trait = cls.traits(config=True)[traitname]
             help = cls.class_get_trait_help(trait).splitlines()
             # reformat first line
             help[0] = help[0].replace(longname, alias) + ' (%s)'%longname

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -205,7 +205,7 @@ class Configurable(HasTraits):
         final_help = []
         final_help.append(u'%s options' % cls.__name__)
         final_help.append(len(final_help[0])*u'-')
-        for k, v in sorted(cls.class_traits(config=True).items()):
+        for k, v in sorted(cls.traits(config=True).items()):
             help = cls.class_get_trait_help(v, inst)
             final_help.append(help)
         return '\n'.join(final_help)
@@ -261,7 +261,7 @@ class Configurable(HasTraits):
         s = "# %s configuration" % cls.__name__
         lines = [breaker, s, breaker, '']
         # get the description trait
-        desc = cls.class_traits().get('description')
+        desc = cls.traits().get('description')
         if desc:
             desc = desc.default_value
         else:

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -687,7 +687,6 @@ class TestHasTraits(TestCase):
             f = Float()
         a = A()
         self.assertEqual(sorted(a.trait_names()),['f','i'])
-        self.assertEqual(sorted(A.class_trait_names()),['f','i'])
         self.assertTrue(a.has_trait('f'))
         self.assertFalse(a.has_trait('g'))
 
@@ -717,7 +716,6 @@ class TestHasTraits(TestCase):
             f = Float()
         a = A()
         self.assertEqual(a.traits(), dict(i=A.i, f=A.f))
-        self.assertEqual(A.class_traits(), dict(i=A.i, f=A.f))
 
     def test_traits_metadata(self):
         class A(HasTraits):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1401,7 +1401,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
             return trait.metadata.get(key, default)
 
     @classmethod
-    def class_own_events(cls, name):
+    def class_own_trait_events(cls, name):
         """Get a dict of all event handlers defined on this class, not a parent.
 
         Works like ``event_handlers``, except for excluding traits from parents.
@@ -1411,7 +1411,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
                 if getattr(sup, n, None) is not e}
 
     @classmethod
-    def events(cls, name=None):
+    def trait_events(cls, name=None):
         """Get a ``dict`` of all the event handlers of this class.
 
         Parameters

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -58,6 +58,7 @@ import six
 from .utils.getargspec import getargspec
 from .utils.importstring import import_item
 from .utils.sentinel import Sentinel
+from .utils.docgen import traitlet_documentation
 
 SequenceTypes = (list, tuple, set, frozenset)
 
@@ -161,7 +162,6 @@ def is_trait(t):
     return (isinstance(t, TraitType) or
             (isinstance(t, type) and issubclass(t, TraitType)))
 
-
 def parse_notifier_name(names):
     """Convert the name argument to a list of names.
 
@@ -185,7 +185,6 @@ def parse_notifier_name(names):
         for n in names:
             assert isinstance(n, six.string_types), "names must be strings"
         return names
-
 
 class _SimpleTest:
     def __init__ ( self, value ): self.value = value
@@ -814,14 +813,13 @@ def validate(*names):
     """
     return ValidateHandler(names)
 
-
-def default(name):
+def default(*names):
     """ A decorator which assigns a dynamic default for a Trait on a HasTraits object.
 
     Parameters
     ----------
-    name
-        The str name of the Trait on the object whose default should be generated.
+    *names:
+        The str names of the Traits on the object whose default should be generated.
 
     Notes
     -----
@@ -853,10 +851,12 @@ def default(name):
                 return 3.0                 # ignored since it is defined in a
                                            # class derived from B.a.this_class.
     """
-    return DefaultHandler(name)
+    return DefaultHandler(names)
 
 
 class EventHandler(BaseDescriptor):
+
+    info_text = None
 
     def _init_call(self, func):
         self.func = func
@@ -874,8 +874,14 @@ class EventHandler(BaseDescriptor):
             return self
         return types.MethodType(self.func, inst)
 
+    def info(self):
+        """Returns helpful info"""
+        return self.info_text
+
 
 class ObserveHandler(EventHandler):
+
+    info_text = "observes changes"
 
     def __init__(self, names, type):
         self.trait_names = names
@@ -887,6 +893,8 @@ class ObserveHandler(EventHandler):
 
 class ValidateHandler(EventHandler):
 
+    info_text = "validates values"
+
     def __init__(self, names):
         self.trait_names = names
 
@@ -896,12 +904,15 @@ class ValidateHandler(EventHandler):
 
 class DefaultHandler(EventHandler):
 
-    def __init__(self, name):
-        self.trait_name = name
+    info_text = "sets the default"
+
+    def __init__(self, names):
+        self.trait_names = names
 
     def class_init(self, cls, name):
         super(DefaultHandler, self).class_init(cls, name)
-        cls._trait_default_generators[self.trait_name] = self
+        for name in self.trait_names:
+            cls._trait_default_generators[name] = self
 
 
 class HasDescriptors(six.with_metaclass(MetaHasDescriptors, object)):
@@ -945,6 +956,20 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         self._trait_notifiers = {}
         self._trait_validators = {}
         super(HasTraits, self).setup_instance(*args, **kwargs)
+
+    @classmethod
+    def setup_class(cls, classdict):
+        cls._write_docs_to_class()
+        MetaHasTraits.setup_class(cls, classdict)
+
+    @classmethod
+    def _write_docs_to_class(cls):
+        docs = trait_documentation(cls)
+        if docs:
+            if cls.__doc__ is not None:
+                cls.__doc__ += '\n\n' + docs
+            else:
+                cls.__doc__ = docs
 
     def __init__(self, *args, **kwargs):
         # Allow trait values to be set using keyword arguments.
@@ -1400,6 +1425,15 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         else:
             return trait.metadata.get(key, default)
 
+
+    def set_trait(self, name, value):
+        """Forcibly sets trait attribute, including read-only attributes."""
+        if not self.has_trait(name):
+            raise TraitError("Class %s does not have a trait named %s" %
+                                (self.__class__.__name__, name))
+        else:
+            self.traits()[name].set(self, value)
+
     @classmethod
     def class_own_trait_events(cls, name):
         """Get a dict of all event handlers defined on this class, not a parent.
@@ -1434,6 +1468,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
                     if cls.trait_names(**v.tags):
                         events[k] = v
         return events
+
 
 #-----------------------------------------------------------------------------
 # Actual TraitTypes implementations/subclasses
@@ -1726,7 +1761,7 @@ class Union(TraitType):
         with the validation function of Float, then Bool, and finally Int.
         """
         self.trait_types = trait_types
-        self.info_text = " or ".join([tt.info_text for tt in self.trait_types])
+        self.info_text = " or ".join([tt.info() for tt in self.trait_types])
         self.default_value = self.trait_types[0].default_value
         super(Union, self).__init__(**metadata)
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -58,7 +58,7 @@ import six
 from .utils.getargspec import getargspec
 from .utils.importstring import import_item
 from .utils.sentinel import Sentinel
-from .utils.docgen import traitlet_documentation
+from .utils import docgen
 
 SequenceTypes = (list, tuple, set, frozenset)
 
@@ -959,17 +959,9 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
 
     @classmethod
     def setup_class(cls, classdict):
-        cls._write_docs_to_class()
         MetaHasTraits.setup_class(cls, classdict)
-
-    @classmethod
-    def _write_docs_to_class(cls):
-        docs = trait_documentation(cls)
-        if docs:
-            if cls.__doc__ is not None:
-                cls.__doc__ += '\n\n' + docs
-            else:
-                cls.__doc__ = docs
+        docs = docgen.trait_documentation(cls)
+        docgen.write_docs_to_class(cls, docs)
 
     def __init__(self, *args, **kwargs):
         # Allow trait values to be set using keyword arguments.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1286,6 +1286,42 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         for name in names:
             self._trait_validators[name] = handler
 
+    def add_traits(self, **traits):
+        """Dynamically add trait attributes to the HasTraits instance."""
+        self.__class__ = type(self.__class__.__name__, (self.__class__,),
+                              traits)
+        for trait in traits.values():
+            trait.instance_init(self)
+
+    def set_trait(self, name, value):
+        """Forcibly sets trait attribute, including read-only attributes."""
+        cls = self.__class__
+        if not self.has_trait(name):
+            raise TraitError("Class %s does not have a trait named %s" %
+                                (cls.__name__, name))
+        else:
+            getattr(cls, name).set(self, value)
+
+    @classmethod
+    def class_own_traits(cls, **metadata):
+        """Get a dict of all the traitlets defined on this class, not a parent.
+
+        Works like ``traits``, except for excluding traits from parents.
+        """
+        sup = super(cls, cls)
+        return {n: t for (n, t) in cls.traits(**metadata).items()
+                if getattr(sup, n, None) is not t}
+
+    @classmethod
+    def has_trait(cls, name):
+        """Returns True if the object has a trait with the specified name."""
+        return isinstance(getattr(cls, name, None), TraitType)
+
+    @classmethod
+    def trait_names(cls, **metadata):
+        """Get a list of all the names of this class' traits."""
+        return cls.traits(**metadata).keys()
+
     @classmethod
     def class_trait_names(cls, **metadata):
         """Get a list of all the names of this class' traits.
@@ -1293,7 +1329,9 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         This method is just like the :meth:`trait_names` method,
         but is unbound.
         """
-        return cls.class_traits(**metadata).keys()
+        warn("``HasTraits.class_trait_names`` is deprecated in favor of ``HasTraits.trait_names``"
+             " as a classmethod", DeprecationWarning, stacklevel=2)
+        return cls.traits(**metadata).keys()
 
     @classmethod
     def class_traits(cls, **metadata):
@@ -1312,43 +1350,12 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         the output.  If a metadata key doesn't exist, None will be passed
         to the function.
         """
-        traits = dict([memb for memb in getmembers(cls) if
-                     isinstance(memb[1], TraitType)])
-
-        if len(metadata) == 0:
-            return traits
-
-        result = {}
-        for name, trait in traits.items():
-            for meta_name, meta_eval in metadata.items():
-                if type(meta_eval) is not types.FunctionType:
-                    meta_eval = _SimpleTest(meta_eval)
-                if not meta_eval(trait.metadata.get(meta_name, None)):
-                    break
-            else:
-                result[name] = trait
-
-        return result
+        warn("``HasTraits.class_traits`` is deprecated in favor of ``HasTraits.traits``"
+             " as a classmethod", DeprecationWarning, stacklevel=2)
+        return cls.traits(**metadata)
 
     @classmethod
-    def class_own_traits(cls, **metadata):
-        """Get a dict of all the traitlets defined on this class, not a parent.
-
-        Works like `class_traits`, except for excluding traits from parents.
-        """
-        sup = super(cls, cls)
-        return {n: t for (n, t) in cls.class_traits(**metadata).items()
-                if getattr(sup, n, None) is not t}
-
-    def has_trait(self, name):
-        """Returns True if the object has a trait with the specified name."""
-        return isinstance(getattr(self.__class__, name, None), TraitType)
-        
-    def trait_names(self, **metadata):
-        """Get a list of all the names of this class' traits."""
-        return self.traits(**metadata).keys()
-
-    def traits(self, **metadata):
+    def traits(cls, **metadata):
         """Get a ``dict`` of all the traits of this class.  The dictionary
         is keyed on the name and the values are the TraitType objects.
 
@@ -1362,17 +1369,19 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         the output.  If a metadata key doesn't exist, None will be passed
         to the function.
         """
-        traits = dict([memb for memb in getmembers(self.__class__) if
+        traits = dict([memb for memb in getmembers(cls) if
                      isinstance(memb[1], TraitType)])
 
         if len(metadata) == 0:
             return traits
 
+        for meta_name, meta_eval in metadata.items():
+            if type(meta_eval) is not types.FunctionType:
+                metadata[meta_name] = _SimpleTest(meta_eval)
+
         result = {}
         for name, trait in traits.items():
             for meta_name, meta_eval in metadata.items():
-                if type(meta_eval) is not types.FunctionType:
-                    meta_eval = _SimpleTest(meta_eval)
                 if not meta_eval(trait.metadata.get(meta_name, None)):
                     break
             else:
@@ -1380,31 +1389,51 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
 
         return result
 
-    def trait_metadata(self, traitname, key, default=None):
+    @classmethod
+    def trait_metadata(cls, traitname, key, default=None):
         """Get metadata values for trait by key."""
         try:
-            trait = getattr(self.__class__, traitname)
+            trait = getattr(cls, traitname)
         except AttributeError:
             raise TraitError("Class %s does not have a trait named %s" %
-                                (self.__class__.__name__, traitname))
+                                (cls.__name__, traitname))
         else:
             return trait.metadata.get(key, default)
 
-    def add_traits(self, **traits):
-        """Dynamically add trait attributes to the HasTraits instance."""
-        self.__class__ = type(self.__class__.__name__, (self.__class__,),
-                              traits)
-        for trait in traits.values():
-            trait.instance_init(self)
+    @classmethod
+    def class_own_events(cls, name):
+        """Get a dict of all event handlers defined on this class, not a parent.
 
-    def set_trait(self, name, value):
-        """Forcibly sets trait attribute, including read-only attributes."""
-        cls = self.__class__
-        if not self.has_trait(name):
-            raise TraitError("Class %s does not have a trait"
-                             "named %s" % (cls.__name__, name))
-        else:
-            getattr(cls, name).set(self, value)
+        Works like ``event_handlers``, except for excluding traits from parents.
+        """
+        sup = super(cls, cls)
+        return {n: e for (n, e) in cls.events(name).items()
+                if getattr(sup, n, None) is not e}
+
+    @classmethod
+    def events(cls, name=None):
+        """Get a ``dict`` of all the event handlers of this class.
+
+        Parameters
+        ----------
+        name: str (default: None)
+            The name of a trait of this class. If name is ``None`` then all 
+            the event handlers of this class will be returned instead.
+
+        Returns
+        -------
+        The event handlers associated with a trait name, or all event handlers."""
+        events = {}
+        for k, v in getmembers(cls):
+            if isinstance(v, EventHandler):
+                if name is None:
+                    events[k] = v
+                elif name in v.trait_names:
+                    events[k] = v
+                elif hasattr(v, 'tags'):
+                    if cls.trait_names(**v.tags):
+                        events[k] = v
+        return events
 
 #-----------------------------------------------------------------------------
 # Actual TraitTypes implementations/subclasses

--- a/traitlets/utils/docgen.py
+++ b/traitlets/utils/docgen.py
@@ -1,0 +1,119 @@
+# encoding: utf-8
+"""
+Functions for generating class specific documentation of traits and event handlers
+"""
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+_indent = 4
+nl = '\n'
+t = ' '*_indent
+
+def _clip(l, delimiter, interval=60):
+    divs = range(0, len(l), interval)
+    cuts = [l[i:i + interval] for i in divs]
+    return delimiter.join(cuts)
+
+# - - - - - - - - -
+# Raw Data Parsers
+# - - - - - - - - -
+
+def _gen_trait_help_docs(help):
+    h = _clip(help, nl + t*2 + '   ')
+    return (nl + t + ':help: ' if h else '') + h + (nl if h else '')
+
+def _gen_trait_metadata_docs(metadata):
+    data_list = ['``' + k + " = " + str(v) + '``' for k, v in metadata.items()]
+    return (nl + '*').join(_clip(d, nl + t + '  ') for d in sorted(data_list))
+
+def _gen_trait_event_docs(event_objs):
+    events = [_format_event(e, n) for n, e in event_objs.items()]
+    return (nl+'*').join(_clip(e, nl + t + '  ') for e in sorted(events) if e)
+
+def _format_event(e, name):
+    try:
+        c = e.this_class.__name__
+        m = ':method:`' + c + '.' + e.name + '`'
+        return m + ' - ' + e.info()
+    except:
+        # event was not properly
+        # setup or has no info
+        return ''
+
+
+# - - - - - - - - - - - - - - - - - - - - - -
+# Consolidated Doc Parser For A Single Trait
+# - - - - - - - - - - - - - - - - - - - - - -
+
+def _help_by_name(cls, name):
+    trait = getattr(cls, name)
+    try:
+        main_title = trait.name + " : " + trait.info()
+    except:
+        # info was not a string or trait has no name
+        return
+
+    # add main title
+    docs = nl + main_title
+
+    # parse trait help
+    raw_help = trait.metadata.pop('help', None)
+    if raw_help:
+        docs += _gen_trait_help_docs(raw_help)
+
+    # parse the metadata
+    raw_metadata = trait.metadata.copy()
+    data = _gen_trait_metadata_docs(raw_metadata)
+    if data:
+        data = nl + '*' + data
+
+    # parse event handlers
+    raw_event_objs = cls.events(name)
+    events = _gen_trait_event_docs(raw_event_objs)
+    if events:
+        events = nl + '*' + events
+
+    # add section titles
+    data_title = t + '- trait metadata' if data else ''
+    event_title = t + '- event handlers' if events else ''
+
+    docs += nl if data else ''
+    docs += data_title + data
+    docs += nl if events else ''
+    docs += event_title + events
+
+    # add extra tabs for bullets
+    bullets = docs.split('*')
+    docs = (t*2 + '* ').join(bullets)
+
+    return docs
+
+# - - - - - - - - - - - - - - - -
+# Public Documentation Generator
+# - - - - - - - - - - - - - - - -
+
+def traitlet_documentation(cls, name=None):
+    """Generate documentaiton for traits and event handlers on the class
+
+    Parameters
+    ----------
+    cls: HasTraits
+        The class whose trait documentation will be gathered and parsed
+    name: str (default: None)
+        The name of a particular trait or event handler on the given class,
+        whose documentation should be returned. If name is ``None``, then the
+        documentation for all traits and event handlers will be returned.
+
+    Returns
+    -------
+    A doc string with information about traits and event handlers. If no
+    documentation exists, will return ``None`` instead.
+    """
+    if name is not None:
+        return _help_by_name(cls, name)
+    else:
+        trait_title = ":Traits of :class:`%s` Instances:" % cls.__name__
+        trait_helps = [_help_by_name(cls, n) for n in sorted(cls.trait_names())]
+        trait_helps = "\n".join(h for h in trait_helps if h)
+        if trait_helps:
+            return trait_title + nl + '-'*len(trait_title) + trait_helps

--- a/traitlets/utils/docgen.py
+++ b/traitlets/utils/docgen.py
@@ -73,7 +73,7 @@ def _help_by_name(cls, name):
         data = nl + '*' + data
 
     # parse event handlers
-    raw_event_objs = cls.events(name)
+    raw_event_objs = cls.trait_events(name)
     events = _gen_trait_event_docs(raw_event_objs)
     if events:
         events = nl + '*' + events


### PR DESCRIPTION
A first go at generating `TraitType` documentation inside the `HasTraits.__init__` docstring.

```python
class A(HasTraits):
    i = Int().tag(allow_none=True, default_value=1)
    j = Any().tag(help='some help text for j', data={'x':1})

    def __init__(self, *args, **kwargs):
        """The constructor for the class
        
        More details about the constructor"""
        pass
    
    @default('j')
    def h(self): pass
    
    @validate('j')
    def g(self, commit):
        return commit['value']
    
    @observe('i', 'j')
    def f(self, change):
        pass
    
help(A.__init__)
```
has a docstring that reads:
```text
:Traits of :class:`A` Instances:
--------------------------------
i : an int
    - trait metadata
        * ``allow_none = True``
        * ``default_value = 1``
    - event handlers
        * :method:`A.f` - observes changes

j : any value
    :help: some help text for j

    - trait metadata
        * ``data = {'x': 1}``
    - event handlers
        * :method:`A.f` - observes changes
        * :method:`A.g` - validates values
        * :method:`A.h` - sets the default
```

closes #130 