### PR TITLE
getting bound methods requires handler name

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1046,7 +1046,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
 
             if isinstance(c, _CallbackWrapper):
                 c = c.__call__
-            elif isinstance(c, EventHandler):
+            elif isinstance(c, EventHandler) and c.name is not None:
                 c = getattr(self, c.name)
             
             c(change)


### PR DESCRIPTION
Retrieving bound methods from event handlers is only valid if their `name` attribute is not `None` (i.e. they were registered with `@observe`). Without checking that `name` is not `None`, EventHandler instances registered using `HasTraits.observe` will fail.