### PR TITLE
trait names in Py3 are a list, not dict_key iterator

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1347,7 +1347,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         This method is just like the :meth:`trait_names` method,
         but is unbound.
         """
-        return cls.class_traits(**metadata).keys()
+        return list(cls.class_traits(**metadata))
 
     @classmethod
     def class_traits(cls, **metadata):
@@ -1400,7 +1400,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         
     def trait_names(self, **metadata):
         """Get a list of all the names of this class' traits."""
-        return self.traits(**metadata).keys()
+        return list(self.traits(**metadata))
 
     def traits(self, **metadata):
         """Get a ``dict`` of all the traits of this class.  The dictionary


### PR DESCRIPTION
Unintuitive for `trait_names` method to return a `dict_key` iterator.

Closes #240 