### PR TITLE
limit common deprecation messages to once per package

### DIFF
--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -19,6 +19,7 @@ from traitlets.config.configurable import (
 
 from traitlets.traitlets import (
     Integer, Float, Unicode, List, Dict, Set,
+    _deprecations_shown,
 )
 
 from traitlets.config.loader import Config
@@ -401,6 +402,8 @@ class TestConfigContainers(TestCase):
         class SomeSingleton(SingletonConfigurable):
             pass
 
+        # reset deprecation limiter
+        _deprecations_shown.clear()
         with expected_warnings(['Metadata should be set using the \.tag\(\) method']):
             class DefaultConfigurable(Configurable):
                 a = Integer(config=True)


### PR DESCRIPTION
since `_default` and `config=True` deprecations are likely to occur numerous times in packages, limit their display to once per package by default.

Setting env TRAITLETS_ALL_DEPRECATIONS=1 will go back to showing all the deprecation warnings.

Not sure if this is the best thing to do, but it should reduce some of the annoyance while packages are in transition.