### PR TITLE
Remove uses of ipython_genutils.py3compat in favor of six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setuptools_args = {}
 
 install_requires = setuptools_args['install_requires'] = [
     'ipython_genutils',
+    'six',
     'decorator',
 ]
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -344,7 +344,7 @@ class Application(SingletonConfigurable):
                     app=self.name)):
             lines.append(p)
             lines.append('')
-        for subc, (cls, help) in iteritems(self.subcommands):
+        for subc, (cls, help) in self.subcommands.items():
             lines.append(subc)
             if help:
                 lines.append(indent(dedent(help.strip())))
@@ -449,7 +449,7 @@ class Application(SingletonConfigurable):
         # flatten aliases, which have the form:
         # { 'alias' : 'Class.trait' }
         aliases = {}
-        for alias, cls_trait in iteritems(self.aliases):
+        for alias, cls_trait in self.aliases.items():
             cls,trait = cls_trait.split('.',1)
             children = mro_tree[cls]
             if len(children) == 1:
@@ -460,9 +460,9 @@ class Application(SingletonConfigurable):
         # flatten flags, which are of the form:
         # { 'key' : ({'Cls' : {'trait' : value}}, 'help')}
         flags = {}
-        for key, (flagdict, help) in iteritems(self.flags):
+        for key, (flagdict, help) in self.flags.items():
             newflag = {}
-            for cls, subdict in iteritems(flagdict):
+            for cls, subdict in flagdict.items():
                 children = mro_tree[cls]
                 # exactly one descendent, promote flag section
                 if len(children) == 1:

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -28,7 +28,6 @@ from ipython_genutils.text import indent, wrap_paragraphs, dedent
 from ipython_genutils import py3compat
 
 import six
-from six import iteritems
 
 #-----------------------------------------------------------------------------
 # Descriptions for the various sections
@@ -230,7 +229,7 @@ class Application(SingletonConfigurable):
     def _flags_changed(self, change):
         """ensure flags dict is valid"""
         new = change['new']
-        for key, value in iteritems(new):
+        for key, value in new.items():
             assert len(value) == 2, "Bad flag: %r:%s" % (key, value)
             assert isinstance(value[0], (dict, Config)), "Bad flag: %r:%s" % (key, value)
             assert isinstance(value[1], six.string_types), "Bad flag: %r:%s" % (key, value)
@@ -292,7 +291,7 @@ class Application(SingletonConfigurable):
             for c in cls.mro()[:-3]:
                 classdict[c.__name__] = c
 
-        for alias, longname in iteritems(self.aliases):
+        for alias, longname in self.aliases.items():
             classname, traitname = longname.split('.',1)
             cls = classdict[classname]
 
@@ -312,7 +311,7 @@ class Application(SingletonConfigurable):
             return
 
         lines = []
-        for m, (cfg,help) in iteritems(self.flags):
+        for m, (cfg,help) in self.flags.items():
             prefix = '--' if len(m) > 1 else '-'
             lines.append(prefix+m)
             lines.append(indent(dedent(help.strip())))
@@ -587,7 +586,6 @@ class Application(SingletonConfigurable):
 
     def exit(self, exit_status=0):
         self.log.debug("Exiting application: %s" % self.name)
-        logging.shutdown()
         sys.exit(exit_status)
 
     @classmethod

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -26,7 +26,9 @@ from traitlets.traitlets import (
 from ipython_genutils.importstring import import_item
 from ipython_genutils.text import indent, wrap_paragraphs, dedent
 from ipython_genutils import py3compat
-from ipython_genutils.py3compat import string_types, iteritems
+
+import six
+from six import iteritems
 
 #-----------------------------------------------------------------------------
 # Descriptions for the various sections
@@ -162,7 +164,7 @@ class Application(SingletonConfigurable):
     def _log_level_changed(self, change):
         """Adjust the log level when log_level is set."""
         new = change['new']
-        if isinstance(new, string_types):
+        if isinstance(new, six.string_types):
             new = getattr(logging, new)
             self.log_level = new
         self.log.setLevel(new)
@@ -228,10 +230,10 @@ class Application(SingletonConfigurable):
     def _flags_changed(self, change):
         """ensure flags dict is valid"""
         new = change['new']
-        for key, value in new.items():
+        for key, value in iteritems(new):
             assert len(value) == 2, "Bad flag: %r:%s" % (key, value)
             assert isinstance(value[0], (dict, Config)), "Bad flag: %r:%s" % (key, value)
-            assert isinstance(value[1], string_types), "Bad flag: %r:%s" % (key, value)
+            assert isinstance(value[1], six.string_types), "Bad flag: %r:%s" % (key, value)
 
 
     # subcommands for launching other applications
@@ -415,7 +417,7 @@ class Application(SingletonConfigurable):
         """Initialize a subcommand with argv."""
         subapp,help = self.subcommands.get(subc)
 
-        if isinstance(subapp, string_types):
+        if isinstance(subapp, six.string_types):
             subapp = import_item(subapp)
 
         # clear existing instances

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -12,7 +12,6 @@ import warnings
 from .loader import Config, LazyConfigValue, _is_section_key
 from traitlets.traitlets import HasTraits, Instance, observe, observe_compat, default
 from ipython_genutils.text import indent, dedent, wrap_paragraphs
-from six import iteritems
 
 
 #-----------------------------------------------------------------------------
@@ -141,7 +140,7 @@ class Configurable(HasTraits):
         
         # hold trait notifications until after all config has been loaded
         with self.hold_trait_notifications():
-            for name, config_value in iteritems(my_config):
+            for name, config_value in my_config.items():
                 if name in traits:
                     if isinstance(config_value, LazyConfigValue):
                         # ConfigValue is a wrapper for using append / update on containers

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -12,7 +12,7 @@ import warnings
 from .loader import Config, LazyConfigValue, _is_section_key
 from traitlets.traitlets import HasTraits, Instance, observe, observe_compat, default
 from ipython_genutils.text import indent, dedent, wrap_paragraphs
-from ipython_genutils.py3compat import iteritems
+from six import iteritems
 
 
 #-----------------------------------------------------------------------------

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -16,7 +16,7 @@ from ast import literal_eval
 from ipython_genutils.path import filefind
 from ipython_genutils import py3compat
 from ipython_genutils.encoding import DEFAULT_ENCODING
-from ipython_genutils.py3compat import unicode_type, iteritems
+from six import text_type, iteritems
 from traitlets.traitlets import HasTraits, List, Any
 
 #-----------------------------------------------------------------------------
@@ -603,7 +603,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         if enc is None:
             enc = DEFAULT_ENCODING
         for arg in argv:
-            if not isinstance(arg, unicode_type):
+            if not isinstance(arg, text_type):
                 # only decode if not already decoded
                 arg = arg.decode(enc)
             uargv.append(arg)
@@ -793,9 +793,9 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
             else:
                 nargs = None
             if len(key) is 1:
-                paa('-'+key, '--'+key, type=unicode_type, dest=value, nargs=nargs)
+                paa('-'+key, '--'+key, type=text_type, dest=value, nargs=nargs)
             else:
-                paa('--'+key, type=unicode_type, dest=value, nargs=nargs)
+                paa('--'+key, type=text_type, dest=value, nargs=nargs)
         for key, (value, help) in iteritems(flags):
             if key in self.aliases:
                 #

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -16,7 +16,7 @@ from ast import literal_eval
 from ipython_genutils.path import filefind
 from ipython_genutils import py3compat
 from ipython_genutils.encoding import DEFAULT_ENCODING
-from six import text_type, iteritems
+from six import text_type
 from traitlets.traitlets import HasTraits, List, Any
 
 #-----------------------------------------------------------------------------
@@ -182,7 +182,7 @@ class Config(dict):
     def merge(self, other):
         """merge another config object into this one"""
         to_update = {}
-        for k, v in iteritems(other):
+        for k, v in other.items():
             if k not in self:
                 to_update[k] = v
             else: # I have this key
@@ -521,7 +521,7 @@ class CommandLineConfigLoader(ConfigLoader):
         if isinstance(cfg, (dict, Config)):
             # don't clobber whole config sections, update
             # each section from config:
-            for sec,c in iteritems(cfg):
+            for sec,c in cfg.items():
                 self.config[sec].update(c)
         else:
             raise TypeError("Invalid flag: %r" % cfg)
@@ -769,7 +769,7 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
 
     def _convert_to_config(self):
         """self.parsed_data->self.config"""
-        for k, v in iteritems(vars(self.parsed_data)):
+        for k, v in vars(self.parsed_data).items():
             exec("self.config.%s = v"%k, locals(), globals())
 
 class KVArgParseConfigLoader(ArgParseConfigLoader):
@@ -786,7 +786,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
         if flags is None:
             flags = self.flags
         paa = self.parser.add_argument
-        for key,value in iteritems(aliases):
+        for key,value in aliases.items():
             if key in flags:
                 # flags
                 nargs = '?'
@@ -796,7 +796,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
                 paa('-'+key, '--'+key, type=text_type, dest=value, nargs=nargs)
             else:
                 paa('--'+key, type=text_type, dest=value, nargs=nargs)
-        for key, (value, help) in iteritems(flags):
+        for key, (value, help) in flags.items():
             if key in self.aliases:
                 #
                 self.alias_flags[self.aliases[key]] = value
@@ -815,7 +815,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
         else:
             subcs = []
 
-        for k, v in iteritems(vars(self.parsed_data)):
+        for k, v in vars(self.parsed_data).items():
             if v is None:
                 # it was a flag that shares the name of an alias
                 subcs.append(self.alias_flags[k])

--- a/traitlets/config/manager.py
+++ b/traitlets/config/manager.py
@@ -7,8 +7,8 @@ import io
 import json
 import os
 
+from six import PY3
 from traitlets.config import LoggingConfigurable
-from ipython_genutils.py3compat import PY3
 from traitlets.traitlets import Unicode
 
 

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -22,7 +22,7 @@ from traitlets.traitlets import (
 )
 
 from traitlets.config.loader import Config
-from ipython_genutils.py3compat import PY3
+from six import PY3
 
 from ...tests._warnings import expected_warnings
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -13,7 +13,7 @@ import sys
 from ._warnings import expected_warnings
 
 from nose2.compat import unittest
-from unittest import TestCase
+from unittest import TestCase, skipif
 from nose2.tools.such import helper as testhelper
 
 from traitlets import (
@@ -24,7 +24,8 @@ from traitlets import (
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
     observe_compat, BaseDescriptor, HasDescriptors,
 )
-from ipython_genutils import py3compat
+
+import six
 
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')
@@ -1143,30 +1144,30 @@ class TestInt(TraitTestBase):
     _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j,
                       10.1, -10.1, '10L', '-10L', '10.1', '-10.1', u'10L',
                       u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', -200]
-    if not py3compat.PY3:
+    if not six.PY3:
         _bad_values.extend([long(10), long(-10), 10*sys.maxint, -10*sys.maxint])
 
 
 class LongTrait(HasTraits):
 
-    value = Long(99 if py3compat.PY3 else long(99))
+    value = Long(99 if six.PY3 else long(99))
 
 class TestLong(TraitTestBase):
 
     obj = LongTrait()
 
-    _default_value = 99 if py3compat.PY3 else long(99)
+    _default_value = 99 if six.PY3 else long(99)
     _good_values   = [10, -10]
     _bad_values    = ['ten', u'ten', [10], {'ten': 10},(10,),
                       None, 1j, 10.1, -10.1, '10', '-10', '10L', '-10L', '10.1',
                       '-10.1', u'10', u'-10', u'10L', u'-10L', u'10.1',
                       u'-10.1']
-    if not py3compat.PY3:
+    if not six.PY3:
         # maxint undefined on py3, because int == long
         _good_values.extend([long(10), long(-10), 10*sys.maxint, -10*sys.maxint])
         _bad_values.extend([[long(10)], (long(10),)])
 
-    @unittest.skipIf(py3compat.PY3, "not relevant on py3")
+    @skipif(six.PY3, "not relevant on py3")
     def test_cast_small(self):
         """Long casts ints to long"""
         self.obj.value = 10
@@ -1183,10 +1184,10 @@ class TestInteger(TestLong):
     def coerce(self, n):
         return int(n)
 
-    @unittest.skipIf(py3compat.PY3, "not relevant on py3")
+    @skipif(six.PY3, "not relevant on py3")
     def test_cast_small(self):
         """Integer casts small longs to int"""
-        if py3compat.PY3:
+        if six.PY3:
             raise unittest.SkipTest("not relevant on py3")
 
         self.obj.value = long(100)
@@ -1206,7 +1207,7 @@ class TestFloat(TraitTestBase):
     _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None,
                       1j, '10', '-10', '10L', '-10L', '10.1', '-10.1', u'10',
                       u'-10', u'10L', u'-10L', u'10.1', u'-10.1', 201.0]
-    if not py3compat.PY3:
+    if not six.PY3:
         _bad_values.extend([long(10), long(-10)])
 
 
@@ -1222,7 +1223,7 @@ class TestComplex(TraitTestBase):
     _good_values   = [10, -10, 10.1, -10.1, 10j, 10+10j, 10-10j,
                       10.1j, 10.1+10.1j, 10.1-10.1j]
     _bad_values    = [u'10L', u'-10L', 'ten', [10], {'ten': 10},(10,), None]
-    if not py3compat.PY3:
+    if not six.PY3:
         _bad_values.extend([long(10), long(-10)])
 
 
@@ -1239,7 +1240,7 @@ class TestBytes(TraitTestBase):
                       b'-10L', b'10.1', b'-10.1', b'string']
     _bad_values    = [10, -10, 10.1, -10.1, 1j, [10],
                       ['ten'],{'ten': 10},(10,), None,  u'string']
-    if not py3compat.PY3:
+    if not six.PY3:
         _bad_values.extend([long(10), long(-10)])
 
 
@@ -1256,7 +1257,7 @@ class TestUnicode(TraitTestBase):
                       '-10.1', '', u'', 'string', u'string', u"€"]
     _bad_values    = [10, -10, 10.1, -10.1, 1j,
                       [10], ['ten'], [u'ten'], {'ten': 10},(10,), None]
-    if not py3compat.PY3:
+    if not six.PY3:
         _bad_values.extend([long(10), long(-10)])
 
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -13,7 +13,7 @@ import sys
 from ._warnings import expected_warnings
 
 from nose2.compat import unittest
-from unittest import TestCase, skipif
+from unittest import TestCase, skipIf
 from nose2.tools.such import helper as testhelper
 
 from traitlets import (
@@ -1167,7 +1167,7 @@ class TestLong(TraitTestBase):
         _good_values.extend([long(10), long(-10), 10*sys.maxint, -10*sys.maxint])
         _bad_values.extend([[long(10)], (long(10),)])
 
-    @skipif(six.PY3, "not relevant on py3")
+    @skipIf(six.PY3, "not relevant on py3")
     def test_cast_small(self):
         """Long casts ints to long"""
         self.obj.value = 10
@@ -1184,7 +1184,7 @@ class TestInteger(TestLong):
     def coerce(self, n):
         return int(n)
 
-    @skipif(six.PY3, "not relevant on py3")
+    @skipIf(six.PY3, "not relevant on py3")
     def test_cast_small(self):
         """Integer casts small longs to int"""
         if six.PY3:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -53,8 +53,8 @@ except:
     ClassTypes = (type,)
 from warnings import warn, warn_explicit
 
-from ipython_genutils import py3compat
-from ipython_genutils.py3compat import iteritems, string_types
+import six
+from six import iteritems
 
 from .utils.getargspec import getargspec
 from .utils.importstring import import_item
@@ -90,6 +90,14 @@ class TraitError(Exception):
 # Utilities
 #-----------------------------------------------------------------------------
 
+_name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
+
+def isidentifier(s):
+    if six.PY3:
+        return s.isidentifier()
+    else:
+        return bool(_name_re.match(s))
+        
 
 def _deprecated_method(method, cls, method_name, msg):
     """Show deprecation warning about a magic method definition.
@@ -119,7 +127,7 @@ def class_of(object):
     correct indefinite article ('a' or 'an') preceding it (e.g., 'an Image',
     'a PlotValue').
     """
-    if isinstance( object, py3compat.string_types ):
+    if isinstance( object, six.string_types ):
         return add_article( object )
 
     return add_article( object.__class__.__name__ )
@@ -140,7 +148,7 @@ def repr_type(obj):
     error messages.
     """
     the_type = type(obj)
-    if (not py3compat.PY3) and the_type is InstanceType:
+    if (not six.PY3) and the_type is InstanceType:
         # Old-style class.
         the_type = obj.__class__
     msg = '%r %r' % (obj, the_type)
@@ -169,13 +177,13 @@ def parse_notifier_name(names):
     >>> parse_notifier_name(All)
     [All]
     """
-    if names is All or isinstance(names, string_types):
+    if names is All or isinstance(names, six.string_types):
         return [names]
     elif isinstance(names, (list, tuple)):
         if not names or All in names:
             return [All]
         for n in names:
-            assert isinstance(n, string_types), "names must be strings"
+            assert isinstance(n, six.string_types), "names must be strings"
         return names
 
 
@@ -896,7 +904,7 @@ class DefaultHandler(EventHandler):
         cls._trait_default_generators[self.trait_name] = self
 
 
-class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
+class HasDescriptors(six.with_metaclass(MetaHasDescriptors, object)):
     """The base class for all classes that have descriptors.
     """
 
@@ -930,7 +938,7 @@ class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
                     value.instance_init(self)
 
 
-class HasTraits(py3compat.with_metaclass(MetaHasTraits, HasDescriptors)):
+class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
 
     def setup_instance(self, *args, **kwargs):
         self._trait_values = {}
@@ -1421,7 +1429,7 @@ class ClassBasedTraitType(TraitType):
 
     def error(self, obj, value):
         kind = type(value)
-        if (not py3compat.PY3) and kind is InstanceType:
+        if (not six.PY3) and kind is InstanceType:
             msg = 'class %s' % value.__class__.__name__
         else:
             msg = '%s (i.e. %s)' % ( str( kind )[1:-1], repr( value ) )
@@ -1475,7 +1483,7 @@ class Type(ClassBasedTraitType):
             else:
                 klass = default_value
 
-        if not (inspect.isclass(klass) or isinstance(klass, py3compat.string_types)):
+        if not (inspect.isclass(klass) or isinstance(klass, six.string_types)):
             raise TraitError("A Type trait must specify a class.")
 
         self.klass = klass
@@ -1484,7 +1492,7 @@ class Type(ClassBasedTraitType):
 
     def validate(self, obj, value):
         """Validates that the value is a valid object instance."""
-        if isinstance(value, py3compat.string_types):
+        if isinstance(value, six.string_types):
             try:
                 value = self._resolve_string(value)
             except ImportError:
@@ -1500,7 +1508,7 @@ class Type(ClassBasedTraitType):
 
     def info(self):
         """ Returns a description of the trait."""
-        if isinstance(self.klass, py3compat.string_types):
+        if isinstance(self.klass, six.string_types):
             klass = self.klass
         else:
             klass = self.klass.__module__+'.'+self.klass.__name__
@@ -1514,14 +1522,14 @@ class Type(ClassBasedTraitType):
         super(Type, self).instance_init(obj)
 
     def _resolve_classes(self):
-        if isinstance(self.klass, py3compat.string_types):
+        if isinstance(self.klass, six.string_types):
             self.klass = self._resolve_string(self.klass)
-        if isinstance(self.default_value, py3compat.string_types):
+        if isinstance(self.default_value, six.string_types):
             self.default_value = self._resolve_string(self.default_value)
 
     def default_value_repr(self):
         value = self.default_value
-        if isinstance(value, py3compat.string_types):
+        if isinstance(value, six.string_types):
             return repr(value)
         else:
             return repr('{}.{}'.format(value.__module__, value.__name__))
@@ -1567,7 +1575,7 @@ class Instance(ClassBasedTraitType):
         if klass is None:
             klass = self.klass
         
-        if (klass is not None) and (inspect.isclass(klass) or isinstance(klass, py3compat.string_types)):
+        if (klass is not None) and (inspect.isclass(klass) or isinstance(klass, six.string_types)):
             self.klass = klass
         else:
             raise TraitError('The klass attribute must be a class'
@@ -1590,7 +1598,7 @@ class Instance(ClassBasedTraitType):
             self.error(obj, value)
 
     def info(self):
-        if isinstance(self.klass, py3compat.string_types):
+        if isinstance(self.klass, six.string_types):
             klass = self.klass
         else:
             klass = self.klass.__name__
@@ -1605,7 +1613,7 @@ class Instance(ClassBasedTraitType):
         super(Instance, self).instance_init(obj)
 
     def _resolve_classes(self):
-        if isinstance(self.klass, py3compat.string_types):
+        if isinstance(self.klass, six.string_types):
             self.klass = self._resolve_string(self.klass)
 
     def make_dynamic_default(self):
@@ -1777,7 +1785,7 @@ class CInt(Int):
         except:
             self.error(obj, value)
 
-if py3compat.PY3:
+if six.PY3:
     Long, CLong = Int, CInt
     Integer = Int
 else:
@@ -1917,7 +1925,7 @@ class Unicode(TraitType):
     info_text = 'a unicode string'
 
     def validate(self, obj, value):
-        if isinstance(value, py3compat.unicode_type):
+        if isinstance(value, six.text_type):
             return value
         if isinstance(value, bytes):
             try:
@@ -1933,7 +1941,7 @@ class CUnicode(Unicode):
 
     def validate(self, obj, value):
         try:
-            return py3compat.unicode_type(value)
+            return six.text_type(value)
         except:
             self.error(obj, value)
 
@@ -1944,7 +1952,7 @@ class ObjectName(TraitType):
     This does not check that the name exists in any scope."""
     info_text = "a valid object identifier in Python"
 
-    if py3compat.PY3:
+    if six.PY3:
         # Python 3:
         coerce_str = staticmethod(lambda _,s: s)
 
@@ -1962,7 +1970,7 @@ class ObjectName(TraitType):
     def validate(self, obj, value):
         value = self.coerce_str(obj, value)
 
-        if isinstance(value, string_types) and py3compat.isidentifier(value):
+        if isinstance(value, six.string_types) and isidentifier(value):
             return value
         self.error(obj, value)
 
@@ -1971,7 +1979,8 @@ class DottedObjectName(ObjectName):
     def validate(self, obj, value):
         value = self.coerce_str(obj, value)
 
-        if isinstance(value, string_types) and py3compat.isidentifier(value, dotted=True):
+        if isinstance(value, six.string_types) and all(isidentifier(a)
+          for a in value.split('.')):
             return value
         self.error(obj, value)
 
@@ -2029,7 +2038,7 @@ class CaselessStrEnum(Enum):
     def validate(self, obj, value):
         if isinstance(value, str):
             value = py3compat.cast_unicode_py2(value)
-        if not isinstance(value, py3compat.string_types):
+        if not isinstance(value, six.string_types):
             self.error(obj, value)
 
         for v in self.values:
@@ -2453,7 +2462,7 @@ class TCPAddress(TraitType):
     def validate(self, obj, value):
         if isinstance(value, tuple):
             if len(value) == 2:
-                if isinstance(value[0], py3compat.string_types) and isinstance(value[1], int):
+                if isinstance(value[0], six.string_types) and isinstance(value[1], int):
                     port = value[1]
                     if port >= 0 and port <= 65535:
                         return value

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2533,7 +2533,7 @@ class UseEnum(TraitType):
 
     def select_by_name(self, value, default=Undefined):
         """Selects enum-value by using its name or scoped-name."""
-        assert isinstance(value, string_types)
+        assert isinstance(value, six.string_types)
         if value.startswith(self.name_prefix):
             # -- SUPPORT SCOPED-NAMES, like: "Color.red" => "red"
             value = value.replace(self.name_prefix, "", 1)
@@ -2547,7 +2547,7 @@ class UseEnum(TraitType):
             value2 = self.select_by_number(value)
             if value2 is not Undefined:
                 return value2
-        elif isinstance(value, string_types):
+        elif isinstance(value, six.string_types):
             # -- CONVERT: name or scoped_name (as string) => enum_value (item)
             value2 = self.select_by_name(value)
             if value2 is not Undefined:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -54,7 +54,6 @@ except:
 from warnings import warn, warn_explicit
 
 import six
-from six import iteritems
 
 from .utils.getargspec import getargspec
 from .utils.importstring import import_item
@@ -698,7 +697,7 @@ class MetaHasDescriptors(type):
 
     def __new__(mcls, name, bases, classdict):
         """Create the HasDescriptors class."""
-        for k, v in iteritems(classdict):
+        for k, v in classdict.items():
             # ----------------------------------------------------------------
             # Support of deprecated behavior allowing for TraitType types
             # to be used instead of TraitType instances.
@@ -722,7 +721,7 @@ class MetaHasDescriptors(type):
         BaseDescriptor in the class dict of the newly created ``cls`` before
         calling their :attr:`class_init` method.
         """
-        for k, v in iteritems(classdict):
+        for k, v in classdict.items():
             if isinstance(v, BaseDescriptor):
                 v.class_init(cls, k)
 
@@ -953,7 +952,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         super_args = args
         super_kwargs = {}
         with self.hold_trait_notifications():
-            for key, value in iteritems(kwargs):
+            for key, value in kwargs.items():
                 if self.has_trait(key):
                     setattr(self, key, value)
                 else:

--- a/traitlets/utils/getargspec.py
+++ b/traitlets/utils/getargspec.py
@@ -10,7 +10,7 @@
 """
 
 import inspect
-from ipython_genutils.py3compat import PY3
+from six import PY3
 
 # Unmodified from sphinx below this line
 

--- a/traitlets/utils/importstring.py
+++ b/traitlets/utils/importstring.py
@@ -5,7 +5,8 @@ A simple utility to import something by its string name.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipython_genutils.py3compat import cast_bytes_py2, string_types
+from ipython_genutils.py3compat import cast_bytes_py2
+from six import string_types
 
 def import_item(name):
     """Import and return ``bar`` given the string ``foo.bar``.


### PR DESCRIPTION
Just rebased @SylvainCorlay's work (#117)