### PR TITLE
Add an EventReport class

### DIFF
--- a/traitlets/utils/bunch.py
+++ b/traitlets/utils/bunch.py
@@ -6,8 +6,26 @@ attribute-access of items on a dict.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from six import with_metaclass
+
+
+class EmptyMethodDescriptor(object):
+    
+    def __init__(self, name, etype, msg):
+        self.name = name
+        self.etype = etype
+        self.msg = msg
+    
+    def __get__(self, inst, cls=None):
+        if inst is not None:
+            m = "'%s' object " % cls.__name__
+        else:
+            m = "type object '%s' " % cls.__name__
+        raise self.etype(m + self.msg)
+
+
 class Bunch(dict):
-    """A dict with attribute-access"""
+    """A dict with attribute access"""
     def __getattr__(self, key):
         try:
             return self.__getitem__(key)
@@ -19,7 +37,33 @@ class Bunch(dict):
     
     def __dir__(self):
         # py2-compat: can't use super because dict doesn't have __dir__
-        names = dir({})
+        names = dir(type(self))
         names.extend(self.keys())
         return names
 
+
+class MetaFrozenBunch(type):
+    
+    def __new__(mcls, name, bases, classdict):
+        for n in ('clear', 'pop', 'popitem', 'setdefault', 'update'):
+            classdict[n] = EmptyMethodDescriptor(n, AttributeError, 'has no attribute %s' % n)
+        classdict['__setattr__'] = EmptyMethodDescriptor( '__setattr__',
+                        TypeError, 'does not support attribute assignment')
+        classdict['__delattr__'] = EmptyMethodDescriptor( '__delattr__',
+                        TypeError, 'does not support attribute deletion')
+        classdict['__setitem__'] = EmptyMethodDescriptor( '__setitem__',
+                        TypeError, 'does not support item assignment')
+        classdict['__delitem__'] = EmptyMethodDescriptor('__delitem__',
+                        TypeError, 'does not support item deletion')
+        return super(MetaFrozenBunch, mcls).__new__(mcls, name, bases, classdict)
+
+
+class FrozenBunch(with_metaclass(MetaFrozenBunch, Bunch)):
+    """A read-only dict with attribute access"""
+
+    def __hash__(self):
+        return hash(tuple(self.items()))
+
+    def thaw(self):
+        """Returns a mutable copy"""
+        return Bunch(self)

--- a/traitlets/utils/bunch.py
+++ b/traitlets/utils/bunch.py
@@ -26,6 +26,10 @@ class EmptyMethodDescriptor(object):
 
 class Bunch(dict):
     """A dict with attribute access"""
+
+    def __contains__(self, key):
+        return hasattr(self, key)
+
     def __getattr__(self, key):
         try:
             return self.__getitem__(key)
@@ -67,3 +71,12 @@ class FrozenBunch(with_metaclass(MetaFrozenBunch, Bunch)):
     def thaw(self):
         """Returns a mutable copy"""
         return Bunch(self)
+
+    def copy(self, *args, **kwargs):
+        """Get a new instance with the given updates"""
+        new = FrozenBunch(self)
+        dict.update(new, *args, **kwargs)
+        object.__setattr__(new, "__class__", type(self))
+        return new
+
+

--- a/traitlets/utils/tests/test_bunch.py
+++ b/traitlets/utils/tests/test_bunch.py
@@ -1,10 +1,12 @@
-from ..bunch import Bunch
+import pytest
+from ..bunch import Bunch, FrozenBunch
 
 def test_bunch():
     b = Bunch(x=5, y=10)
     assert 'y' in b
     assert 'x' in b
     assert b.x == 5
+    assert b['x'] == 5
     b['a'] = 'hi'
     assert b.a == 'hi'
 
@@ -12,3 +14,24 @@ def test_bunch_dir():
     b = Bunch(x=5, y=10)
     assert 'x' in dir(b)
     assert 'keys' in dir(b)
+
+def test_frozenbunch():
+    b = FrozenBunch(x=1)
+
+    pytest.raises(TypeError, "b.y = 1")
+    pytest.raises(TypeError, "b['y'] = 1")
+    pytest.raises(TypeError, "del b['x']")
+    pytest.raises(TypeError, "del b.x")
+
+    for attr in ('clear', 'pop', 'popitem', 'setdefault', 'update'):
+        pytest.raises(AttributeError, "getattr(b, attr)")
+
+    b = FrozenBunch(clear=1)
+    assert b.clear == 1
+
+    assert isinstance(b.thaw(), Bunch)
+    assert b.thaw() == b
+
+    # frozen bunches are hashable
+    hash(b)
+    {b: 1}


### PR DESCRIPTION
The `EventReport` class provides a base class for all `FrozenBunch` instances being passed to event callbacks. At minimum, a report has a `'type'` key/attribute indicating the type of event being reported. Outside of this, it's up to subclasses to add more information.

Benefits of an `EventReport` class:
1. Uniformity can be enforced across traitlets callbacks
2. Subclasses can set which keys/attributes they contain
3. The report instances themselves are "frozen" bunches

*note: we implement a `FrozenBunch` rather than a `Bunch` class (still inherits from `dict`)

This will break any usages of Traitlets that attempt to modify event reports. Ultimately this shouldn't ever happen, but it may be a significant enough problem that the reports will need to be mutable. Making them mutable would be unfortunate though, since an error caused by a notification that accidently modified a report would be hard to trace.

At the very least it would be beneficial to implement an `EventReport` that has a `'type'`:

``` python
class EventReport(Bunch):
    def __init__(self, type, **kwargs):
        super(Bunch, self).__init__(type=type, **kwargs)
```
