### PR TITLE
Remove depedency towards ipython_genutils.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-ipython_genutils
+

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 setuptools_args = {}
 
 install_requires = setuptools_args['install_requires'] = [
-    'ipython_genutils',
     'decorator',
 ]
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -23,11 +23,11 @@ from traitlets.config.loader import (
 from traitlets.traitlets import (
     Unicode, List, Enum, Dict, Instance, TraitError, observe, observe_compat, default,
 )
-from ipython_genutils.importstring import import_item
 from ipython_genutils.text import indent, wrap_paragraphs, dedent
 
 
 from traitlets.utils import py3compat
+from traitlets.utils.importstring import import_item
 from traitlets.utils.py3compat import string_types, iteritems
 
 #-----------------------------------------------------------------------------

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -25,8 +25,10 @@ from traitlets.traitlets import (
 )
 from ipython_genutils.importstring import import_item
 from ipython_genutils.text import indent, wrap_paragraphs, dedent
-from ipython_genutils import py3compat
-from ipython_genutils.py3compat import string_types, iteritems
+
+
+from traitlets.utils import py3compat
+from traitlets.utils.py3compat import string_types, iteritems
 
 #-----------------------------------------------------------------------------
 # Descriptions for the various sections

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -23,8 +23,8 @@ from traitlets.config.loader import (
 from traitlets.traitlets import (
     Unicode, List, Enum, Dict, Instance, TraitError, observe, observe_compat, default,
 )
-from ipython_genutils.text import indent, wrap_paragraphs, dedent
 
+from .configurable import indent, wrap_paragraphs, dedent
 
 from traitlets.utils import py3compat
 from traitlets.utils.importstring import import_item

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -12,7 +12,8 @@ import warnings
 from .loader import Config, LazyConfigValue, _is_section_key
 from traitlets.traitlets import HasTraits, Instance, observe, observe_compat, default
 from ipython_genutils.text import indent, dedent, wrap_paragraphs
-from ipython_genutils.py3compat import iteritems
+from traitlets.utils.py3compat import iteritems
+
 
 
 #-----------------------------------------------------------------------------

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -14,7 +14,6 @@ import warnings
 
 from .loader import Config, LazyConfigValue, _is_section_key
 from traitlets.traitlets import HasTraits, Instance, observe, observe_compat, default
-from ipython_genutils.text import indent, dedent, wrap_paragraphs
 from traitlets.utils.py3compat import iteritems
 
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -13,7 +13,6 @@ import sys
 import json
 from ast import literal_eval
 
-from ipython_genutils.path import filefind
 
 from traitlets.utils import py3compat
 from traitlets.utils.encoding import DEFAULT_ENCODING
@@ -381,9 +380,84 @@ class FileConfigLoader(ConfigLoader):
         self.path = path
         self.full_filename = ''
 
+    def filefind(filename, path_dirs=None):
+        """Find a file by looking through a sequence of paths.
+
+        This iterates through a sequence of paths looking for a file and returns
+        the full, absolute path of the first occurence of the file.  If no set of
+        path dirs is given, the filename is tested as is, after running through
+        :func:`expandvars` and :func:`expanduser`.  Thus a simple call::
+
+            filefind('myfile.txt')
+
+        will find the file in the current working dir, but::
+
+            filefind('~/myfile.txt')
+
+        Will find the file in the users home directory.  This function does not
+        automatically try any paths, such as the cwd or the user's home directory.
+
+        Parameters
+        ----------
+        filename : str
+            The filename to look for.
+        path_dirs : str, None or sequence of str
+            The sequence of paths to look for the file in.  If None, the filename
+            need to be absolute or be in the cwd.  If a string, the string is
+            put into a sequence and the searched.  If a sequence, walk through
+            each element and join with ``filename``, calling :func:`expandvars`
+            and :func:`expanduser` before testing for existence.
+
+        Returns
+        -------
+        Raises :exc:`IOError` or returns absolute path to file.
+        """
+
+        def expand_path(s):
+            """Expand $VARS and ~names in a string, like a shell
+
+            :Examples:
+
+               In [2]: os.environ['FOO']='test'
+
+               In [3]: expand_path('variable FOO is $FOO')
+               Out[3]: 'variable FOO is test'
+            """
+            # This is a pretty subtle hack. When expand user is given a UNC path
+            # on Windows (\\server\share$\%username%), os.path.expandvars, removes
+            # the $ to get (\\server\share\%username%). I think it considered $
+            # alone an empty var. But, we need the $ to remains there (it indicates
+            # a hidden share).
+            if os.name=='nt':
+                s = s.replace('$\\', 'IPYTHON_TEMP')
+            s = os.path.expandvars(os.path.expanduser(s))
+            if os.name=='nt':
+                s = s.replace('IPYTHON_TEMP', '$\\')
+            return s
+
+        # If paths are quoted, abspath gets confused, strip them...
+        filename = filename.strip('"').strip("'")
+        # If the input is an absolute path, just check it exists
+        if os.path.isabs(filename) and os.path.isfile(filename):
+            return filename
+
+        if path_dirs is None:
+            path_dirs = ("",)
+        elif isinstance(path_dirs, py3compat.string_types):
+            path_dirs = (path_dirs,)
+
+        for path in path_dirs:
+            if path == '.': path = py3compat.getcwd()
+            testname = expand_path(os.path.join(path, filename))
+            if os.path.isfile(testname):
+                return os.path.abspath(testname)
+
+        raise IOError("File %r does not exist in any of the search paths: %r" %
+                      (filename, path_dirs) )
+
     def _find_file(self):
         """Try to find the file by searching the paths."""
-        self.full_filename = filefind(self.filename, self.path)
+        self.full_filename = FileConfigLoader.filefind(self.filename, self.path)
 
 class JSONFileConfigLoader(FileConfigLoader):
     """A JSON file loader for config

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -380,6 +380,7 @@ class FileConfigLoader(ConfigLoader):
         self.path = path
         self.full_filename = ''
 
+    @staticmethod
     def filefind(filename, path_dirs=None):
         """Find a file by looking through a sequence of paths.
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -14,9 +14,10 @@ import json
 from ast import literal_eval
 
 from ipython_genutils.path import filefind
-from ipython_genutils import py3compat
-from ipython_genutils.encoding import DEFAULT_ENCODING
-from ipython_genutils.py3compat import unicode_type, iteritems
+
+from traitlets.utils import py3compat
+from traitlets.utils.encoding import DEFAULT_ENCODING
+from traitlets.utils.py3compat import unicode_type, iteritems
 from traitlets.traitlets import HasTraits, List, Any
 
 #-----------------------------------------------------------------------------

--- a/traitlets/config/manager.py
+++ b/traitlets/config/manager.py
@@ -8,7 +8,7 @@ import json
 import os
 
 from traitlets.config import LoggingConfigurable
-from ipython_genutils.py3compat import PY3
+from utils.py3compat import PY3
 from traitlets.traitlets import Unicode
 
 

--- a/traitlets/config/tests/tempdir.py
+++ b/traitlets/config/tests/tempdir.py
@@ -1,0 +1,150 @@
+"""TemporaryDirectory class, copied from Python 3
+
+This is copied from the stdlib and will be standard in Python 3.2 and onwards.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import print_function
+
+import os as _os
+import warnings as _warnings
+import sys as _sys
+
+# This code should only be used in Python versions < 3.2, since after that we
+# can rely on the stdlib itself.
+try:
+    from tempfile import TemporaryDirectory
+
+except ImportError:
+    from tempfile import mkdtemp, template
+
+    class TemporaryDirectory(object):
+        """Create and return a temporary directory.  This has the same
+        behavior as mkdtemp but can be used as a context manager.  For
+        example:
+
+            with TemporaryDirectory() as tmpdir:
+                ...
+
+        Upon exiting the context, the directory and everthing contained
+        in it are removed.
+        """
+
+        def __init__(self, suffix="", prefix=template, dir=None):
+            self.name = mkdtemp(suffix, prefix, dir)
+            self._closed = False
+
+        def __enter__(self):
+            return self.name
+
+        def cleanup(self, _warn=False):
+            if self.name and not self._closed:
+                try:
+                    self._rmtree(self.name)
+                except (TypeError, AttributeError) as ex:
+                    # Issue #10188: Emit a warning on stderr
+                    # if the directory could not be cleaned
+                    # up due to missing globals
+                    if "None" not in str(ex):
+                        raise
+                    print("ERROR: {!r} while cleaning up {!r}".format(ex, self,),
+                          file=_sys.stderr)
+                    return
+                self._closed = True
+                if _warn:
+                    self._warn("Implicitly cleaning up {!r}".format(self),
+                               Warning)
+
+        def __exit__(self, exc, value, tb):
+            self.cleanup()
+
+        def __del__(self):
+            # Issue a ResourceWarning if implicit cleanup needed
+            self.cleanup(_warn=True)
+
+
+        # XXX (ncoghlan): The following code attempts to make
+        # this class tolerant of the module nulling out process
+        # that happens during CPython interpreter shutdown
+        # Alas, it doesn't actually manage it. See issue #10188
+        _listdir = staticmethod(_os.listdir)
+        _path_join = staticmethod(_os.path.join)
+        _isdir = staticmethod(_os.path.isdir)
+        _remove = staticmethod(_os.remove)
+        _rmdir = staticmethod(_os.rmdir)
+        _os_error = _os.error
+        _warn = _warnings.warn
+
+        def _rmtree(self, path):
+            # Essentially a stripped down version of shutil.rmtree.  We can't
+            # use globals because they may be None'ed out at shutdown.
+            for name in self._listdir(path):
+                fullname = self._path_join(path, name)
+                try:
+                    isdir = self._isdir(fullname)
+                except self._os_error:
+                    isdir = False
+                if isdir:
+                    self._rmtree(fullname)
+                else:
+                    try:
+                        self._remove(fullname)
+                    except self._os_error:
+                        pass
+            try:
+                self._rmdir(path)
+            except self._os_error:
+                pass
+
+# extra temp-dir-related context managers
+
+class NamedFileInTemporaryDirectory(object):
+
+    def __init__(self, filename, mode='w+b', bufsize=-1, **kwds):
+        """
+        Open a file named `filename` in a temporary directory.
+
+        This context manager is preferred over `NamedTemporaryFile` in
+        stdlib `tempfile` when one needs to reopen the file.
+
+        Arguments `mode` and `bufsize` are passed to `open`.
+        Rest of the arguments are passed to `TemporaryDirectory`.
+
+        """
+        self._tmpdir = TemporaryDirectory(**kwds)
+        path = _os.path.join(self._tmpdir.name, filename)
+        self.file = open(path, mode, bufsize)
+
+    def cleanup(self):
+        self.file.close()
+        self._tmpdir.cleanup()
+
+    __del__ = cleanup
+
+    def __enter__(self):
+        return self.file
+
+    def __exit__(self, type, value, traceback):
+        self.cleanup()
+
+
+class TemporaryWorkingDirectory(TemporaryDirectory):
+    """
+    Creates a temporary directory and sets the cwd to that directory.
+    Automatically reverts to previous cwd upon cleanup.
+    Usage example:
+
+        with TemporaryWorkingDirectory() as tmpdir:
+            ...
+    """
+    def __enter__(self):
+        self.old_wd = _os.getcwd()
+        _os.chdir(self.name)
+        return super(TemporaryWorkingDirectory, self).__enter__()
+
+    def __exit__(self, exc, value, tb):
+        _os.chdir(self.old_wd)
+        return super(TemporaryWorkingDirectory, self).__exit__(exc, value, tb)
+

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -27,7 +27,7 @@ from traitlets.config.application import (
     Application
 )
 
-from ipython_genutils.tempdir import TemporaryDirectory
+from .tempdir import TemporaryDirectory
 from traitlets.traitlets import (
     Bool, Unicode, Integer, List, Dict
 )

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -21,7 +21,7 @@ from traitlets.traitlets import (
 )
 
 from traitlets.config.loader import Config
-from ipython_genutils.py3compat import PY3
+from traitlets.utils.py3compat import PY3
 
 from ...tests._warnings import expected_warnings
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -956,9 +956,9 @@ class TestType(TestCase):
     def test_str_klass(self):
 
         class A(HasTraits):
-            klass = Type('ipython_genutils.ipstruct.Struct')
+            klass = Type('traitlets.tests.utils.Struct')
 
-        from ipython_genutils.ipstruct import Struct
+        from traitlets.tests.utils import Struct
         a = A()
         a.klass = Struct
         self.assertEqual(a.klass, Struct)
@@ -970,8 +970,8 @@ class TestType(TestCase):
         class A(HasTraits):
             klass = Type()
 
-        a = A(klass='ipython_genutils.ipstruct.Struct')
-        from ipython_genutils.ipstruct import Struct
+        a = A(klass='traitlets.tests.utils.Struct')
+        from traitlets.tests.utils import Struct
         self.assertEqual(a.klass, Struct)
 
 class TestInstance(TestCase):
@@ -1194,7 +1194,7 @@ class UnionTrait(HasTraits):
 
 class UnionTraitTest(TraitTestBase):
 
-    obj = UnionTrait(value='ipython_genutils.ipstruct.Struct')
+    obj = UnionTrait(value='traitlets.tests.utils.Struct')
     _good_values = [int, float, True]
     _bad_values = [[], (0,), 1j]
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -24,8 +24,8 @@ from traitlets import (
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
     observe_compat, BaseDescriptor, HasDescriptors,
 )
-from ipython_genutils import py3compat
 from ipython_genutils.testing.decorators import skipif
+from traitlets.utils import py3compat
 
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -24,8 +24,84 @@ from traitlets import (
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
     observe_compat, BaseDescriptor, HasDescriptors,
 )
-from ipython_genutils.testing.decorators import skipif
 from traitlets.utils import py3compat
+
+
+
+# Inspired by numpy's skipif, but uses the full apply_wrapper utility to
+# preserve function metadata better and allows the skip condition to be a
+# callable.
+def skipif(skip_condition, msg=None):
+    ''' Make function raise SkipTest exception if skip_condition is true
+
+    Parameters
+    ----------
+
+    skip_condition : bool or callable
+      Flag to determine whether to skip test. If the condition is a
+      callable, it is used at runtime to dynamically make the decision. This
+      is useful for tests that may require costly imports, to delay the cost
+      until the test suite is actually executed.
+    msg : string
+      Message to give on raising a SkipTest exception.
+
+    Returns
+    -------
+    decorator : function
+      Decorator, which, when applied to a function, causes SkipTest
+      to be raised when the skip_condition was True, and the function
+      to be called normally otherwise.
+
+    Notes
+    -----
+    You will see from the code that we had to further decorate the
+    decorator with the nose.tools.make_decorator function in order to
+    transmit function name, and various other metadata.
+    '''
+
+    def skip_decorator(f):
+        # Local import to avoid a hard nose dependency and only incur the
+        # import time overhead at actual test-time.
+        import nose
+
+        # Allow for both boolean or callable skip conditions.
+        if callable(skip_condition):
+            skip_val = skip_condition
+        else:
+            skip_val = lambda : skip_condition
+
+        def get_msg(func,msg=None):
+            """Skip message with information about function being skipped."""
+            if msg is None: out = 'Test skipped due to test condition.'
+            else: out = msg
+            return "Skipping test: %s. %s" % (func.__name__,out)
+
+        # We need to define *two* skippers because Python doesn't allow both
+        # return with value and yield inside the same function.
+        def skipper_func(*args, **kwargs):
+            """Skipper for normal test functions."""
+            if skip_val():
+                raise nose.SkipTest(get_msg(f,msg))
+            else:
+                return f(*args, **kwargs)
+
+        def skipper_gen(*args, **kwargs):
+            """Skipper for test generators."""
+            if skip_val():
+                raise nose.SkipTest(get_msg(f,msg))
+            else:
+                for x in f(*args, **kwargs):
+                    yield x
+
+        # Choose the right skipper to use when building the actual generator.
+        if nose.util.isgenerator(f):
+            skipper = skipper_gen
+        else:
+            skipper = skipper_func
+
+        return nose.tools.make_decorator(f)(skipper)
+
+    return skip_decorator
 
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')

--- a/traitlets/tests/utils.py
+++ b/traitlets/tests/utils.py
@@ -38,3 +38,368 @@ def check_help_all_output(pkg, subcommand=None):
     nt.assert_in("Options", out)
     nt.assert_in("Class parameters", out)
     return out, err
+
+
+class Struct(dict):
+    """A dict subclass with attribute style access.
+
+    This dict subclass has a a few extra features:
+
+    * Attribute style access.
+    * Protection of class members (like keys, items) when using attribute
+      style access.
+    * The ability to restrict assignment to only existing keys.
+    * Intelligent merging.
+    * Overloaded operators.
+    """
+    _allownew = True
+    def __init__(self, *args, **kw):
+        """Initialize with a dictionary, another Struct, or data.
+
+        Parameters
+        ----------
+        args : dict, Struct
+            Initialize with one dict or Struct
+        kw : dict
+            Initialize with key, value pairs.
+
+        Examples
+        --------
+
+        >>> s = Struct(a=10,b=30)
+        >>> s.a
+        10
+        >>> s.b
+        30
+        >>> s2 = Struct(s,c=30)
+        >>> sorted(s2.keys())
+        ['a', 'b', 'c']
+        """
+        object.__setattr__(self, '_allownew', True)
+        dict.__init__(self, *args, **kw)
+
+    def __setitem__(self, key, value):
+        """Set an item with check for allownew.
+
+        Examples
+        --------
+
+        >>> s = Struct()
+        >>> s['a'] = 10
+        >>> s.allow_new_attr(False)
+        >>> s['a'] = 10
+        >>> s['a']
+        10
+        >>> try:
+        ...     s['b'] = 20
+        ... except KeyError:
+        ...     print('this is not allowed')
+        ...
+        this is not allowed
+        """
+        if not self._allownew and key not in self:
+            raise KeyError(
+                "can't create new attribute %s when allow_new_attr(False)" % key)
+        dict.__setitem__(self, key, value)
+
+    def __setattr__(self, key, value):
+        """Set an attr with protection of class members.
+
+        This calls :meth:`self.__setitem__` but convert :exc:`KeyError` to
+        :exc:`AttributeError`.
+
+        Examples
+        --------
+
+        >>> s = Struct()
+        >>> s.a = 10
+        >>> s.a
+        10
+        >>> try:
+        ...     s.get = 10
+        ... except AttributeError:
+        ...     print("you can't set a class member")
+        ...
+        you can't set a class member
+        """
+        # If key is an str it might be a class member or instance var
+        if isinstance(key, str):
+            # I can't simply call hasattr here because it calls getattr, which
+            # calls self.__getattr__, which returns True for keys in
+            # self._data.  But I only want keys in the class and in
+            # self.__dict__
+            if key in self.__dict__ or hasattr(Struct, key):
+                raise AttributeError(
+                    'attr %s is a protected member of class Struct.' % key
+                )
+        try:
+            self.__setitem__(key, value)
+        except KeyError as e:
+            raise AttributeError(e)
+
+    def __getattr__(self, key):
+        """Get an attr by calling :meth:`dict.__getitem__`.
+
+        Like :meth:`__setattr__`, this method converts :exc:`KeyError` to
+        :exc:`AttributeError`.
+
+        Examples
+        --------
+
+        >>> s = Struct(a=10)
+        >>> s.a
+        10
+        >>> type(s.get)
+        <... 'builtin_function_or_method'>
+        >>> try:
+        ...     s.b
+        ... except AttributeError:
+        ...     print("I don't have that key")
+        ...
+        I don't have that key
+        """
+        try:
+            result = self[key]
+        except KeyError:
+            raise AttributeError(key)
+        else:
+            return result
+
+    def __iadd__(self, other):
+        """s += s2 is a shorthand for s.merge(s2).
+
+        Examples
+        --------
+
+        >>> s = Struct(a=10,b=30)
+        >>> s2 = Struct(a=20,c=40)
+        >>> s += s2
+        >>> sorted(s.keys())
+        ['a', 'b', 'c']
+        """
+        self.merge(other)
+        return self
+
+    def __add__(self,other):
+        """s + s2 -> New Struct made from s.merge(s2).
+
+        Examples
+        --------
+
+        >>> s1 = Struct(a=10,b=30)
+        >>> s2 = Struct(a=20,c=40)
+        >>> s = s1 + s2
+        >>> sorted(s.keys())
+        ['a', 'b', 'c']
+        """
+        sout = self.copy()
+        sout.merge(other)
+        return sout
+
+    def __sub__(self,other):
+        """s1 - s2 -> remove keys in s2 from s1.
+
+        Examples
+        --------
+
+        >>> s1 = Struct(a=10,b=30)
+        >>> s2 = Struct(a=40)
+        >>> s = s1 - s2
+        >>> s
+        {'b': 30}
+        """
+        sout = self.copy()
+        sout -= other
+        return sout
+
+    def __isub__(self,other):
+        """Inplace remove keys from self that are in other.
+
+        Examples
+        --------
+
+        >>> s1 = Struct(a=10,b=30)
+        >>> s2 = Struct(a=40)
+        >>> s1 -= s2
+        >>> s1
+        {'b': 30}
+        """
+        for k in other.keys():
+            if k in self:
+                del self[k]
+        return self
+
+    def __dict_invert(self, data):
+        """Helper function for merge.
+
+        Takes a dictionary whose values are lists and returns a dict with
+        the elements of each list as keys and the original keys as values.
+        """
+        outdict = {}
+        for k,lst in data.items():
+            if isinstance(lst, str):
+                lst = lst.split()
+            for entry in lst:
+                outdict[entry] = k
+        return outdict
+
+    def dict(self):
+        return self
+
+    def copy(self):
+        """Return a copy as a Struct.
+
+        Examples
+        --------
+
+        >>> s = Struct(a=10,b=30)
+        >>> s2 = s.copy()
+        >>> type(s2) is Struct
+        True
+        """
+        return Struct(dict.copy(self))
+
+    def hasattr(self, key):
+        """hasattr function available as a method.
+
+        Implemented like has_key.
+
+        Examples
+        --------
+
+        >>> s = Struct(a=10)
+        >>> s.hasattr('a')
+        True
+        >>> s.hasattr('b')
+        False
+        >>> s.hasattr('get')
+        False
+        """
+        return key in self
+
+    def allow_new_attr(self, allow = True):
+        """Set whether new attributes can be created in this Struct.
+
+        This can be used to catch typos by verifying that the attribute user
+        tries to change already exists in this Struct.
+        """
+        object.__setattr__(self, '_allownew', allow)
+
+    def merge(self, __loc_data__=None, __conflict_solve=None, **kw):
+        """Merge two Structs with customizable conflict resolution.
+
+        This is similar to :meth:`update`, but much more flexible. First, a
+        dict is made from data+key=value pairs. When merging this dict with
+        the Struct S, the optional dictionary 'conflict' is used to decide
+        what to do.
+
+        If conflict is not given, the default behavior is to preserve any keys
+        with their current value (the opposite of the :meth:`update` method's
+        behavior).
+
+        Parameters
+        ----------
+        __loc_data : dict, Struct
+            The data to merge into self
+        __conflict_solve : dict
+            The conflict policy dict.  The keys are binary functions used to
+            resolve the conflict and the values are lists of strings naming
+            the keys the conflict resolution function applies to.  Instead of
+            a list of strings a space separated string can be used, like
+            'a b c'.
+        kw : dict
+            Additional key, value pairs to merge in
+
+        Notes
+        -----
+
+        The `__conflict_solve` dict is a dictionary of binary functions which will be used to
+        solve key conflicts.  Here is an example::
+
+            __conflict_solve = dict(
+                func1=['a','b','c'],
+                func2=['d','e']
+            )
+
+        In this case, the function :func:`func1` will be used to resolve
+        keys 'a', 'b' and 'c' and the function :func:`func2` will be used for
+        keys 'd' and 'e'.  This could also be written as::
+
+            __conflict_solve = dict(func1='a b c',func2='d e')
+
+        These functions will be called for each key they apply to with the
+        form::
+
+            func1(self['a'], other['a'])
+
+        The return value is used as the final merged value.
+
+        As a convenience, merge() provides five (the most commonly needed)
+        pre-defined policies: preserve, update, add, add_flip and add_s. The
+        easiest explanation is their implementation::
+
+            preserve = lambda old,new: old
+            update   = lambda old,new: new
+            add      = lambda old,new: old + new
+            add_flip = lambda old,new: new + old  # note change of order!
+            add_s    = lambda old,new: old + ' ' + new  # only for str!
+
+        You can use those four words (as strings) as keys instead
+        of defining them as functions, and the merge method will substitute
+        the appropriate functions for you.
+
+        For more complicated conflict resolution policies, you still need to
+        construct your own functions.
+
+        Examples
+        --------
+
+        This show the default policy:
+
+        >>> s = Struct(a=10,b=30)
+        >>> s2 = Struct(a=20,c=40)
+        >>> s.merge(s2)
+        >>> sorted(s.items())
+        [('a', 10), ('b', 30), ('c', 40)]
+
+        Now, show how to specify a conflict dict:
+
+        >>> s = Struct(a=10,b=30)
+        >>> s2 = Struct(a=20,b=40)
+        >>> conflict = {'update':'a','add':'b'}
+        >>> s.merge(s2,conflict)
+        >>> sorted(s.items())
+        [('a', 20), ('b', 70)]
+        """
+
+        data_dict = dict(__loc_data__,**kw)
+
+        # policies for conflict resolution: two argument functions which return
+        # the value that will go in the new struct
+        preserve = lambda old,new: old
+        update   = lambda old,new: new
+        add      = lambda old,new: old + new
+        add_flip = lambda old,new: new + old  # note change of order!
+        add_s    = lambda old,new: old + ' ' + new
+
+        # default policy is to keep current keys when there's a conflict
+        conflict_solve = dict.fromkeys(self, preserve)
+
+        # the conflict_solve dictionary is given by the user 'inverted': we
+        # need a name-function mapping, it comes as a function -> names
+        # dict. Make a local copy (b/c we'll make changes), replace user
+        # strings for the three builtin policies and invert it.
+        if __conflict_solve:
+            inv_conflict_solve_user = __conflict_solve.copy()
+            for name, func in [('preserve',preserve), ('update',update),
+                               ('add',add), ('add_flip',add_flip),
+                               ('add_s',add_s)]:
+                if name in inv_conflict_solve_user.keys():
+                    inv_conflict_solve_user[func] = inv_conflict_solve_user[name]
+                    del inv_conflict_solve_user[name]
+            conflict_solve.update(self.__dict_invert(inv_conflict_solve_user))
+        for key in data_dict:
+            if key not in self:
+                self[key] = data_dict[key]
+            else:
+                self[key] = conflict_solve[key](self[key],data_dict[key])

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -52,8 +52,8 @@ except:
     ClassTypes = (type,)
 from warnings import warn, warn_explicit
 
-from ipython_genutils import py3compat
-from ipython_genutils.py3compat import iteritems, string_types
+from .utils import py3compat
+from .utils.py3compat import iteritems, string_types
 
 from .utils.getargspec import getargspec
 from .utils.importstring import import_item

--- a/traitlets/utils/encoding.py
+++ b/traitlets/utils/encoding.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+"""
+Utilities for dealing with text encodings
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2012  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+import sys
+import locale
+import warnings
+
+# to deal with the possibility of sys.std* not being a stream at all
+def get_stream_enc(stream, default=None):
+    """Return the given stream's encoding or a default.
+
+    There are cases where ``sys.std*`` might not actually be a stream, so
+    check for the encoding attribute prior to returning it, and return
+    a default if it doesn't exist or evaluates as False. ``default``
+    is None if not provided.
+    """
+    if not hasattr(stream, 'encoding') or not stream.encoding:
+        return default
+    else:
+        return stream.encoding
+
+# Less conservative replacement for sys.getdefaultencoding, that will try
+# to match the environment.
+# Defined here as central function, so if we find better choices, we
+# won't need to make changes all over IPython.
+def getdefaultencoding(prefer_stream=True):
+    """Return IPython's guess for the default encoding for bytes as text.
+    
+    If prefer_stream is True (default), asks for stdin.encoding first,
+    to match the calling Terminal, but that is often None for subprocesses.
+    
+    Then fall back on locale.getpreferredencoding(),
+    which should be a sensible platform default (that respects LANG environment),
+    and finally to sys.getdefaultencoding() which is the most conservative option,
+    and usually ASCII on Python 2 or UTF8 on Python 3.
+    """
+    enc = None
+    if prefer_stream:
+        enc = get_stream_enc(sys.stdin)
+    if not enc or enc=='ascii':
+        try:
+            # There are reports of getpreferredencoding raising errors
+            # in some cases, which may well be fixed, but let's be conservative here.
+            enc = locale.getpreferredencoding()
+        except Exception:
+            pass
+    enc = enc or sys.getdefaultencoding()
+    # On windows `cp0` can be returned to indicate that there is no code page.
+    # Since cp0 is an invalid encoding return instead cp1252 which is the
+    # Western European default.
+    if enc == 'cp0':
+        warnings.warn(
+            "Invalid code page cp0 detected - using cp1252 instead."
+            "If cp1252 is incorrect please ensure a valid code page "
+            "is defined for the process.", RuntimeWarning)
+        return 'cp1252'
+    return enc
+
+DEFAULT_ENCODING = getdefaultencoding()

--- a/traitlets/utils/getargspec.py
+++ b/traitlets/utils/getargspec.py
@@ -10,7 +10,7 @@
 """
 
 import inspect
-from ipython_genutils.py3compat import PY3
+from .py3compat import PY3
 
 # Unmodified from sphinx below this line
 

--- a/traitlets/utils/importstring.py
+++ b/traitlets/utils/importstring.py
@@ -5,7 +5,7 @@ A simple utility to import something by its string name.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipython_genutils.py3compat import cast_bytes_py2, string_types
+from .py3compat import cast_bytes_py2, string_types
 
 def import_item(name):
     """Import and return ``bar`` given the string ``foo.bar``.

--- a/traitlets/utils/py3compat.py
+++ b/traitlets/utils/py3compat.py
@@ -1,0 +1,331 @@
+# coding: utf-8
+"""Compatibility tricks for Python 3. Mainly to do with unicode."""
+import functools
+import os
+import sys
+import re
+import shutil
+import types
+
+from .encoding import DEFAULT_ENCODING
+
+def no_code(x, encoding=None):
+    return x
+
+def decode(s, encoding=None):
+    encoding = encoding or DEFAULT_ENCODING
+    return s.decode(encoding, "replace")
+
+def encode(u, encoding=None):
+    encoding = encoding or DEFAULT_ENCODING
+    return u.encode(encoding, "replace")
+
+
+def cast_unicode(s, encoding=None):
+    if isinstance(s, bytes):
+        return decode(s, encoding)
+    return s
+
+def cast_bytes(s, encoding=None):
+    if not isinstance(s, bytes):
+        return encode(s, encoding)
+    return s
+
+def buffer_to_bytes(buf):
+    """Cast a buffer or memoryview object to bytes"""
+    if isinstance(buf, memoryview):
+        return buf.tobytes()
+    if not isinstance(buf, bytes):
+        return bytes(buf)
+    return buf
+
+def _modify_str_or_docstring(str_change_func):
+    @functools.wraps(str_change_func)
+    def wrapper(func_or_str):
+        if isinstance(func_or_str, string_types):
+            func = None
+            doc = func_or_str
+        else:
+            func = func_or_str
+            doc = func.__doc__
+        
+        doc = str_change_func(doc)
+        
+        if func:
+            func.__doc__ = doc
+            return func
+        return doc
+    return wrapper
+
+def safe_unicode(e):
+    """unicode(e) with various fallbacks. Used for exceptions, which may not be
+    safe to call unicode() on.
+    """
+    try:
+        return unicode_type(e)
+    except UnicodeError:
+        pass
+
+    try:
+        return str_to_unicode(str(e))
+    except UnicodeError:
+        pass
+
+    try:
+        return str_to_unicode(repr(e))
+    except UnicodeError:
+        pass
+
+    return u'Unrecoverably corrupt evalue'
+
+# shutil.which from Python 3.4
+def _shutil_which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    
+    This is a backport of shutil.which from Python 3.4
+    """
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode)
+                and not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to the
+    # current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
+        return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if not os.curdir in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if not normdir in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
+
+if sys.version_info[0] >= 3:
+    PY3 = True
+    
+    # keep reference to builtin_mod because the kernel overrides that value
+    # to forward requests to a frontend.
+    def input(prompt=''):
+        return builtin_mod.input(prompt)
+    
+    builtin_mod_name = "builtins"
+    import builtins as builtin_mod
+    
+    str_to_unicode = no_code
+    unicode_to_str = no_code
+    str_to_bytes = encode
+    bytes_to_str = decode
+    cast_bytes_py2 = no_code
+    cast_unicode_py2 = no_code
+    buffer_to_bytes_py2 = no_code
+    
+    string_types = (str,)
+    unicode_type = str
+    
+    which = shutil.which
+    
+    def isidentifier(s, dotted=False):
+        if dotted:
+            return all(isidentifier(a) for a in s.split("."))
+        return s.isidentifier()
+
+    xrange = range
+    def iteritems(d): return iter(d.items())
+    def itervalues(d): return iter(d.values())
+    getcwd = os.getcwd
+    
+    MethodType = types.MethodType
+
+    def execfile(fname, glob, loc=None, compiler=None):
+        loc = loc if (loc is not None) else glob
+        with open(fname, 'rb') as f:
+            compiler = compiler or compile
+            exec(compiler(f.read(), fname, 'exec'), glob, loc)
+    
+    # Refactor print statements in doctests.
+    _print_statement_re = re.compile(r"\bprint (?P<expr>.*)$", re.MULTILINE)
+    def _print_statement_sub(match):
+        expr = match.groups('expr')
+        return "print(%s)" % expr
+    
+    @_modify_str_or_docstring
+    def doctest_refactor_print(doc):
+        """Refactor 'print x' statements in a doctest to print(x) style. 2to3
+        unfortunately doesn't pick up on our doctests.
+        
+        Can accept a string or a function, so it can be used as a decorator."""
+        return _print_statement_re.sub(_print_statement_sub, doc)
+    
+    # Abstract u'abc' syntax:
+    @_modify_str_or_docstring
+    def u_format(s):
+        """"{u}'abc'" --> "'abc'" (Python 3)
+        
+        Accepts a string or a function, so it can be used as a decorator."""
+        return s.format(u='')
+    
+    def get_closure(f):
+        """Get a function's closure attribute"""
+        return f.__closure__
+
+else:
+    PY3 = False
+    
+    # keep reference to builtin_mod because the kernel overrides that value
+    # to forward requests to a frontend.
+    def input(prompt=''):
+        return builtin_mod.raw_input(prompt)
+    
+    builtin_mod_name = "__builtin__"
+    import __builtin__ as builtin_mod
+    
+    str_to_unicode = decode
+    unicode_to_str = encode
+    str_to_bytes = no_code
+    bytes_to_str = no_code
+    cast_bytes_py2 = cast_bytes
+    cast_unicode_py2 = cast_unicode
+    buffer_to_bytes_py2 = buffer_to_bytes
+    
+    string_types = (str, unicode)
+    unicode_type = unicode
+    
+    import re
+    _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
+    def isidentifier(s, dotted=False):
+        if dotted:
+            return all(isidentifier(a) for a in s.split("."))
+        return bool(_name_re.match(s))
+    
+    xrange = xrange
+    def iteritems(d): return d.iteritems()
+    def itervalues(d): return d.itervalues()
+    getcwd = os.getcwdu
+
+    def MethodType(func, instance):
+        return types.MethodType(func, instance, type(instance))
+    
+    def doctest_refactor_print(func_or_str):
+        return func_or_str
+
+    def get_closure(f):
+        """Get a function's closure attribute"""
+        return f.func_closure
+    
+    which = _shutil_which
+
+    # Abstract u'abc' syntax:
+    @_modify_str_or_docstring
+    def u_format(s):
+        """"{u}'abc'" --> "u'abc'" (Python 2)
+        
+        Accepts a string or a function, so it can be used as a decorator."""
+        return s.format(u='u')
+
+    if sys.platform == 'win32':
+        def execfile(fname, glob=None, loc=None, compiler=None):
+            loc = loc if (loc is not None) else glob
+            scripttext = builtin_mod.open(fname).read()+ '\n'
+            # compile converts unicode filename to str assuming
+            # ascii. Let's do the conversion before calling compile
+            if isinstance(fname, unicode):
+                filename = unicode_to_str(fname)
+            else:
+                filename = fname
+            compiler = compiler or compile
+            exec(compiler(scripttext, filename, 'exec'), glob, loc)
+
+    else:
+        def execfile(fname, glob=None, loc=None, compiler=None):
+            if isinstance(fname, unicode):
+                filename = fname.encode(sys.getfilesystemencoding())
+            else:
+                filename = fname
+            where = [ns for ns in [glob, loc] if ns is not None]
+            if compiler is None:
+                builtin_mod.execfile(filename, *where)
+            else:
+                scripttext = builtin_mod.open(fname).read().rstrip() + '\n'
+                exec(compiler(scripttext, filename, 'exec'), glob, loc)
+
+
+def annotate(**kwargs):
+    """Python 3 compatible function annotation for Python 2."""
+    if not kwargs:
+        raise ValueError('annotations must be provided as keyword arguments')
+    def dec(f):
+        if hasattr(f, '__annotations__'):
+            for k, v in kwargs.items():
+                f.__annotations__[k] = v
+        else:
+            f.__annotations__ = kwargs
+        return f
+    return dec
+
+
+# Parts below taken from six:
+# Copyright (c) 2010-2013 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    return meta("_NewBase", bases, {})


### PR DESCRIPTION
Hi,

**ipython_genutils** is marked for deprecation, you might as well incorporate only the functionalities needed and remove the import.  Traitlets is much better as a stand-alone library anyway.
The 9 commits incrementally add external utilities from ipython_genutils into the traitlets package (every commits pass the nosetest tests on my machine). 
Note : I've copied py3compat in its entirety, but only a portion is useful. You might need to trim it down, or abstracting away using six.


Cheers,

lucasg

### Results from Travis 

https://travis-ci.org/lucasg/traitlets/builds/113952990

### Results from tests (on my machine)
```
`(ipython_env) [lucasg traitlets]$ python --version
Python 3.5.1

(ipython_env) [lucas traitlets]$ pip freeze
coverage==4.0.3
coveralls==1.1
decorator==4.0.9
docopt==0.6.2
ipython==5.0.0.dev0
ipython-genutils==0.2.0.dev0
nose==1.3.7
path.py==8.1.2
pexpect==4.0.1
pickleshare==0.6
prompt-toolkit==0.59
ptyprocess==0.5.1
Pygments==2.1.3
requests==2.9.1
simplegeneric==0.8.1
six==1.10.0
traitlets==4.2.0.dev0
wcwidth==0.1.6
wheel==0.29.0

(ipython_env) [lucas traitlets]$ python -c "import IPython; print(IPython.sys_info())"
{'commit_hash': 'eb2f497',
 'commit_source': 'installation',
 'default_encoding': 'UTF-8',
 'ipython_path': REDACTED,
 'ipython_version': '5.0.0.dev',
 'os_name': 'posix',
 'platform': 'Linux-4.1.18-2-MANJARO-x86_64-with-glibc2.3.4',
 'sys_executable': REDACTED,
 'sys_platform': 'linux',
 'sys_version': '3.5.1 (default, Dec  7 2015, 12:58:09) \n[GCC 5.2.0]'}




(ipython_env) [lucasg traitlets]$ nosetests --exe --with-coverage --cover-package traitlets traitlets
...................................................................................................................................................................................S................S............................................................................................
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
traitlets.py                           3      0   100%   
traitlets/_version.py                  2      0   100%   
traitlets/config.py                    3      0   100%   
traitlets/config/application.py      326    131    60%   54, 77-82, 103, 205, 209, 229-233, 277-278, 282-304, 308-317, 320-331, 335-350, 357-378, 391-393, 401-406, 410, 415-425, 480, 484-487, 499-500, 503-504, 523, 536-542, 564, 579-581, 589-591, 620-627, 635-638
traitlets/config/configurable.py     213     17    92%   51, 54, 59, 77, 329-330, 337, 404, 408, 434-435, 465-471, 513
traitlets/config/loader.py           438     55    87%   54-55, 138-147, 180, 248, 289, 297, 356-357, 432, 435, 531-532, 538, 541-544, 603, 714, 751, 753-757, 827, 830, 837, 861, 863, 868, 878-879, 881, 897, 922-933
traitlets/log.py                      10      1    90%   21
traitlets/traitlets.py              1130    157    86%   50, 110-112, 144, 186, 188, 202-203, 214, 217, 219, 312, 402, 407, 423-424, 445-447, 452-456, 510-512, 540-542, 555, 582, 595, 653, 677, 908, 924-925, 991-992, 1039, 1067, 1134-1135, 1144, 1147-1148, 1241-1247, 1274, 1377-1378, 1392-1396, 1422, 1431, 1476, 1501, 1574, 1576, 1591, 1715-1718, 1748, 1764-1767, 1773-1816, 1849-1852, 1872-1875, 1896-1899, 1912-1916, 1924-1927, 1942-1949, 1984-1987, 1996, 2002, 2006-2009, 2015-2016, 2019-2027, 2081, 2089, 2103, 2291, 2360, 2363-2366, 2375, 2389, 2397
traitlets/utils.py                     0      0   100%   
traitlets/utils/encoding.py           23      7    70%   30, 53-58, 64-68
traitlets/utils/getargspec.py         64     52    19%   25-45, 49, 51, 55-86
traitlets/utils/importstring.py       16      0   100%   
traitlets/utils/py3compat.py         190    128    33%   20-21, 30-32, 36-40, 45-57, 64-79, 96-143, 151, 190-191, 199, 207, 211-291, 296-305
traitlets/utils/sentinel.py            8      1    88%   16
----------------------------------------------------------------
TOTAL                               2426    549    77%   
----------------------------------------------------------------------
Ran 289 tests in 0.307s

OK (SKIP=2)

```