### PR TITLE
Fix erroneous example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ return the default value. For example:
 
 ```Python
 import getpass
-from traitlets import HasTraits, Unicode, observe
+from traitlets import HasTraits, Unicode, default
 
 class Identity(HasTraits):
     username = Unicode()


### PR DESCRIPTION
This fixes a bug in the readme's example code that prohibited it from running.

Also I was wondering if you'd be partial to adding something like the following to the bottom of the example code:

    identity = Identity()
    identity.username  # returns system user

And for the example below it:

    example = TraitletsExample()
    example.num = 6  # prints 'num changed from 5 to 6'

Something along those lines would just complete the examples. As someone looking over the project readme for the first time, it would make it instantly obvious what was happening.