### PR TITLE
register TraitEventHandlers with tags

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -628,10 +628,6 @@ class TestObserveDecorator(TestCase):
         a.bar = 1
         self.assertEqual(a.foo, a.bar)
 
-        a.add_traits(baz=Int().tag(test=True))
-        a.baz = 2
-        self.assertEqual(a.foo, a.baz)
-
     def test_observe_via_tags(self):
 
         class unhashable(object):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -671,11 +671,8 @@ class TestObserveDecorator(TestCase):
 
         a.unobserve_all()
 
-        # test that tagged notifiers know
-        # about dynamically added traits
-        a.observe(_test_observer1, tags={'type': 'b'})
         a.add_traits(baz=Int().tag(type='b'))
-
+        a.observe(_test_observer1, tags={'type': 'b'})
         a.baz = 1
         self.assertEqual(a.foo, 1)
         a.foo = 0

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -23,7 +23,7 @@ from traitlets import (
     List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
     observe_compat, BaseDescriptor, HasDescriptors, parse_notifier_name,
-    parse_notifier_tags, TraitEventHandler
+    parse_notifier_tags, EventHandler
 )
 
 import six

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -22,7 +22,8 @@ from traitlets import (
     TraitError, Union, All, Undefined, Type, This, Instance, TCPAddress,
     List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
-    observe_compat, BaseDescriptor, HasDescriptors,
+    observe_compat, BaseDescriptor, HasDescriptors, parse_notifier_name,
+    parse_notifier_tags, TraitEventHandler
 )
 
 import six
@@ -30,6 +31,7 @@ import six
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')
     return dict(zip(change_names, ordered_values))
+
 
 #-----------------------------------------------------------------------------
 # Helper classes for testing
@@ -566,6 +568,10 @@ class TestObserveDecorator(TestCase):
 
     def notify2(self, change):
         self._notify2.append(change)
+
+    def test_raise_on_no_names(self):
+        with pytest.raises(TypeError):
+            observe()
 
     def test_notify_all(self):
 
@@ -2637,3 +2643,18 @@ def test_cls_self_argument():
             pass
 
     x = X(cls=None, self=None)
+
+
+#-----------------------------------------------------------------------------
+# Misc testing for improved coverage
+#-----------------------------------------------------------------------------
+
+
+def test_notifier_parsing():
+    with pytest.raises(TypeError):
+        parse_notifier_name([0])
+
+    with pytest.raises(TypeError):
+        parse_notifier_tags(0, {"type": None})
+
+

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -23,7 +23,7 @@ from traitlets import (
     List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
     observe_compat, BaseDescriptor, HasDescriptors, parse_notifier_name,
-    parse_notifier_tags, EventHandler
+    parse_notifier_names, EventHandler
 )
 
 import six
@@ -2652,6 +2652,6 @@ def test_notifier_parsing():
         parse_notifier_name([0])
 
     with pytest.raises(TypeError):
-        parse_notifier_tags(0, {"type": None})
+        parse_notifier_names(0, {"type": None})
 
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -988,7 +988,7 @@ class ObserveHandler(TraitEventHandler):
 
     caches_instance_resources = True
 
-    def __init__(self, names, tags, type):
+    def __init__(self, names, type, tags):
         super(ObserveHandler, self).__init__(names, tags)
         self.type = type
 
@@ -1376,7 +1376,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         else:
             self.observe(_callback_wrapper(handler), names=name)
 
-    def observe(self, handler, names=None, tags=None, type='change'):
+    def observe(self, handler, names=None, type='change', tags=None):
         """Setup a handler to be called when a trait changes.
 
         This is used to setup dynamic notifications of trait changes.
@@ -1411,10 +1411,10 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         if isinstance(handler, ObserveHandler):
             self._add_notifiers(handler, names, type)
         else:
-            event = ObserveHandler(names, tags, type)
+            event = ObserveHandler(names, type, tags)
             event(handler).register(self)
 
-    def unobserve(self, handler, names=None, tags=None, type='change'):
+    def unobserve(self, handler, names=None, type='change', tags=None):
         """Remove a trait change handler.
 
         This is used to unregister handlers to trait change notifications.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -233,7 +233,7 @@ def parse_notifier_names(owner, names=None, tags=None):
         names = []
     elif names is All or isinstance(names, six.string_types):
         names = [names]
-    elif not names or All in names:
+    elif (not names and not tags) or All in names:
         names = [All]
     else:
         for n in names:


### PR DESCRIPTION
Allows the use of metadata as a way to register trait events

``` python
class A(HasTraits):
    foo = Int().tag(bar=True)
    @observe(tags={'bar':True})
    def _bar_observer(self, change):
        print 'change from bar tagged trait'

a = A()

a.foo = 1
```

The same pattern also works for `@validate` and `@default`.
## General:
- More elegant than #111.
- Closes #219, #215, #221 
## Under The Hood:
1. `default`, `validate`, `observe` (method and decorator), `unobserve`, and `unobserve_all` have a new `'tags'` keyword that provides metadata for gathering groups of traits for observation or for removing observers (depending on the method).
   - The metadata provided via `'tags'` does not create a dynamic reference to traits - e.g. if the metadata of a trait is modified, the tagged registration of observers to that trait will not be recomputed. Thus, in edge cases where metadata might be modified, or new traits are added, the timing of a call to one of the above methods should be closely considered.
3. New functionality for `unobserve_all`
   - Previously `unobserve_all` either deleted all notifiers, or all notifiers of a given name.
   - Now, it's taken a feature previously belonging to `HasTraits.unobserve` when its `'handler'` argument was `None`. Thus `unobserve_all` can remove the handlers of a given name and type.
   - Additionally, `unobserve_all` can now remove all handlers of a specified type across all traits.
   - Calls to `unobserve` where `'handler'` is `None` are redirected to `unobserve_all` with a warning.
