### PR TITLE
demote super().__init__ argument warning to deprecation

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -964,7 +964,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
                     arg_s=arg_s, classname=self.__class__.__name__,
                     error=e,
                 ),
-                RuntimeWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
 


### PR DESCRIPTION
because stable IPython (4.1) shows *a lot* of these (on Python 3), which is probably annoying. It is deprecated behavior, after all.