### PR TITLE
passthrough unused args to super.__init__

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1025,7 +1025,7 @@ class TestThis(TestCase):
 
         tree = Tree(
             value='foo',
-            leaves=[Tree('bar'), Tree('buzz')]
+            leaves=[Tree(value='bar'), Tree(value='buzz')]
         )
 
         with self.assertRaises(TraitError):
@@ -2163,3 +2163,19 @@ def test_subclass_add_observer():
     obj.trait = 5
     nt.assert_true(obj.child_called)
     nt.assert_true(obj.parent_called)
+
+def test_super_args():
+    class SuperRecorder(object):
+        def __init__(self, *args, **kwargs):
+            self.super_args = args
+            self.super_kwargs = kwargs
+    
+    class SuperHasTraits(HasTraits, SuperRecorder):
+        i = Integer()
+    
+    obj = SuperHasTraits('a1', 'a2', b=10, i=5, c='x')
+    nt.assert_equal(obj.i, 5)
+    assert not hasattr(obj, 'b')
+    assert not hasattr(obj, 'c')
+    nt.assert_equal(obj.super_args, ('a1', 'a2'))
+    nt.assert_equal(obj.super_kwargs, {'b': 10, 'c': 'x'})

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -940,10 +940,16 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
         # Allow trait values to be set using keyword arguments.
         # We need to use setattr for this to trigger validation and
         # notifications.
+        super_args = args
+        super_kwargs = {}
         with self.hold_trait_notifications():
             for key, value in iteritems(kwargs):
-                setattr(self, key, value)
-        super(HasTraits, self).__init__()
+                if self.has_trait(key):
+                    setattr(self, key, value)
+                else:
+                    # passthrough args that don't set traits to super
+                    super_kwargs[key] = value
+        super(HasTraits, self).__init__(*super_args, **super_kwargs)
 
     def __getstate__(self):
         d = self.__dict__.copy()


### PR DESCRIPTION
only those not consumed by trait value-setting

for proper cooperative inheritance

finishes fixing #113