### PR TITLE
better errors, type checking in event handlers

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2213,6 +2213,47 @@ def test_subclass_add_observer():
     assert obj.child_called
     assert obj.parent_called
 
+
+def test_observe_iterables():
+
+    class C(HasTraits):
+        i = Integer()
+        s = Unicode()
+
+    c = C()
+    recorded = {}
+    def record(change):
+        recorded['change'] = change
+
+    # observe with names=set
+    c.observe(record, names={'i', 's'})
+    c.i = 5
+    assert recorded['change'].name == 'i'
+    assert recorded['change'].new == 5
+    c.s = 'hi'
+    assert recorded['change'].name == 's'
+    assert recorded['change'].new == 'hi'
+
+    # observe with names=custom container with iter, contains
+    class MyContainer(object):
+        def __init__(self, container):
+            self.container = container
+
+        def __iter__(self):
+            return iter(self.container)
+
+        def __contains__(self, key):
+            return key in self.container
+
+    c.observe(record, names=MyContainer({'i', 's'}))
+    c.i = 10
+    assert recorded['change'].name == 'i'
+    assert recorded['change'].new == 10
+    c.s = 'ok'
+    assert recorded['change'].name == 's'
+    assert recorded['change'].new == 'ok'
+
+
 def test_super_args():
     class SuperRecorder(object):
         def __init__(self, *args, **kwargs):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -790,6 +790,11 @@ def observe(*names, **kwargs):
     type: str, kwarg-only
         The type of event to observe (e.g. 'change')
     """
+    if not names:
+        raise TypeError("Please specify at least one trait name to observe.")
+    for name in names:
+        if name is not All and not isinstance(name, six.string_types):
+            raise TypeError("trait names to observe must be strings or All, not %r" % name)
     return ObserveHandler(names, type=kwargs.get('type', 'change'))
 
 
@@ -841,13 +846,18 @@ def validate(*names):
 
     Notes
     -----
-    Since the owner has access to the ``Hastraits`` instance via the 'owner' key,
+    Since the owner has access to the ``HasTraits`` instance via the 'owner' key,
     the registered cross validator could potentially make changes to attributes
     of the ``HasTraits`` instance. However, we recommend not to do so. The reason
     is that the cross-validation of attributes may run in arbitrary order when
     exiting the ``hold_trait_notifications` context, and such changes may not
     commute.
     """
+    if not names:
+        raise TypeError("Please specify at least one trait name to validate.")
+    for name in names:
+        if name is not All and not isinstance(name, six.string_types):
+            raise TypeError("trait names to validate must be strings or All, not %r" % name)
     return ValidateHandler(names)
 
 
@@ -889,6 +899,8 @@ def default(name):
                 return 3.0                 # ignored since it is defined in a
                                            # class derived from B.a.this_class.
     """
+    if not isinstance(name, six.string_types):
+        raise TypeError("Trait name must be a string or All, not %r" % name)
     return DefaultHandler(name)
 
 
@@ -899,7 +911,7 @@ class EventHandler(BaseDescriptor):
         return self
 
     def __call__(self, *args, **kwargs):
-        """Pass `*args` and `**kwargs` to the handler's funciton if it exists."""
+        """Pass `*args` and `**kwargs` to the handler's function if it exists."""
         if hasattr(self, 'func'):
             return self.func(*args, **kwargs)
         else:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -202,11 +202,12 @@ def parse_notifier_name(names):
     """
     if names is All or isinstance(names, six.string_types):
         return [names]
-    elif isinstance(names, (list, tuple)):
+    else:
         if not names or All in names:
             return [All]
         for n in names:
-            assert isinstance(n, six.string_types), "names must be strings"
+            if not isinstance(n, six.string_types):
+                raise TypeError("names must be strings, not %r" % n)
         return names
 
 


### PR DESCRIPTION
- raise TypeError immediately on wrong type in decorators (closes #221)
- allow any container in parse_notifier_name (closes #215, closes #219)