### PR TITLE
run tests with py.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
     - 3.3
 sudo: false
 install:
-    - pip install . nose2
-    - pip install . cov-core
+    - pip install .
+    - pip install traitlets[test] pytest-cov codecov
 script:
-    - nose2 --with-coverage
+    - py.test --cov traitlets -v traitlets
 after_success:
-    - coveralls
+    - codecov

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ For a development installation:
 
 ## Running the tests
 
-* `nosetests traitlets`.
+    pip install "traitlets[test]"
+    py.test traitlets
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test': ['nose2'],
+    'test': ['pytest'],
     # -- SUPPORT UNIFORM-WHEELS: Extra packages for Python 2.7, 3.3
     # SEE: https://bitbucket.org/pypa/wheel/ , CHANGES.txt (v0.24.0)
     ':python_version=="2.7"': ["enum34"],

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -18,7 +18,7 @@ except ImportError:
 
 pjoin = os.path.join
 
-from nose2.compat import unittest
+from pytest import mark
 
 from traitlets.config.configurable import Configurable
 from traitlets.config.loader import Config
@@ -225,9 +225,8 @@ class TestApplication(TestCase):
                 app.init_bar()
                 self.assertEqual(app.bar.b, 1)
     
+    @mark.skipif(not hasattr(TestCase, 'assertLogs'), reason='requires TestCase.assertLogs')
     def test_log_bad_config(self):
-        if not hasattr(self, 'assertLogs'):
-            raise unittest.SkipTest("Test requires unittest.TestCase.assertLogs")
         app = MyApp()
         app.log = logging.getLogger()
         name = 'config.py'

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -7,9 +7,7 @@
 import logging
 from unittest import TestCase
 
-from nose2.compat import unittest
-from unittest import TestCase
-from nose2.tools.such import helper as testhelper
+from pytest import mark
 
 from traitlets.config.configurable import (
     Configurable,
@@ -422,18 +420,15 @@ class TestConfigContainers(TestCase):
         self.assertEqual(d2.a, 5)
 
 
-
-class TestLogger(unittest.TestCase):
+class TestLogger(TestCase):
 
     class A(LoggingConfigurable):
             foo = Integer(config=True)
             bar = Integer(config=True)
             baz = Integer(config=True)
     
+    @mark.skipif(not hasattr(TestCase, 'assertLogs'), reason='requires TestCase.assertLogs')
     def test_warn_match(self):
-        if not hasattr(self, 'assertLogs'):
-            raise unittest.SkipTest("Test requires unittest.TestCase.assertLogs")
-
         logger = logging.getLogger('test_warn_match')
         cfg = Config({'A': {'bat': 5}})
         with self.assertLogs(logger, logging.WARNING) as captured:

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -9,13 +9,10 @@ import logging
 import os
 import pickle
 import sys
-
 from tempfile import mkstemp
-
-from nose2.compat import unittest
 from unittest import TestCase
 
-
+from pytest import skip
 
 from traitlets.config.loader import (
     Config,
@@ -275,7 +272,7 @@ class TestKeyValueCL(TestCase):
         try:
             barg = uarg.encode(sys.stdin.encoding)
         except (TypeError, UnicodeEncodeError):
-            raise unittest.SkipTest("sys.stdin.encoding can't handle 'é'")
+            raise skip("sys.stdin.encoding can't handle 'é'")
         
         cl = self.klass(log=log)
         config = cl.load_config([barg])

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -12,9 +12,9 @@ import re
 import sys
 from ._warnings import expected_warnings
 
-from nose2.compat import unittest
-from unittest import TestCase, skipIf
-from nose2.tools.such import helper as testhelper
+from unittest import TestCase
+import pytest
+from pytest import mark
 
 from traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
@@ -1167,7 +1167,7 @@ class TestLong(TraitTestBase):
         _good_values.extend([long(10), long(-10), 10*sys.maxint, -10*sys.maxint])
         _bad_values.extend([[long(10)], (long(10),)])
 
-    @skipIf(six.PY3, "not relevant on py3")
+    @mark.skipif(six.PY3, reason="not relevant on py3")
     def test_cast_small(self):
         """Long casts ints to long"""
         self.obj.value = 10
@@ -1184,11 +1184,9 @@ class TestInteger(TestLong):
     def coerce(self, n):
         return int(n)
 
-    @skipIf(six.PY3, "not relevant on py3")
+    @mark.skipif(six.PY3, reason="not relevant on py3")
     def test_cast_small(self):
         """Integer casts small longs to int"""
-        if six.PY3:
-            raise unittest.SkipTest("not relevant on py3")
 
         self.obj.value = long(100)
         self.assertEqual(type(self.obj.value), int)
@@ -2088,7 +2086,7 @@ def test_enum_no_default():
 
     c = C()
 
-    with testhelper.assertRaises(TraitError):
+    with pytest.raises(TraitError):
         t = c.t
 
     c = C(t='b')


### PR DESCRIPTION
instead of nose2.

And use codecov instead of coveralls while we're at it, since that's what we do now.