### PR TITLE
faster `set_trait`

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1389,11 +1389,12 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
 
     def set_trait(self, name, value):
         """Forcibly sets trait attribute, including read-only attributes."""
+        cls = self.__class__
         if not self.has_trait(name):
-            raise TraitError("Class %s does not have a trait named %s" %
-                                (self.__class__.__name__, name))
+            raise TraitError("Class %s does not have a trait"
+                             "named %s" % (cls.__name__, name))
         else:
-            self.traits()[name].set(self, value)
+            getattr(cls, name).set(self, value)
 
 #-----------------------------------------------------------------------------
 # Actual TraitTypes implementations/subclasses


### PR DESCRIPTION
`set_trait` makes an unnecessary call to `HasTraits.traits` - this is replaced with a call to `getattr`.