### PR TITLE
remove json config version warning

### DIFF
--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -416,7 +416,6 @@ class JSONFileConfigLoader(FileConfigLoader):
             version = dictionary.pop('version')
         else:
             version = 1
-            self.log.warning("Unrecognized JSON config file version, assuming version {}".format(version))
 
         if version == 1:
             return Config(dictionary)


### PR DESCRIPTION
version isn't normally defined in JSON config, so it's misleading to warn about its absence