### PR TITLE
enable non-decorator event handler setup

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -893,16 +893,28 @@ def default(name):
 
 class EventHandler(BaseDescriptor):
 
-    def _init_call(self, func):
+    func = None
+
+    def setup_callback(self, func, force=False):
+        """Setup a new callback for the event
+
+        Use ``force=True`` to setup the callback even if one already exists
+        """
+        if self.func is not None and not force:
+            raise ValueError("a callback already exist")
         self.func = func
         return self
 
     def __call__(self, *args, **kwargs):
-        """Pass `*args` and `**kwargs` to the handler's funciton if it exists."""
-        if hasattr(self, 'func'):
+        """A proxy for the event's callback
+
+        If no callback has been setup, an attempt is made to setup one up
+        (without calling it) by passing all arguments to ``setup_callback``
+        """
+        if self.func is not None:
             return self.func(*args, **kwargs)
         else:
-            return self._init_call(*args, **kwargs)
+            return self.setup_callback(*args, **kwargs)
 
     def __get__(self, inst, cls=None):
         if inst is None:


### PR DESCRIPTION
## Summary

Enable non-decorate setup for event handlers:

+ `EventHandler._init_call(func)` goes to `EventHandler.setup_callback(func, force=False)`

This change makes it possible to register a callback without using `__call__`.

Currently, if an attempt to re-instantiate a callback with `__call__` is made, no useful error gets raise because the new callback will simply be passed to the old one as an argument.

With this change, non-decorator `EventHandler` setup should now use `setup_callback`. By default a `ValueError` is raised if there is an attempt to replace a callback. However this can be bypassed with `force=True`.

## Problem Case

```python
def callback_0(change):
	print('cb0', change)

def callback_1(change):
	print('cb1', change)

# the only public way to register
# a callback is with `__call__`
e = ObserveHandler('a', 'change')(callback_0)

# if we try to register a callback again
# on accident we get unexpected
# behavior, no errors get raised, and
# the new callback is never registered
e(callback_1)
```
```
('cb0', <function callback_1 at 0x10ad147d0>)
```