### PR TITLE
pass args and kwargs to setup_instance

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -22,7 +22,7 @@ from traitlets import (
     Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
-    observe_compat,
+    observe_compat, BaseDescriptor, HasDescriptors,
 )
 from ipython_genutils import py3compat
 from ipython_genutils.testing.decorators import skipif
@@ -265,6 +265,25 @@ class TestHasDescriptorsMeta(TestCase):
         self.assertEqual(B.t.this_class, A)
         self.assertEqual(B.tt.this_class, B)
         self.assertEqual(B.ttt.this_class, B)
+
+class TestHasDescriptors(TestCase):
+
+    def test_setup_instance(self):
+
+        class FooDescriptor(BaseDescriptor):
+
+            def instance_init(self, inst):
+                foo = inst.foo # instance should have the attr
+
+        class HasFooDescriptors(HasDescriptors):
+
+            fd = FooDescriptor()
+
+            def setup_instance(self, *args, **kwargs):
+                self.foo = kwargs.get('foo', None)
+                super(HasFooDescriptors, self).setup_instance(*args, **kwargs)
+
+        hfd = HasFooDescriptors(foo='bar')
 
 class TestHasTraitsNotify(TestCase):
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -906,10 +906,10 @@ class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
             inst = new_meth(cls)
         else:
             inst = new_meth(cls, *args, **kwargs)
-        inst.setup_instance()
+        inst.setup_instance(*args, **kwargs)
         return inst
 
-    def setup_instance(self):
+    def setup_instance(self, *args, **kwargs):
         """
         This is called **before** self.__init__ is called.
         """
@@ -930,11 +930,11 @@ class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
 
 class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
 
-    def setup_instance(self):
+    def setup_instance(self, *args, **kwargs):
         self._trait_values = {}
         self._trait_notifiers = {}
         self._trait_validators = {}
-        super(HasTraits, self).setup_instance()
+        super(HasTraits, self).setup_instance(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         # Allow trait values to be set using keyword arguments.


### PR DESCRIPTION
There is no way to initialize the attributes of a `HasDescriptors` instance, which descriptors are dependant on, if those attributes are determined by the args and kwargs passed to the `HasDescriptors` constructor.

The following attempt to initialize `HasDescriptors` attributes that descriptors are dependant on raises:

```python
class FooDescriptor(BaseDescriptor):

	def instance_init(self, inst):
		foo = inst.foo # <-- this will raise an AttributeError
		
class HasFooDescriptors(HasDescriptors):

	fd = FooDescriptor()

	def __new__(cls, *args, **kwargs):
		inst = super(HasFooDescriptors, cls).__new__(cls, *args, **kwargs)
		inst.foo = kwargs.get('foo', None)
		
hfd = HasFooDescriptors(foo='bar')
# raises AttributeError because foo does not exist
# on the instance by the time instance_init is called
```

Now, because args and kwargs are passed to `setup_isntance`, this can be accomplished:

```python
class FooDescriptor(BaseDescriptor):

	def instance_init(self, inst):
		foo = inst.foo # no error is raised
		
class HasFooDescriptors(HasDescriptors):

	fd = FooDescriptor()

	def setup_instance(self, *args, **kwargs):
		self.foo = kwargs.get('foo', None)
		super(HasFooDescriptors, self).setup_instance(*args, **kwargs)
		
hfd = HasFooDescriptors(foo='bar')
```