### PR TITLE
Add make_dynamic_default method to Union trait type

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -460,6 +460,7 @@ class TraitType(BaseDescriptor):
 
         This looks for:
 
+        * default generators registered with the @default descriptor.
         * obj._{name}_default() on the class with the traitlet, or a subclass
           that obj belongs to.
         * trait.make_dynamic_default, which is defined by Instance
@@ -1717,6 +1718,14 @@ class Union(TraitType):
             return Union(self.trait_types + other.trait_types)
         else:
             return Union(self.trait_types + [other])
+
+    def make_dynamic_default(self):
+        for trait_type in self.trait_types:
+            if trait_type.default_value != Undefined:
+                return trait_type.default_value
+            elif hasattr(trait_type, 'make_dynamic_default'):
+                return trait_type.make_dynamic_default()
+
 
 #-----------------------------------------------------------------------------
 # Basic TraitTypes implementations/subclasses


### PR DESCRIPTION
This is a bug fix for the `Union` trait type.

Before, this code would generate an error:
```python
class Foo(HasTraits):
    bar = Dict() | List()

foo = Foo()
print(foo.bar)
```

The problem is that `bar`has no correct default value, since the the default value for `Dict` is generated with `make_dynamic_default`. Hence union traits must have a `make_dynamic_default` function calling the same thing or checking for presence of an explicit default value in the underlying trait types.