### PR TITLE
show RuntimeWarning if super init raises TypeError

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2198,3 +2198,12 @@ def test_super_args():
     assert not hasattr(obj, 'c')
     nt.assert_equal(obj.super_args, ('a1', 'a2'))
     nt.assert_equal(obj.super_kwargs, {'b': 10, 'c': 'x'})
+
+def test_super_bad_args():
+    class SuperHasTraits(HasTraits):
+        a = Integer()
+    
+    with expected_warnings(["Passing unrecoginized arguments"]):
+        obj = SuperHasTraits(a=1, b=2)
+    nt.assert_equal(obj.a, 1)
+    assert not hasattr(obj, 'b')

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2203,7 +2203,12 @@ def test_super_bad_args():
     class SuperHasTraits(HasTraits):
         a = Integer()
     
-    with expected_warnings(["Passing unrecoginized arguments"]):
+    if sys.version_info < (3,):
+        # Legacy Python, object.__init__ warns itself, instead of raising
+        w = ['object.__init__']
+    else:
+        w = ["Passing unrecoginized arguments"]
+    with expected_warnings(w):
         obj = SuperHasTraits(a=1, b=2)
     nt.assert_equal(obj.a, 1)
     assert not hasattr(obj, 'b')

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -949,7 +949,24 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
                 else:
                     # passthrough args that don't set traits to super
                     super_kwargs[key] = value
-        super(HasTraits, self).__init__(*super_args, **super_kwargs)
+        try:
+            super(HasTraits, self).__init__(*super_args, **super_kwargs)
+        except TypeError as e:
+            arg_s_list = [ repr(arg) for arg in super_args ]
+            for k, v in kwargs.items():
+                arg_s_list.append("%s=%r" % (k, v))
+            arg_s = ', '.join(arg_s_list)
+            warn(
+                "Passing unrecoginized arguments to super({classname}).__init__({arg_s}).\n"
+                "{error}\n"
+                "This error will be raised in a future release of traitlets."
+                .format(
+                    arg_s=arg_s, classname=self.__class__.__name__,
+                    error=e,
+                ),
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     def __getstate__(self):
         d = self.__dict__.copy()


### PR DESCRIPTION
Since we are now passing unused constructor args to `super().__init__`, improper arguments that were being silently ignored will raise.

This shows a warning in that case, so that downstream bugs have a release cycle to fix their bugs revealed by the change.

I decided to use RuntimeWarning instead of a DeprecationWarning because anything that causes this was always a bug, it was just a silently ignored bug and silence is bad.

closes #176