### PR TITLE
Allow to configure whether Application abort on bad config.

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -113,6 +113,8 @@ The answers to these questions are provided by the various
 application uses. Let's look at how this would work for a simple configurable
 subclass::
 
+.. code-block:: python
+
     # Sample configurable:
     from traitlets.config.configurable import Configurable
     from traitlets import Int, Float, Unicode, Bool
@@ -130,6 +132,8 @@ of which (``name``, ``ranking``) can be configured.  All of the attributes
 are given types and default values.  If a :class:`MyClass` is instantiated,
 but not configured, these default values will be used.  But let's see how
 to configure this class in a configuration file::
+
+.. code-block:: python
 
     # Sample config file
     c.MyClass.name = 'coolname'
@@ -287,8 +291,21 @@ Is the same as adding:
     c.InteractiveShell.use_readline=False
     c.BaseIPythonApplication.profile='myprofile'
 
-to your config file. Key/Value arguments *always* take a value, separated by '='
+to your configuration file. Key/Value arguments *always* take a value, separated by '='
 and no spaces.
+
+.. note::
+
+    By default any error in configuration files with lead to this configuration
+    file be ignored by default.  Application subclasses may specify
+    `raise_config_file_errors = True` to exit on failure to load config files,
+    instead of the default of logging the failures.
+
+.. versionadded:: 4.3
+
+    The environement variable ``TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR``
+    to ``'1'`` or ``'true'`` to change the defautl value of ``raise_config_file_errors``.
+
 
 Common Arguments
 ----------------

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -62,6 +62,17 @@ subcommand 'cmd', do: `{app} cmd -h`.
 # Application class
 #-----------------------------------------------------------------------------
 
+
+
+_envvar = os.environ.get('TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR','')
+if _envvar.lower() in {'1','true'}:
+    TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR = True
+elif _envvar.lower() in {'0','false',''} :
+    TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR = False
+else:
+    raise ValueError("Unsupported value for environment variable: 'TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR' is set to '%s' which is none of  {'0', '1', 'false', 'true', ''}."% _envvar )
+
+
 @decorator
 def catch_config_error(method, app, *args, **kwargs):
     """Method decorator for catching invalid config (Trait/ArgumentErrors) during init.
@@ -151,7 +162,7 @@ class Application(SingletonConfigurable):
     argv = List()
 
     # Whether failing to load config files should prevent startup
-    raise_config_file_errors = Bool(False)
+    raise_config_file_errors = Bool(TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR)
 
     # The log level for the application
     log_level = Enum((0,10,20,30,40,50,'DEBUG','INFO','WARN','ERROR','CRITICAL'),


### PR DESCRIPTION
Does that through an env variable:
TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR

Might want to expose that at higher level so that application can
make this setting on a per-application bassis.

Related to https://github.com/ipython/ipython/issues/8927