### PR TITLE
Allow replacing cross validator in derived class

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1267,10 +1267,6 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
             The names of the traits that should be cross-validated
         """
         for name in names:
-            if name in self._trait_validators:
-                raise TraitError("A cross-validator for the trait"
-                                 " '%s' already exists" % name)
-
             magic_name = '_%s_validate' % name
             if hasattr(self, magic_name):
                 class_value = getattr(self.__class__, magic_name)


### PR DESCRIPTION
By design, we can only have one cross validator at a time.

Instead of throwing an error when we call `@validate` a second time, I propose replacing the existing cross validator with the new one.

The goal is to allow for things like this:

```python
class Foo(HasTraits):
    
    a = Int()
    
    @validate('a')
    def val(self, proposal):
        value = proposal['value']
        if value < 0:
            raise TraitError('setting a < 0')
        else:
            return value
        
class Bar(Foo):
    
    a = Int()
    
    @validate('a')
    def valid(self, proposal):
        value = super(Bar, self).val(proposal)
        if value > 1:
            raise TraitError('setting a > 1')
        else:
            return value
        
bar = Bar()
```

where the validator is replaced in a derived class.