### PR TITLE
_notify_change should be public API

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -186,18 +186,18 @@ class Configurable(HasTraits):
         # merge new config
         self.config.merge(config)
         # unconditionally notify trait change, which triggers load of new config
-        self._notify_change({
+        self.notify_change({
             'name': 'config',
             'old': oldconfig,
             'new': self.config,
             'owner': self,
-            'type': 'trait_change', 
+            'type': 'change',
         })
 
     @classmethod
     def class_get_help(cls, inst=None):
         """Get the help string for this class in ReST format.
-        
+
         If `inst` is given, it's current trait values will be used in place of
         class defaults.
         """

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -37,7 +37,7 @@ def change_dict(*ordered_values):
 
 class HasTraitsStub(HasTraits):
 
-    def _notify_change(self, change):
+    def notify_change(self, change):
         self._notify_name = change['name']
         self._notify_old = change['old']
         self._notify_new = change['new']


### PR DESCRIPTION
1.  Changes a 'trait_change' to 'change' which was left out in #107 .

2. Rename method `_notify_change` to `notify_change`, making it public API.
    The reason why `notify_change` should be public API becomes clear in ipython/ipywidgets/pull/270:
     - ipywidgets directly uses the private method `_notify_traits` which is replaced by the more general `_notify_change`.
     - If, instead of overloading `_notify_trait` or `notify_change`, we used `observe` to register the notification to the front-end we could not guarantee that these would be triggered before other trait notifications. It is important that they are because if another trait notifications raises an exception, the notification of the front-end is never done and we end up in an inconsistent state. Therefore, ipywidgets needs to overload `notify_change` which should be public API.

cc @jdfreder @minrk 