### PR TITLE
Work on deprecation warnings

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -6,11 +6,10 @@
 
 from __future__ import print_function
 
-import logging
 from copy import deepcopy
 
 from .loader import Config, LazyConfigValue
-from traitlets.traitlets import HasTraits, Instance
+from traitlets.traitlets import HasTraits, Instance, observe, default
 from ipython_genutils.text import indent, dedent, wrap_paragraphs
 from ipython_genutils.py3compat import iteritems
 
@@ -162,8 +161,8 @@ class Configurable(HasTraits):
                         self.log.warning(u"Config option `{option}` not recognized by `{klass}`, do you mean one of : `{matches}`"
                                 .format(option=name, klass=type(self).__name__, matches=' ,'.join(matches)))
 
-
-    def _config_changed(self, name, old, new):
+    @observe('config')
+    def _config_changed(self, change):
         """Update all the class traits having ``config=True`` in metadata.
 
         For any class trait with a ``config`` metadata attribute that is
@@ -177,7 +176,7 @@ class Configurable(HasTraits):
         # classes that are Configurable subclasses.  This starts with Configurable
         # and works down the mro loading the config for each section.
         section_names = self.section_names()
-        self._load_config(new, traits=traits, section_names=section_names)
+        self._load_config(change['new'], traits=traits, section_names=section_names)
 
     def update_config(self, config):
         """Update config and trigger reload of config via trait events"""
@@ -329,6 +328,7 @@ class LoggingConfigurable(Configurable):
     """
 
     log = Instance('logging.Logger')
+    @default('log')
     def _log_default(self):
         from traitlets import log
         return log.get_logger()

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -410,8 +410,15 @@ class TraitType(BaseDescriptor):
             )
 
         if len(metadata) > 0:
+            stacklevel = 1
+            f = inspect.currentframe()
+            # count supers to determine stacklevel for warning
+            while f.f_code.co_name == '__init__':
+                stacklevel += 1
+                f = f.f_back
+            
             warn("metadata %s was set from the constructor.  Metadata should be set using the .tag() method, e.g., Int().tag(key1='value1', key2='value2')" % (metadata,),
-                 DeprecationWarning, stacklevel=2)
+                 DeprecationWarning, stacklevel=stacklevel)
             if len(self.metadata) > 0:
                 self.metadata = self.metadata.copy()
                 self.metadata.update(metadata)


### PR DESCRIPTION
- handle super offset to get correct stacklevel for `init(**metadata)` warning
- use `warn_explicit` to point to deprecated magic method definitions,
  instead of the event-triggering code, which isn't relevant.

(includes #149)