### PR TITLE
ENH: Use own logger for the package rather than the root logger.

### DIFF
--- a/traitlets/log.py
+++ b/traitlets/log.py
@@ -9,17 +9,19 @@ _logger = None
 
 def get_logger():
     """Grab the global logger instance.
-    
+
     If a global Application is instantiated, grab its logger.
     Otherwise, grab the root logger.
     """
     global _logger
-    
+
     if _logger is None:
         from .config import Application
         if Application.initialized():
             _logger = Application.instance().log
         else:
-            logging.basicConfig()
-            _logger = logging.getLogger()
+            _logger = logging.getLogger('traitlets')
+            # Add a NullHandler to silence warnings about not being
+            # initialized, per best practice for libraries.
+            _logger.addHandler(logging.NullHandler())
     return _logger


### PR DESCRIPTION
Libraries should not attempt to configure the root logger. The standard best practice is to use a namespaced logger for the package and to add a `NullHandler` to it.