### PR TITLE
engage cross-validaiton lock for trait types of a union

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1610,14 +1610,19 @@ class Union(TraitType):
         super(Union, self).instance_init(obj)
 
     def validate(self, obj, value):
-        for trait_type in self.trait_types:
-            try:
-                v = trait_type._validate(obj, value)
-                self.metadata = trait_type.metadata
-                return v
-            except TraitError:
-                continue
+        obj._cross_validation_lock = True
+        try:
+            for trait_type in self.trait_types:
+                try:
+                    v = trait_type._validate(obj, value)
+                    self.metadata = trait_type.metadata
+                    return v
+                except TraitError:
+                    continue
+        finally:
+            obj._cross_validation_lock = False
         self.error(obj, value)
+
 
     def __or__(self, other):
         if isinstance(other, Union):


### PR DESCRIPTION
When a `Union` validates a value, it calls `_validate` on each of the traits it depends on. However, this means that cross-validation is performed multiple times - once for each `TraitType` the `Union` is wrapping, and then again for the `Union` itself. It doesn't make sense for this to be the case since the `Union` is passed to the cross-validator and would allow the above behavior to be replicated using its `trait_types` attribute without calling the method multiple times.