### PR TITLE
allow non-decorator event handler setup

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -893,16 +893,28 @@ def default(name):
 
 class EventHandler(BaseDescriptor):
 
-    def _init_call(self, func):
+    func = None
+
+    def setup_callback(self, func, force=False):
+        """Setup a new callback for the event
+
+        Use ``force=True`` to setup the callback even if one already exists
+        """
+        if self.func is not None and not force:
+            raise ValueError("a callback already exist")
         self.func = func
         return self
 
     def __call__(self, *args, **kwargs):
-        """Pass `*args` and `**kwargs` to the handler's funciton if it exists."""
-        if hasattr(self, 'func'):
+        """A proxy for the event's callback
+
+        If no callback has been setup, an attempt is made to setup one up
+        (without calling it) by passing all arguments to ``setup_callback``
+        """
+        if self.func is not None:
             return self.func(*args, **kwargs)
         else:
-            return self._init_call(*args, **kwargs)
+            return self.setup_callback(*args, **kwargs)
 
     def __get__(self, inst, cls=None):
         if inst is None:

--- a/traitlets/utils/docgen.py
+++ b/traitlets/utils/docgen.py
@@ -1,0 +1,184 @@
+import inspect
+from traitlets import HasTraits, TraitType
+from six import with_metaclass
+
+# - - - - - - - - - - - - - -
+# Document Section Descriptor
+# - - - - - - - - - - - - - -
+
+class DocumentSection(object):
+
+    source = None
+    _fetch = None
+    section = None
+    _parse = None
+
+    def __init__(self, source):
+        self.source = source
+
+    @staticmethod
+    def fetch(source):
+        return DocumentSection(source)
+
+    def __call__(self, func):
+        self._fetch = func
+
+    def class_init(self, cls, name):
+        self.this_class = cls
+        self.section = name
+
+    def parse(self, func):
+        self._parse = func
+        return self
+
+    def __set__(self, inst, obj):
+        inst._rep_content[self.section] = self._fetch(inst, getattr(obj, self.source))
+        inst._str_content[self.section] = self._parse(inst, inst._content[self.section])
+
+    def __get__(self, inst, cls=None):
+        if inst is None:
+            return self
+        else:
+            return isnt._str_content[self.section]
+
+    @property
+    def incomplete(self):
+        return (callable(self._fetch) and callable(self._parse)
+            and None not in (self.source, self.section))
+
+    @staticmethod
+    def new(source, getter, parser):
+        return DocumentSection(source)(getter).parser(parser)
+
+
+# simple abbreviated decorator name
+class docsec(DocumentSection): pass
+
+# - - - - - - - - - - - - - -
+# DocLog Object and Metaclass
+# - - - - - - - - - - - - - -
+
+class MetaDocLog(type):
+
+    def __init__(cls, *args):
+        super(MetaDocLog, cls).__init__(*args)
+        for k, v in inspect.getmembers(cls):
+            if isinstance(v, DocumentSection):
+                v.class_init(cls, k)
+                if v.incomplete:
+                    raise RuntimeError("Encountered an incomplete"
+                        " document section defition for '%s'" % k)
+
+
+class DocLog(with_metaclass(MetaDocLog, object)):
+
+    _logs_type = None
+    _from_class = False
+    # public attribute with parsed content
+    content = None
+    # private attribute with raw content
+    _content = {}
+
+    def __init__(self, obj):
+        cls = obj if inspect.isclass(obj) else obj.__class__
+        if self._type is not None and not issubclass(cls, self._type):
+            raise TypeError("A '%s' makes autodocs for '%s', not %r"
+                        % (self.__class__.__name__, self._type.__name__, obj))
+        self.obj = cls if self._from_class else obj
+
+        self._rep_content = {}
+        self._str_content = {}
+
+        # generate docs
+        self._docgen()
+
+    def __iter__(self):
+        return iter(self._str_content)
+
+    def __len__(self):
+        return len(self._str_content)
+
+    def __repr__(self):
+        return self.__class__.__name__ + '(' + repr(self._rep_content) + ')'
+
+    def __str__(self):
+        return self.__class__.__name__ + '(' + str(self._str_content) + ')'
+
+    def _docgen(self):
+        """Generate the docs"""
+        for s in self.document_sections():
+            setattr(self, s, getattr(self.obj, s))
+
+    @classmethod
+    def sections(cls):
+        return dict([member for member in getmembers(cls) if
+                    isinstance(member[1], DocumentSection)])
+
+    @property
+    def content(self):
+        return self._str_content.copy()
+
+# - - - - - - - - - - - - -
+# TraitType DocLog Objects
+# - - - - - - - - - - - - -
+
+class TraitTypeDocLog(DocLog):
+
+    _logs_type = TraitType
+
+    def docgen(self):
+        self._content['name'] = self.obj.name
+        self._content['info'] = self.obj.info()
+
+        metadata = self.obj.metadata.copy()
+        self._content['help'] = metadata.pop('help')
+        self._content['metadata'] = metadata
+
+# - - - - - - - - - - - -
+# HasTraits DocLog Object
+# - - - - - - - - - - - -
+
+class MetaHasTraitsDocLog(MetaDocLog):
+
+    ttype_doclogs = {TraitType: TraitTypeDocLog}
+
+    @classmethod
+    def _get_log_obj(mcls, trait):
+        for c in trait.__class__.mro():
+            if c in mcls.ttype_doclogs:
+                return mcls.ttype_doclogs[c](trait)
+        # returns None if no log object
+        # exists for the given trait
+        return None
+
+    @classmethod
+    def _parser(mcls, inst, trait):
+        # simple proxy for log obj getter
+        return mcls._get_log_obj(trait)
+
+    @classmethod
+    def _fetcher(mcls, inst, trait):
+        return trait
+
+    def __new__(mcls, name, bases, classdict):
+    	if '_logs_type' in classdict:
+    		cls = classdict['_logs_type']
+    	else:
+    		cls = None
+    		for c in bases:
+    			if hasattr(c, '_logs_type'):
+    				cls = getattr(c, '_logs_type')
+    	if not issubclass(cls, HasTraits):
+    		raise TypeError("The attribute '_logs_type' must be a 'HasTraits' subclass")
+        super(MetaHasTraitsDocLog, mcls).__new__(mcls, cls.__name__ + 'DocLog',
+            (DocLog,), dict([(n, docsec.new(n, mcls._fetcher, mcls._parser))
+            for n in cls.class_trait_names()]))
+
+
+class HasTraitsDocLog(with_metaclass(MetaHasTraitsDocLog, DocLog)): pass
+
+
+def trait_documentation(obj, name=None):
+    if name is not None:
+        cls = obj if inspect.isclass(obj) else obj.__class__
+        HasTraitsDocLog.ttype_doclogs[getattr(cls,)]


### PR DESCRIPTION
## Summary

Enable non-decorate setup for event handlers:

+ `EventHandler._init_call(func)` goes to `EventHandler.setup_callback(func, force=False)`

This change makes it possible to register a callback without using `__call__`.

Currently, if an attempt to re-instantiate a callback with `__call__` is made, no useful error gets raise because the new callback will simply be passed to the old one as an argument.

With this change, non-decorator `EventHandler` setup should now use `setup_callback`. By default a `ValueError` is raised if there is an attempt to replace a callback. However this can be bypassed with `force=True`.

## Problem Case

```python
def callback_0(change):
	print('cb0', change)

def callback_1(change):
	print('cb1', change)

# the only public way to register
# a callback is with `__call__`
e = ObserveHandler('a', 'change')(callback_0)

# if we try to register a callback again
# on accident we get unexpected
# behavior, no errors get raised, and
# the new callback is never registered
e(callback_1)
```
```
('cb0', <function callback_1 at 0x10ad147d0>)
```

## Solution

```python
def callback_0(change):
	print('cb0', change)

def callback_1(change):
	print('cb1', change)

# a public callback setup method is available
e = ObserveHandler('a', 'change').setup_callback(callback_0)

# try to register a callback again
# on accident will now raise *if
# `register_callback` is used*
.setup_callback(callback_1)
```