### PR TITLE
Add `@observe_compat` decorator

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from copy import deepcopy
 
 from .loader import Config, LazyConfigValue
-from traitlets.traitlets import HasTraits, Instance, observe, default
+from traitlets.traitlets import HasTraits, Instance, observe, observe_compat, default
 from ipython_genutils.text import indent, dedent, wrap_paragraphs
 from ipython_genutils.py3compat import iteritems
 
@@ -162,6 +162,7 @@ class Configurable(HasTraits):
                                 .format(option=name, klass=type(self).__name__, matches=' ,'.join(matches)))
 
     @observe('config')
+    @observe_compat
     def _config_changed(self, change):
         """Update all the class traits having ``config=True`` in metadata.
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2111,3 +2111,37 @@ def test_subclass_compat():
     nt.assert_false(obj.parent_override)
     nt.assert_is(obj.d, SubClass)
 
+
+class DefinesHandler(HasTraits):
+    parent_called = False
+    
+    trait = Integer()
+    @observe('trait')
+    def handler(self, change):
+        self.parent_called = True
+
+class OverridesHandler(DefinesHandler):
+    child_called = False
+    
+    @observe('trait')
+    def handler(self, change):
+        self.child_called = True
+
+class AddsHandler(DefinesHandler):
+    child_called = False
+    
+    @observe('trait')
+    def child_handler(self, change):
+        self.child_called = True
+
+def test_override_observer():
+    obj = OverridesHandler()
+    obj.trait = 5
+    nt.assert_true(obj.child_called)
+    nt.assert_false(obj.parent_called)
+
+def test_subclass_add_observer():
+    obj = AddsHandler()
+    obj.trait = 5
+    nt.assert_true(obj.child_called)
+    nt.assert_true(obj.parent_called)

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2120,6 +2120,7 @@ class DefinesHandler(HasTraits):
     def handler(self, change):
         self.parent_called = True
 
+
 class OverridesHandler(DefinesHandler):
     child_called = False
     
@@ -2127,18 +2128,35 @@ class OverridesHandler(DefinesHandler):
     def handler(self, change):
         self.child_called = True
 
+
+def test_subclass_override_observer():
+    obj = OverridesHandler()
+    obj.trait = 5
+    nt.assert_true(obj.child_called)
+    nt.assert_false(obj.parent_called)
+
+
+class DoesntRegisterHandler(DefinesHandler):
+    child_called = False
+    
+    def handler(self, change):
+        self.child_called = True
+
+
+def test_subclass_override_not_registered():
+    """Subclass that overrides observer and doesn't re-register unregisters both"""
+    obj = DoesntRegisterHandler()
+    obj.trait = 5
+    nt.assert_false(obj.child_called)
+    nt.assert_false(obj.parent_called)
+
+
 class AddsHandler(DefinesHandler):
     child_called = False
     
     @observe('trait')
     def child_handler(self, change):
         self.child_called = True
-
-def test_override_observer():
-    obj = OverridesHandler()
-    obj.trait = 5
-    nt.assert_true(obj.child_called)
-    nt.assert_false(obj.parent_called)
 
 def test_subclass_add_observer():
     obj = AddsHandler()

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -471,15 +471,13 @@ class TraitType(BaseDescriptor):
 
             # Only look for default handlers in classes derived from self.this_class.
             mro = type(obj).mro()
+            meth_name = '_%s_default' % self.name
             for cls in mro[:mro.index(self.this_class) + 1]:
                 if hasattr(cls, '_trait_default_generators'):
                     default_handler = cls._trait_default_generators.get(self.name)
                     if default_handler is not None and default_handler.this_class == cls:
                         return types.MethodType(default_handler.func, obj)
 
-            # Handling deprecated magic method
-            meth_name = '_%s_default' % self.name
-            for cls in mro[:mro.index(self.this_class) + 1]:
                 if meth_name in cls.__dict__:
                     method = getattr(obj, meth_name)
                     _deprecated_method(method, cls, meth_name, "use @default decorator instead.")


### PR DESCRIPTION
shim for *explicit* backward-compatible adoption of new APIs.

Using the shim allows classes to update to the new API without breaking subclasses that may be overriding observers with the old API.

```python
class Parent(HasTraits):
    @observe('name')
    @observe_compat
    def _name_changed(self, change)

class Child(parent):
    def _name_changed(self, name, old, new):
        super()._name_changed(name, old, new)
```

I'm not sure if there's an easy way to do this without the explicit additional shim,
but it's possible. I'll spend a little more time investigating that.

If we go with this, we should probably add a similar one for validate.