### PR TITLE
add Path trait

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -9,6 +9,7 @@
 
 import pickle
 import re
+import os
 import sys
 from unittest import TestCase
 from ._warnings import expected_warnings
@@ -18,7 +19,7 @@ from nose import SkipTest
 
 from traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
+    Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError, Path,
     Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default
@@ -2056,3 +2057,24 @@ def test_default_value_repr():
     nt.assert_equal(C.n.default_value_repr(), '0')
     nt.assert_equal(C.lis.default_value_repr(), '[]')
     nt.assert_equal(C.d.default_value_repr(), '{}')
+
+def test_path():
+    class C(HasTraits):
+        p = Path()
+    
+    c = C()
+    nt.assert_equal(c.p, [])
+    c.p = os.pathsep.join(['foø', 'bår'])
+    nt.assert_equal(c.p, [u'foø', u'bår'])
+    nt.assert_is_instance(c.p[0], py3compat.unicode_type)
+    p = [u'∂', u'∫≈']
+    c.p = p
+    nt.assert_equal(c.p, p)
+    
+    with nt.assert_raises(TraitError):
+        c.p = [5]
+    
+    with nt.assert_raises(TraitError):
+        c.p = ('a',)
+
+    

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -42,6 +42,7 @@ Inheritance diagram:
 
 import contextlib
 import inspect
+import os
 import re
 import sys
 import types
@@ -2379,3 +2380,29 @@ class CRegExp(TraitType):
             return re.compile(value)
         except:
             self.error(obj, value)
+
+
+class Path(TraitType):
+    """A search-path trait that can be specified as a path string
+    
+    The trait will be a list of text objects, but can be specified as a single path-delimited string.
+    
+    'foo:bar' will be cast to ['foo', 'bar']
+    """
+    
+    default_value = []
+    info_text = 'a list of text paths or a %s-delimited path string' % os.pathsep
+    
+    def validate(self, obj, value):
+        if isinstance(value, py3compat.string_types):
+            value = py3compat.cast_unicode(value)
+            # split 'foo:bar' into ['foo', 'bar']
+            value = value.split(py3compat.cast_unicode(os.pathsep))
+        if isinstance(value, list):
+            if not all(isinstance(v, py3compat.string_types) for v in value):
+                self.error(obj, value)
+            value = [ py3compat.cast_unicode(v) for v in value ]
+        else:
+            self.error(obj, value)
+        return value
+


### PR DESCRIPTION
allows specifying list-of-text paths as path-separated strings: 'foo:bar:baz'