### PR TITLE
Handle missing source files for deprecated methods

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -107,7 +107,7 @@ def _deprecated_method(method, cls, method_name, msg):
     try:
         fname = inspect.getsourcefile(method) or "<unknown>"
         lineno = inspect.getsourcelines(method)[1] or 0
-    except TypeError as e:
+    except (IOError, TypeError) as e:
         # Failed to inspect for some reason
         warn(warn_msg + ('\n(inspection failed) %s' % e), DeprecationWarning)
     else:


### PR DESCRIPTION
inspect.getsourcelines can throw an IOError if it can't find a source file corresponding to the given method:

```
  File "./build/lib/python2.7/site-packages/traitlets-4.1.0-py2.7.egg/traitlets/traitlets.py", line 109, in _deprecated_method
  File "./build/lib/python2.7/inspect.py", line 690, in getsourcelines
  File "./build/lib/python2.7/inspect.py", line 529, in findsource
IOError: source code not available
```