### PR TITLE
default initialization of configurable traits from os.environ

### DIFF
--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -18,7 +18,7 @@ from traitlets.config.configurable import (
 )
 
 from traitlets.traitlets import (
-    Integer, Float, Unicode, List, Dict, Set,
+    Type, Integer, Float, Unicode, List, Dict, Set, CBool
 )
 
 from traitlets.config.loader import Config
@@ -147,6 +147,17 @@ class TestConfigurable(TestCase):
     def test_help_inst(self):
         inst = MyConfigurable(a=5, b=4)
         self.assertEqual(MyConfigurable.class_get_help(inst), mc_help_inst)
+
+    def test_environment_variable_default(self):
+        import os
+
+        os.environ['MY_ENVVAR'] = 'true'
+
+        class A(Configurable):
+            b = CBool().tag(envvar='MY_ENVVAR')
+
+        a = A()
+        self.assertTrue(a.b)
 
 
 class TestSingletonConfigurable(TestCase):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -635,6 +635,14 @@ class TraitType(BaseDescriptor):
     def default_value_repr(self):
         return repr(self.default_value)
 
+    def set_default_from_envvar(self, string):
+        """Set the default value for the trait from os.environ.
+
+        This hook is only triggered if the key 'envvar' is in metadata, and the trait
+        exists on a :class:`Configurable` instance at the time the class is constructed.
+        """
+        self.default = string
+
 #-----------------------------------------------------------------------------
 # The HasTraits implementation
 #-----------------------------------------------------------------------------
@@ -1996,6 +2004,14 @@ class CBool(Bool):
             return bool(value)
         except:
             self.error(obj, value)
+
+    def set_default_from_envvar(self, string):
+        lowered = string.lower()
+        if lowered == 'true':
+            value = True
+        if lowered == 'false':
+            value = False
+        self.default_value = value
 
 
 class Enum(TraitType):


### PR DESCRIPTION
Configurables hooks into a call from the metaclass to `setup_class` in order to setup default values from `os.environ`. This in turn calls `TraitType.set_default_from_envvar` to apply that default value to the TraitType if the key `'envvar'` is in its metadata.