### PR TITLE
Don't inspect observer signatures

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -631,7 +631,7 @@ class TestObserveDecorator(TestCase):
                 super(A, self).__init__(**kwargs)
                 self.observe(self.listener1, ['a'])
             
-            def listener1(self):
+            def listener1(self, change):
                 self.b += 1
 
         class B(A):
@@ -643,11 +643,11 @@ class TestObserveDecorator(TestCase):
                 super(B, self).__init__(**kwargs)
                 self.observe(self.listener2)
             
-            def listener2(self):
+            def listener2(self, change):
                 self.c += 1
             
             @observe('a')
-            def _a_changed(self):
+            def _a_changed(self, change):
                 self.d += 1
 
         b = B()

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1045,21 +1045,11 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
             # Bound methods have an additional 'self' argument.
 
             if isinstance(c, _CallbackWrapper):
-                # _CallbackWrappers are not compatible with getargspec and have one argument
                 c = c.__call__
             elif isinstance(c, EventHandler):
                 c = getattr(self, c.name)
-
-            offset = 1 if isinstance(c, types.MethodType) else 0
-            nargs = len(getargspec(c)[0]) - offset
-
-            if nargs == 0:
-                c()
-            elif nargs == 1:
-                c(change)
-            else:
-                raise TraitError('an observe change callback '
-                                    'must have 0-1 arguments.')
+            
+            c(change)
 
     def _add_notifiers(self, handler, name, type):
         if name not in self._trait_notifiers:


### PR DESCRIPTION
The main point of the new API is that we don't need to do different things with different signatures.

Listeners must always take one positional arg. Zero-arg listeners are not allowed.