### PR TITLE
default `cls` arg in TraitType.get to None

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -495,7 +495,7 @@ class TraitType(BaseDescriptor):
                 if self.name is not None:
                     obj._trait_values[self.name] = v
 
-    def get(self, obj, cls):
+    def get(self, obj, cls=None):
         try:
             value = obj._trait_values[self.name]
         except KeyError:


### PR DESCRIPTION
As in `__get__`, the class that owns a descriptor is often unused. It makes sense, particularly for internal uses of `TraitType.get` to default `cls` to None.