### PR TITLE
use logging.shutdown()

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -567,6 +567,7 @@ class Application(SingletonConfigurable):
 
     def exit(self, exit_status=0):
         self.log.debug("Exiting application: %s" % self.name)
+        logging.shutdown()
         sys.exit(exit_status)
 
     @classmethod

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -11,7 +11,6 @@ import logging
 import os
 import re
 import sys
-from copy import deepcopy
 from collections import defaultdict
 
 from decorator import decorator


### PR DESCRIPTION
As mention in [the docs](https://docs.python.org/3/library/logging.html?highlight=logging#logging.shutdown)

Though they don't say what does/does not happen if you don't. 