### PR TITLE
Switch over nose2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.3
 sudo: false
 install:
+    - pip install . nose2
     - pip install . cov-core
 script:
     - nose2 --with-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
     - 3.3
 sudo: false
 install:
-    - pip install . coveralls
+    - pip install . cov-core
 script:
-    - nosetests --with-coverage --cover-package traitlets traitlets
+    - nose2 --with-coverage
 after_success:
     - coveralls

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -18,8 +18,7 @@ except ImportError:
 
 pjoin = os.path.join
 
-from nose import SkipTest
-import nose.tools as nt
+from nose2.compat import unittest
 
 from traitlets.config.configurable import Configurable
 from traitlets.config.loader import Config
@@ -89,7 +88,7 @@ class TestApplication(TestCase):
         app.log_format = "%(message)s"
         app.log_datefmt = "%Y-%m-%d %H:%M"
         app.log.info("hello")
-        nt.assert_in("hello", stream.getvalue())
+        assert "hello" in stream.getvalue()
 
     def test_basic(self):
         app = MyApp()
@@ -154,8 +153,8 @@ class TestApplication(TestCase):
         cfg.MyApp.warn_typo = "WOOOO"
         app.config = cfg
 
-        nt.assert_in("warn_typo", stream.getvalue())
-        nt.assert_in("warn_tpyo", stream.getvalue())
+        self.assertIn("warn_typo", stream.getvalue())
+        self.assertIn("warn_tpyo", stream.getvalue())
         
     
     def test_flatten_flags(self):
@@ -226,15 +225,15 @@ class TestApplication(TestCase):
                 self.assertEqual(app.bar.b, 1)
     
     def test_log_bad_config(self):
-        if not hasattr(nt, 'assert_logs'):
-            raise SkipTest("Test requires nose.tests.assert_logs")
+        if not hasattr(self, 'assertLogs'):
+            raise unittest.SkipTest("Test requires unittest.TestCase.assertLogs")
         app = MyApp()
         app.log = logging.getLogger()
         name = 'config.py'
         with TemporaryDirectory() as td:
             with open(pjoin(td, name), 'w') as f:
                 f.write("syntax error()")
-            with nt.assert_logs(app.log, logging.ERROR) as captured:
+            with self.assertLogs(app.log, logging.ERROR) as captured:
                 app.load_config_file(name, path=[td])
         output = '\n'.join(captured.output)
         self.assertIn('SyntaxError', output)
@@ -264,9 +263,9 @@ class DeprecatedApp(Application):
 
 def test_deprecated_notifier():
     app = DeprecatedApp()
-    nt.assert_false(app.override_called)
-    nt.assert_false(app.parent_called)
+    assert not app.override_called
+    assert not app.parent_called
     app.config = Config({'A': {'b': 'c'}})
-    nt.assert_true(app.override_called)
-    nt.assert_true(app.parent_called)
+    assert app.override_called
+    assert app.parent_called
 

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -437,7 +437,7 @@ class TestLogger(unittest.TestCase):
         logger = logging.getLogger('test_warn_match')
         cfg = Config({'A': {'bat': 5}})
         with self.assertLogs(logger, logging.WARNING) as captured:
-            a = A(config=cfg, log=logger)
+            a = TestLogger.A(config=cfg, log=logger)
         
         output = '\n'.join(captured.output)
         self.assertIn('Did you mean one of: `bar, baz`?', output)
@@ -445,7 +445,7 @@ class TestLogger(unittest.TestCase):
 
         cfg = Config({'A': {'fool': 5}})
         with self.assertLogs(logger, logging.WARNING) as captured:
-            a = A(config=cfg, log=logger)
+            a = TestLogger.A(config=cfg, log=logger)
         
         output = '\n'.join(captured.output)
         self.assertIn('Config option `fool` not recognized by `A`.', output)
@@ -453,7 +453,7 @@ class TestLogger(unittest.TestCase):
 
         cfg = Config({'A': {'totally_wrong': 5}})
         with self.assertLogs(logger, logging.WARNING) as captured:
-            a = A(config=cfg, log=logger)
+            a = TestLogger.A(config=cfg, log=logger)
 
         output = '\n'.join(captured.output)
         self.assertIn('Config option `totally_wrong` not recognized by `A`.', output)

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -7,8 +7,9 @@
 import logging
 from unittest import TestCase
 
-import nose.tools as nt
-from nose import SkipTest
+from nose2.compat import unittest
+from unittest import TestCase
+from nose2.tools.such import helper as testhelper
 
 from traitlets.config.configurable import (
     Configurable,
@@ -421,37 +422,40 @@ class TestConfigContainers(TestCase):
         self.assertEqual(d2.a, 5)
 
 
-def test_warn_match():
-    if not hasattr(nt, 'assert_logs'):
-        raise SkipTest("Test requires nose.tests.assert_logs")
+
+class TestLogger(unittest.TestCase):
+
     class A(LoggingConfigurable):
-        foo = Integer(config=True)
-        bar = Integer(config=True)
-        baz = Integer(config=True)
+            foo = Integer(config=True)
+            bar = Integer(config=True)
+            baz = Integer(config=True)
     
-    logger = logging.getLogger('test_warn_match')
-    
-    cfg = Config({'A': {'bat': 5}})
-    with nt.assert_logs(logger, logging.WARNING) as captured:
-        a = A(config=cfg, log=logger)
-    
-    output = '\n'.join(captured.output)
-    nt.assert_in('Did you mean one of: `bar, baz`?', output)
-    nt.assert_in('Config option `bat` not recognized by `A`.', output)
+    def test_warn_match(self):
+        if not hasattr(self, 'assertLogs'):
+            raise unittest.SkipTest("Test requires unittest.TestCase.assertLogs")
 
-    cfg = Config({'A': {'fool': 5}})
-    with nt.assert_logs(logger, logging.WARNING) as captured:
-        a = A(config=cfg, log=logger)
-    
-    output = '\n'.join(captured.output)
-    nt.assert_in('Config option `fool` not recognized by `A`.', output)
-    nt.assert_in('Did you mean `foo`?', output)
+        logger = logging.getLogger('test_warn_match')
+        cfg = Config({'A': {'bat': 5}})
+        with self.assertLogs(logger, logging.WARNING) as captured:
+            a = A(config=cfg, log=logger)
+        
+        output = '\n'.join(captured.output)
+        self.assertIn('Did you mean one of: `bar, baz`?', output)
+        self.assertIn('Config option `bat` not recognized by `A`.', output)
 
-    cfg = Config({'A': {'totally_wrong': 5}})
-    with nt.assert_logs(logger, logging.WARNING) as captured:
-        a = A(config=cfg, log=logger)
+        cfg = Config({'A': {'fool': 5}})
+        with self.assertLogs(logger, logging.WARNING) as captured:
+            a = A(config=cfg, log=logger)
+        
+        output = '\n'.join(captured.output)
+        self.assertIn('Config option `fool` not recognized by `A`.', output)
+        self.assertIn('Did you mean `foo`?', output)
 
-    output = '\n'.join(captured.output)
-    nt.assert_in('Config option `totally_wrong` not recognized by `A`.', output)
-    nt.assert_not_in('Did you mean', output)
+        cfg = Config({'A': {'totally_wrong': 5}})
+        with self.assertLogs(logger, logging.WARNING) as captured:
+            a = A(config=cfg, log=logger)
+
+        output = '\n'.join(captured.output)
+        self.assertIn('Config option `totally_wrong` not recognized by `A`.', output)
+        self.assertNotIn('Did you mean', output)
 

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -11,10 +11,9 @@ import pickle
 import sys
 
 from tempfile import mkstemp
-from unittest import TestCase
 
-from nose import SkipTest
-import nose.tools as nt
+from nose2.compat import unittest
+from unittest import TestCase
 
 
 
@@ -173,7 +172,7 @@ class TestFileCL(TestCase):
         f.close()
         # Unlink the file
         cl = JSONFileConfigLoader(fname, log=log)
-        with nt.assert_raises(ValueError):
+        with self.assertRaises(ValueError):
             cl.load_config()
 
 
@@ -276,7 +275,7 @@ class TestKeyValueCL(TestCase):
         try:
             barg = uarg.encode(sys.stdin.encoding)
         except (TypeError, UnicodeEncodeError):
-            raise SkipTest("sys.stdin.encoding can't handle 'é'")
+            raise unittest.SkipTest("sys.stdin.encoding can't handle 'é'")
         
         cl = self.klass(log=log)
         config = cl.load_config([barg])

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -10,11 +10,11 @@
 import pickle
 import re
 import sys
-from unittest import TestCase
 from ._warnings import expected_warnings
 
-import nose.tools as nt
-from nose import SkipTest
+from nose2.compat import unittest
+from unittest import TestCase
+from nose2.tools.such import helper as testhelper
 
 from traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
@@ -25,7 +25,6 @@ from traitlets import (
     observe_compat, BaseDescriptor, HasDescriptors,
 )
 from ipython_genutils import py3compat
-from ipython_genutils.testing.decorators import skipif
 
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')
@@ -1167,7 +1166,7 @@ class TestLong(TraitTestBase):
         _good_values.extend([long(10), long(-10), 10*sys.maxint, -10*sys.maxint])
         _bad_values.extend([[long(10)], (long(10),)])
 
-    @skipif(py3compat.PY3, "not relevant on py3")
+    @unittest.skipIf(py3compat.PY3, "not relevant on py3")
     def test_cast_small(self):
         """Long casts ints to long"""
         self.obj.value = 10
@@ -1184,11 +1183,11 @@ class TestInteger(TestLong):
     def coerce(self, n):
         return int(n)
 
-    @skipif(py3compat.PY3, "not relevant on py3")
+    @unittest.skipIf(py3compat.PY3, "not relevant on py3")
     def test_cast_small(self):
         """Integer casts small longs to int"""
         if py3compat.PY3:
-            raise SkipTest("not relevant on py3")
+            raise unittest.SkipTest("not relevant on py3")
 
         self.obj.value = long(100)
         self.assertEqual(type(self.obj.value), int)
@@ -1462,8 +1461,8 @@ def test_dict_assignment():
     c = DictTrait()
     c.value = d
     d['a'] = 5
-    nt.assert_equal(d, c.value)
-    nt.assert_true(c.value is d)
+    assert d == c.value  
+    assert c.value is d
 
 class ValidatedDictTrait(HasTraits):
 
@@ -1489,9 +1488,9 @@ def test_dict_default_value():
         d2 = Dict()
 
     foo = Foo()
-    nt.assert_equal(foo.d1, {})
-    nt.assert_equal(foo.d2, {})
-    nt.assert_is_not(foo.d1, foo.d2)
+    assert foo.d1 == {}
+    assert foo.d2 ==  {}
+    assert foo.d1 is not foo.d2
 
 
 class TestValidationHook(TestCase):
@@ -1757,15 +1756,15 @@ def test_pickle_hastraits():
     for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
         p = pickle.dumps(c, protocol)
         c2 = pickle.loads(p)
-        nt.assert_equal(c2.i, c.i)
-        nt.assert_equal(c2.j, c.j)
+        assert c2.i == c.i
+        assert c2.j == c.j
 
     c.i = 5
     for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
         p = pickle.dumps(c, protocol)
         c2 = pickle.loads(p)
-        nt.assert_equal(c2.i, c.i)
-        nt.assert_equal(c2.j, c.j)
+        assert c2.i == c.i
+        assert c2.j == c.j
 
 
 def test_hold_trait_notifications():
@@ -1788,29 +1787,29 @@ def test_hold_trait_notifications():
     with t.hold_trait_notifications():
         with t.hold_trait_notifications():
             t.a = 1
-            nt.assert_equal(t.a, 1)
-            nt.assert_equal(changes, [])
+            assert t.a == 1
+            assert changes == []
         t.a = 2
-        nt.assert_equal(t.a, 2)
+        assert t.a == 2
         with t.hold_trait_notifications():
             t.a = 3
-            nt.assert_equal(t.a, 3)
-            nt.assert_equal(changes, [])
+            assert t.a == 3
+            assert changes == []
             t.a = 4
-            nt.assert_equal(t.a, 4)
-            nt.assert_equal(changes, [])
+            assert t.a == 4
+            assert changes == []
         t.a = 4
-        nt.assert_equal(t.a, 4)
-        nt.assert_equal(changes, [])
+        assert t.a == 4
+        assert changes == []
 
-    nt.assert_equal(changes, [(0, 4)])
+    assert changes == [(0, 4)]
     # Test roll-back
     try:
          with t.hold_trait_notifications():
              t.b = 1  # raises a Trait error
     except:
         pass
-    nt.assert_equal(t.b, 0)
+    assert t.b == 0
 
 
 class RollBack(HasTraits):
@@ -1884,12 +1883,12 @@ class OrderTraits(HasTraits):
 def test_notification_order():
     d = {c:c for c in 'abcdefghijkl'}
     obj = OrderTraits()
-    nt.assert_equal(obj.notified, {})
+    assert obj.notified == {}
     obj = OrderTraits(**d)
     notifications = {
         c: d for c in 'abcdefghijkl'
     }
-    nt.assert_equal(obj.notified, notifications)
+    assert obj.notified == notifications
 
 
 
@@ -2056,7 +2055,7 @@ def test_enum_no_default():
 
     c = C()
 
-    with nt.assert_raises(TraitError):
+    with testhelper.assertRaises(TraitError):
         t = c.t
 
     c = C(t='b')
@@ -2071,11 +2070,11 @@ def test_default_value_repr():
         lis = List()
         d = Dict()
     
-    nt.assert_equal(C.t.default_value_repr(), "'traitlets.HasTraits'")
-    nt.assert_equal(C.t2.default_value_repr(), "'traitlets.traitlets.HasTraits'")
-    nt.assert_equal(C.n.default_value_repr(), '0')
-    nt.assert_equal(C.lis.default_value_repr(), '[]')
-    nt.assert_equal(C.d.default_value_repr(), '{}')
+    assert C.t.default_value_repr() == "'traitlets.HasTraits'"
+    assert C.t2.default_value_repr() == "'traitlets.traitlets.HasTraits'"
+    assert C.n.default_value_repr() == '0'
+    assert C.lis.default_value_repr() == '[]'
+    assert C.d.default_value_repr() == '{}'
 
 
 class TransitionalClass(HasTraits):
@@ -2123,12 +2122,12 @@ class SubClass(TransitionalClass):
 def test_subclass_compat():
     obj = SubClass()
     obj.calls_super = 5
-    nt.assert_true(obj.parent_super)
-    nt.assert_true(obj.subclass_super)
+    assert obj.parent_super
+    assert obj.subclass_super
     obj.overrides = 5
-    nt.assert_true(obj.subclass_override)
-    nt.assert_false(obj.parent_override)
-    nt.assert_is(obj.d, SubClass)
+    assert obj.subclass_override
+    assert not obj.parent_override
+    assert obj.d is SubClass
 
 
 class DefinesHandler(HasTraits):
@@ -2151,8 +2150,8 @@ class OverridesHandler(DefinesHandler):
 def test_subclass_override_observer():
     obj = OverridesHandler()
     obj.trait = 5
-    nt.assert_true(obj.child_called)
-    nt.assert_false(obj.parent_called)
+    assert obj.child_called
+    assert not obj.parent_called
 
 
 class DoesntRegisterHandler(DefinesHandler):
@@ -2166,8 +2165,8 @@ def test_subclass_override_not_registered():
     """Subclass that overrides observer and doesn't re-register unregisters both"""
     obj = DoesntRegisterHandler()
     obj.trait = 5
-    nt.assert_false(obj.child_called)
-    nt.assert_false(obj.parent_called)
+    assert not obj.child_called
+    assert not obj.parent_called
 
 
 class AddsHandler(DefinesHandler):
@@ -2180,8 +2179,8 @@ class AddsHandler(DefinesHandler):
 def test_subclass_add_observer():
     obj = AddsHandler()
     obj.trait = 5
-    nt.assert_true(obj.child_called)
-    nt.assert_true(obj.parent_called)
+    assert obj.child_called
+    assert obj.parent_called
 
 def test_super_args():
     class SuperRecorder(object):
@@ -2193,11 +2192,11 @@ def test_super_args():
         i = Integer()
     
     obj = SuperHasTraits('a1', 'a2', b=10, i=5, c='x')
-    nt.assert_equal(obj.i, 5)
+    assert obj.i ==  5
     assert not hasattr(obj, 'b')
     assert not hasattr(obj, 'c')
-    nt.assert_equal(obj.super_args, ('a1', 'a2'))
-    nt.assert_equal(obj.super_kwargs, {'b': 10, 'c': 'x'})
+    assert obj.super_args == ('a1' ,  'a2')
+    assert obj.super_kwargs == {'b': 10 , 'c': 'x'}
 
 def test_super_bad_args():
     class SuperHasTraits(HasTraits):
@@ -2210,5 +2209,5 @@ def test_super_bad_args():
         w = ["Passing unrecoginized arguments"]
     with expected_warnings(w):
         obj = SuperHasTraits(a=1, b=2)
-    nt.assert_equal(obj.a, 1)
+    assert obj.a ==  1 
     assert not hasattr(obj, 'b')

--- a/traitlets/tests/utils.py
+++ b/traitlets/tests/utils.py
@@ -1,5 +1,4 @@
 import sys
-import nose.tools as nt
 
 from subprocess import Popen, PIPE
 
@@ -19,10 +18,10 @@ def check_help_output(pkg, subcommand=None):
         cmd.extend(subcommand)
     cmd.append('-h')
     out, err, rc = get_output_error_code(cmd)
-    nt.assert_equal(rc, 0, err)
-    nt.assert_not_in("Traceback", err)
-    nt.assert_in("Options", out)
-    nt.assert_in("--help-all", out)
+    assert rc == 0, err)
+    assert "Traceback" not in err
+    assert "Options" in out
+    assert "--help-all" in out
     return out, err
 
 
@@ -33,8 +32,8 @@ def check_help_all_output(pkg, subcommand=None):
         cmd.extend(subcommand)
     cmd.append('--help-all')
     out, err, rc = get_output_error_code(cmd)
-    nt.assert_equal(rc, 0, err)
-    nt.assert_not_in("Traceback", err)
-    nt.assert_in("Options", out)
-    nt.assert_in("Class parameters", out)
+    assert rc == 0, err)
+    assert "Traceback" not in err
+    assert "Options" in out
+    assert "Class parameters" in out
     return out, err


### PR DESCRIPTION
Hi,

As discussed in PR #182, it might be a better idea to migrate the nose testing to `nose2`, since nose does not seem to be maintained any more. This  pull request does not add any new functionalities or tests, it is just simple refactoring. As a bonus, `traitlets` does not need to depend on `ipython_genutils.skipif` since this method is already implemented in `unittest`.

Results from Travis : https://travis-ci.org/lucasg/traitlets/builds/118092234

NB : nose2 output warnings for the test_loader tests, since `TestKeyValueCL` and `TestArgParseKVCL` consider unknwon input parameters as potentially erroneous (see `loader.py:419`).

