### PR TITLE
copy self.config in update_config

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -187,9 +187,12 @@ class Configurable(HasTraits):
 
     def update_config(self, config):
         """Update config and load the new values"""
-        # make a copy of our config prior to loading to protect IPython,
-        # which relies on self.config being immutable
-        # to preserve CLI config priority
+        # traitlets prior to 4.2 created a copy of self.config in order to trigger change events.
+        # Some projects (IPython < 5) relied upon one side effect of this,
+        # that self.config prior to update_config was not modified in-place.
+        # For backward-compatibility, we must ensure that self.config
+        # is a new object and not modified in-place,
+        # but config consumers should not rely on this behavior.
         self.config = deepcopy(self.config)
         # load config
         self._load_config(config)

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -187,6 +187,10 @@ class Configurable(HasTraits):
 
     def update_config(self, config):
         """Update config and load the new values"""
+        # make a copy of our config prior to loading to protect IPython,
+        # which relies on self.config being immutable
+        # to preserve CLI config priority
+        self.config = deepcopy(self.config)
         # load config
         self._load_config(config)
         # merge it into self.config


### PR DESCRIPTION
protects IPython's CLI priority, which accidentally relies upon self.config being replaced during load_config_files.

for backport to 4.2.2

closes #248