### PR TITLE
[WIP] Automatic Documentation

### DIFF
--- a/traitlets/doclogs.py
+++ b/traitlets/doclogs.py
@@ -1,0 +1,325 @@
+import six
+
+from .traitlets import *
+from utils.docgen import (DocLog, DocLogMap,
+	Content, content, Template, ThisTemplate)
+
+
+if six.PY3:
+    def copy_func(f, name=None):
+        return types.FunctionType(f.__code__, f.__globals__,
+        	name or f.__name__, f.__defaults__, f.__closure__)
+else:
+    def copy_func(f, name=None):
+        return types.FunctionType(f.func_code, f.func_globals,
+        	name or f.func_name, f.func_defaults, f.func_closure)
+
+def write_docs_to_class(cls, docs):
+    """Write traitlet documentation for this class to __init__"""
+    im_func = copy_func(cls.__init__.im_func)
+    im_func.__doc__ = trim_docstring(im_func.__doc__) + "\n\n" + docs
+    cls.__init__ = types.MethodType(im_func, None, cls)
+
+
+def trim_docstring(docstring):
+	if not docstring:
+		return ''
+	# Convert tabs to spaces (following the normal Python rules)
+	# and split into a list of lines:
+	lines = docstring.expandtabs().splitlines()
+	# Determine minimum indentation (first line doesn't count):
+	indent = sys.maxint
+	for line in lines[1:]:
+		stripped = line.lstrip()
+		if stripped:
+			indent = min(indent, len(line) - len(stripped))
+	# Remove indentation (first line is special):
+	trimmed = [lines[0].strip()]
+	if indent < sys.maxint:
+		for line in lines[1:]:
+			trimmed.append(line[indent:].rstrip())
+	# Strip off trailing and leading blank lines:
+	while trimmed and not trimmed[-1]:
+		trimmed.pop()
+	while trimmed and not trimmed[0]:
+		trimmed.pop(0)
+	# Return a single string:
+	return '\n'.join(trimmed)
+
+def full_type_name(obj):
+	if not inspect.isclass(obj):
+		klass = obj.__class__
+	else:
+		klass = obj
+	m_n = klass.__module__
+	if m_n != "__main__":
+		return m_n + '.' + klass.__name__
+	else:
+		return klass.__name__
+
+
+class BaseDescriptorDocLog(DocLog):
+
+	template = Template()
+
+	logs_type = BaseDescriptor
+
+	_from_instances = True
+	name = Content('name')
+
+class TraitDocLog(BaseDescriptorDocLog):
+
+	logs_type = TraitType
+
+	read_only = Content('read_only')
+	allow_none = Content('allow_none')
+
+	template = ThisTemplate().extend([
+		"{name} : {info}",
+		"    :help: {help}",
+		"    :read only: {read_only}",
+		"    :allow none: {allow_none}",
+		"",
+		"    **trait metadata:**",
+		"        {metadata}",
+		"",
+		"    **event handlers:**",
+		"        {events}"
+		])
+
+	@content
+	def info(self, source):
+		return source.info()
+
+	@content('help')
+	def help(self, trait):
+		return self.metadata.pop('help', None)
+
+	@content('default_value')
+	def default_value(self, value):
+		if 'default_value' in self.metadata:
+			# pop from given metadata if present
+			return self.metadata.pop('default_value')
+		else:
+			return value
+
+	@content("metadata")
+	def metadata(self, metadata):
+		return metadata.copy()
+
+	@metadata.format
+	def metadata(self, value):
+		series = []
+		for k, v in self.metadata.items():
+			series.append('* %s: %r' % (k, v))
+		return '\n'.join(series) or None
+
+	@content
+	def events(self, source):
+		series = []
+		if isinstance(self.parent, HasTraitsDocLog):
+			for e in self.parent.events.values():
+				if source.name in e.trait_names:
+					series.append("* " + e.document())
+		return '\n'.join(series) or None
+
+
+class EventHandlerDocLog(BaseDescriptorDocLog):
+
+	logs_type = EventHandler
+
+	template = Template(":meth:`{event_owner}.{name}` : {info}")
+	
+	@content
+	def event_owner(self, source):
+		return full_type_name(source.this_class)
+	
+	@content
+	def info(self, source):
+		return source.info()
+
+	@content
+	def trait_names(self, source):
+		try:
+			return source.trait_names
+		except:
+			return [source.trait_name]
+
+
+class ClassBasedTraitDocLog(TraitDocLog):
+
+	logs_type = ClassBasedTraitType
+	klass = Content('klass')
+
+	@klass.format
+	def klass(self, content):
+		return (full_type_name(content)
+			if inspect.isclass(content)
+			else content)
+
+class TypeTraitDocLog(ClassBasedTraitDocLog):
+
+	logs_type = Type
+
+	template = ThisTemplate().insert(
+		2, "    :subclass of: {klass}")
+
+class InstanceTraitDocLog(TraitDocLog):
+
+	logs_type = Instance
+	klass = Content('klass')
+
+	template = ThisTemplate().insert(
+		2, "    :instance of: {klass}")
+
+class UnionTraitDocLog(TraitDocLog):
+
+	logs_type = Union
+
+# not stored in trait_doc_log_map
+class NumberTraitDocLog(TraitDocLog):
+
+	template = ThisTemplate().insert(
+		2, "    :range: [{minimum}, {maximum}]")
+
+	minimum = Content('min')
+	@content('min')
+	def minimum(self, m):
+		if m is None:
+			return '-inf'
+		else:
+			return m
+
+	@content('max')
+	def maximum(self, m):
+		if m is None:
+			return 'inf'
+		else:
+			return m
+
+class IntTraitDocLog(NumberTraitDocLog):
+
+	logs_type = Int
+
+class FloatTraitDocLog(NumberTraitDocLog):
+
+	logs_type = Float
+
+class EnumTraitDocLog(TraitDocLog):
+
+	logs_type = Enum
+
+	template = ThisTemplate().insert(
+		2, "    :valid input: {values}")
+
+	values = Content('values')
+
+class ContainerTraitDocLog(ClassBasedTraitDocLog):
+
+	logs_type = Container
+
+	template = ThisTemplate().insert(
+		2, "    :valid input: {trait_info}")
+
+	@content('_trait')
+	def trait_info(self, trait):
+		return None if trait is None else traitlet_doclog_mapping(trait)
+
+	@trait_info.format
+	def trait_info(self, doclog):
+		return 'any' if doclog is None else doclog.info
+
+class ListTraitDocLog(ContainerTraitDocLog):
+
+	logs_type = List
+
+	template = ThisTemplate().insert(2, (
+		"    :length range: [{minimum_"
+		"length}, {minimum_length}]"))
+
+	@content('_minlen')
+	def minimum_length(self, l):
+		if l is None:
+			return 0
+		else:
+			return l
+
+	@content('_maxlen')
+	def minimum_length(self, l):
+		if l is None:
+			return 'inf'
+		else:
+			return l
+
+class TupleTraitDocLog(ContainerTraitDocLog):
+
+	template = ThisTemplate().insert(2,
+		"    :elements: {traits}")
+
+	trait = None
+
+	@content
+	def traits(self, traits):
+		return [trait_doclog_mapping(t) for t in traits]
+
+	@traits.format
+	def traits(self, doclogs):
+		series = []
+		for dl in doclogs:
+			series.append(dl.info)
+		return str(series)
+
+class DictTraitDocLog(Instance):
+
+	template = ThisTemplate().insert(2, "    valid types: {trait_info}")
+
+	@content('_trait')
+	def trait_info(self, trait):
+		return trait_doclog_mapping(trait)
+
+	@trait_info.format
+	def trait_info(self, doclog):
+		return doclog.info
+
+class UseEnumTraitDoclog(TraitDocLog):
+	# unfinished
+
+	enum_class = Content('enum_class')
+	name_prefix = Content('name_prefix')
+
+# ----------------------------------------------------------------------------
+# HasTraits DocLog Object
+# ----------------------------------------------------------------------------
+
+traitlet_doclog_mapping = DocLogMap(
+	[v for v in globals().values()
+	if inspect.isclass(v) and
+	issubclass(v, BaseDescriptorDocLog)
+	and 'logs_type' in v.__dict__])
+
+class HasTraitsDocLog(DocLog):
+
+	_from_classes = True
+
+	template = ThisTemplate().extend(["{traits}"])
+
+	def _members_to_doclogs(self, member_type):
+		return {name: traitlet_doclog_mapping(member, parent=self)
+			for name, member in inspect.getmembers(self.source)
+			if isinstance(member, member_type)}
+
+	@content(None)
+	def traits(self, source):
+		return self._members_to_doclogs(TraitType)
+
+	@traits.format
+	def traits(self, content):
+		if content:
+			header = "Traits of ``%s`` Instances" % full_type_name(self.source)
+			header += "\n" + "-"*len(header) + "\n"
+			return header + "\n\n".join(dl.document() for dl in content.values())
+		return ""
+
+	@content(None)
+	def events(self, source):
+		return self._members_to_doclogs(EventHandler)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -766,6 +766,10 @@ class MetaHasTraits(MetaHasDescriptors):
     def setup_class(cls, classdict):
         cls._trait_default_generators = {}
         super(MetaHasTraits, cls).setup_class(classdict)
+        if len(cls.class_trait_names()):
+            from .doclogs import HasTraitsDocLog, write_docs_to_class
+            cls._doclog = HasTraitsDocLog(cls)
+            write_docs_to_class(cls, cls._doclog.document())
 
 
 def observe(*names, **kwargs):
@@ -893,6 +897,8 @@ def default(name):
 
 class EventHandler(BaseDescriptor):
 
+    info_text = None
+
     def _init_call(self, func):
         self.func = func
         return self
@@ -909,8 +915,14 @@ class EventHandler(BaseDescriptor):
             return self
         return types.MethodType(self.func, inst)
 
+    def info(self):
+        """Return some helpful info"""
+        return self.info_text
+
 
 class ObserveHandler(EventHandler):
+
+    info_text = "observes changes"
 
     def __init__(self, names, type):
         self.trait_names = names
@@ -922,6 +934,8 @@ class ObserveHandler(EventHandler):
 
 class ValidateHandler(EventHandler):
 
+    info_text = "validates values"
+
     def __init__(self, names):
         self.trait_names = names
 
@@ -930,6 +944,8 @@ class ValidateHandler(EventHandler):
 
 
 class DefaultHandler(EventHandler):
+
+    info_text = "default value generator"
 
     def __init__(self, name):
         self.trait_name = name
@@ -974,6 +990,8 @@ class HasDescriptors(six.with_metaclass(MetaHasDescriptors, object)):
 
 
 class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
+
+    _doclog = None
 
     def setup_instance(self, *args, **kwargs):
         self._trait_values = {}

--- a/traitlets/utils/docgen.py
+++ b/traitlets/utils/docgen.py
@@ -1,0 +1,374 @@
+import re
+import sys
+import inspect
+import types
+
+from six import with_metaclass
+
+import string
+
+_vformat = string.Formatter().vformat
+
+def format_map(string, *args, **kwargs):
+	return _vformat(string, args, kwargs)
+
+# ----------------------------------------------------------------------------
+# Document Section Descriptor
+# ----------------------------------------------------------------------------
+
+class DocLogMember(object):
+
+	def class_init(self, cls, name):
+		self.this_class = cls
+		self.name = name
+
+
+class Content(DocLogMember):
+
+	source = None
+	content = None
+	_renderer = None
+	_format_content = None
+
+	def __init__(self, source=None):
+		if isinstance(source, types.FunctionType):
+			self._renderer = source
+			self.source = None
+		elif source is not None:
+			self.source = source
+
+	def __call__(self, func):
+		self._renderer = func
+		return self
+
+	def __get__(self, inst, cls=None):
+		if inst is None:
+			return self
+		elif self.content is None:
+			raise RuntimeError("Improper metaclass setup for %s descriptor '%s'"
+							   " on type object %s" % (self.__class__.__name__,
+								self.name, inst.__class__.__name__))
+		elif self.content in inst._source_content:
+			return inst._source_content[self.content]
+		elif self.source is None:
+			value = self._renderer(inst, inst.source)
+		else:
+			value = getattr(inst.source, self.source, None)
+			if self._renderer is not None:
+				value = self._renderer(inst, value)
+		inst._source_content[self.content] = value
+		return value
+
+	def format(self, func):
+		self._format_content = func
+		return self
+
+	def format_content(self, inst):
+		if self._format_content is None:
+			return str(getattr(inst, self.content))
+		else:
+			return str(self._format_content(inst, getattr(inst, self.content)))
+
+	def class_init(self, cls, name):
+		super(Content, self).class_init(cls, name)
+		# a more informative attr
+		self.content = self.name
+
+
+def content(source):
+	"""Simple decorator returning a Content with a parser"""
+	return Content(source)
+
+# ----------------------------------------------------------------------------
+# DocLog Template Classes
+# ----------------------------------------------------------------------------
+
+class TemplateUtils(object):
+
+	tab = 4
+
+	def __setitem__(self, index, value):
+		if not isinstance(index, slice):
+			value = Line(value)
+		self._lines[index] = value
+
+	def __delitem__(self, index):
+		del self._lines[index]
+
+	def _to_line(self, lines):
+		out = []
+		for l in lines:
+			if isinstance(l, Line):
+				out.append(l)
+			else:
+				out.extend(Line(l) for l in l.split('\n'))
+		return out
+
+	def setitem(self, index, value):
+		self[index] = value
+		return self
+
+	def delitem(self, index):
+		del self[index]
+		return self
+
+	def extend(self, lines):
+		self._lines.extend(self._to_line(lines))
+		return self
+
+	def insert(self, index, *lines):
+		self[index:index] = self._to_line(lines)
+		return self
+
+	def replace(self, index, *lines):
+		self[index:len(lines)] = self._to_line(lines)
+		return self
+
+
+class Template(TemplateUtils):
+
+	def __init__(self, *lines):
+		self._lines = self._to_line(lines)
+
+	def __repr__(self):
+		return '\n'.join(repr(l) for l in self._lines)
+
+	def __iter__(self):
+		return iter(self._lines)
+
+class Line(object):
+
+	# spaces per tab
+	space2tab = 4
+
+	def __init__(self, text, tab=4):
+		self.tab, spaces = 0, 0
+		for char in text:
+			if char == '\t':
+				self.tab += 1
+			elif char == ' ':
+				spaces += 1
+			else:
+				break
+		self.tab += spaces//self.space2tab
+		self.fields = []
+		for match in re.findall(r'{([^{}]*?)}', text):
+			for i in range(len(match)):
+				if match[i] in ".[!:":
+					break
+			self.fields.append(match[:i+1])
+		self.text = text
+
+	def __repr__(self):
+		return self.text
+
+
+class ThisTemplate(type("ThisTemplateUtils",
+	(DocLogMember,), {k: (lambda k=k:
+	lambda self, *args, **kwargs: None if
+	self._actions.append([k, args, kwargs]) else self)()
+	for k, v in TemplateUtils.__dict__.items()
+	if isinstance(v, types.FunctionType)})):
+
+	def class_init(self, cls, name):
+		for c in cls.mro()[1:]:
+			last = getattr(c, name, None)
+			if isinstance(last, Template):
+				template = Template(*last)
+				break
+		else:
+			template = Template()
+		for a in self._actions:
+			# apply all postponed template actions
+			getattr(template, a[0])(*a[1], **a[2])
+		setattr(cls, name, template)
+
+	def __init__(self):
+		self._actions = []
+
+	__iter__ = None
+	_to_line = None
+
+
+# ----------------------------------------------------------------------------
+# DocLog Object and Metaclass
+# ----------------------------------------------------------------------------
+
+
+class DocLogBase(object):
+
+	# attributes that cannot
+	# be Content instances
+	parent = None
+	children = None
+	logs_type = None
+	template = None
+
+	_from_instances = None
+	_source_content = None
+
+class MetaDocLog(type):
+
+	def __new__(mcls, name, bases, classdict):
+		for n in dir(DocLogBase):
+			if not name.startswith("__") and isinstance(classdict.get(n), Content):
+				raise RuntimeError("The attribute '%s' cannot be Content" % n)
+		return super(MetaDocLog, mcls).__new__(mcls, name, bases, classdict)
+
+	def __init__(cls, name, bases, classdict):
+		"""Simple metaclass for assigning content names"""
+		for k, v in classdict.items():
+			if isinstance(v, DocLogMember):
+				v.class_init(cls, k)
+
+class DocLog(with_metaclass(MetaDocLog, DocLogBase)):
+
+	def __init__(self, source, parent=None):
+		# make parent-child link
+		self.children = []
+		if parent is not None:
+			if not isinstance(parent, DocLog):
+				raise TypeError("parent must be a DocLog instance")
+			parent.children.append(self)
+			self.parent = parent
+
+		# handle the source type
+		if self._from_instances:
+			if self.logs_type is not None and not isinstance(source, self.logs_type):
+				TypeError("A '%s' makes autodocs for '%s' instances, not %r"
+					% (self.__class__.__name__, self.logs_type.__name__, source))
+		else:
+			if not inspect.isclass(source):
+				source = source.__class__
+			if self.logs_type is not None and not issubclass(source, self.logs_type):
+				TypeError("A '%s' makes autodocs for '%s' subclasses, not %r"
+					% (self.__class__.__name__, self.logs_type.__name__, source))
+		self.source = source
+		self._source_content = {}
+
+	def __iter__(self):
+		return iter(self.content)
+
+	def __len__(self):
+		return len(self.content)
+
+	def __str__(self):
+		return self.__class__.__name__ + "(%s)" % str(list(self))[1:-1]
+
+	@classmethod
+	def content_members(cls):
+		return dict([member for member in inspect.getmembers(cls)
+						if isinstance(member[1], Content)])
+
+	@property
+	def content(self):
+		content_members = self.content_members()
+		if len(self._source_content) != len(content_members):
+			c = {}
+			for name in content_members:
+				c[name] = getattr(self, name)
+		else:
+			c = self._source_content.copy()
+		return c
+
+	def reset(self, *content_members):
+		"""Force all, or the given content members, to be recomposed"""
+		if self.template is None:
+			raise ValueError("Type object '%s' has no defined"
+						" template" % self.__class__.__name__)
+		if len(content_members):
+			for s in secitons:
+				del self._source_content[s]
+		else:
+			self._source_content = {}
+
+	def formated_content(self, name, tabs=0):
+		return self.content_members()[name].format_content(self, tabs)
+
+	def document(self):
+		"""Return a string of merged, and content filled sections"""
+		lines = []
+		members = self.content_members()
+		for line in self.template:
+			d = {}
+			for f in line.fields:
+				text = members[f].format_content(self)
+				tabbed = text.replace('\n', '\n'+' '*(line.tab*line.space2tab))
+				d[f] = FormatRepr(getattr(self, f), tabbed)
+			lines.append(line.text.format(**d))
+		return '\n'.join(lines)
+
+
+class FormatRepr(object):
+
+	def __init__(self, raw, doc=None):
+		if doc is None:
+			doc = str(raw)
+		self._raw = raw
+		self._doc = doc
+
+	def __getitem__(self, key):
+		return self._raw[key]
+
+	def __getattr__(self, key):
+		return getattr(self._raw, key)
+
+	def __repr__(self):
+		return self._doc
+
+
+class DocLogMap(object):
+
+	def __init__(self, doclog_types):
+		self._d = {}
+		for dlt in doclog_types:
+			if not inspect.isclass(dlt) and not issubclass(dlt, DocLog):
+				raise TypeError("Expected subclasses of DocLog, not %r" % dlt)
+			if 'logs_type' not in dlt.__dict__:
+				raise TypeError("The 'logs_type' attribute is not "
+					"explicitely defined for '%s'" % dlt.__name__)
+			self._d[self._to_name(dlt.logs_type)] = dlt
+
+	def __iter__(self):
+		return iter(self._d)
+
+	def __call__(self, obj, *args, **kwargs):
+		"""A factory returning a correctly mapped DocLog instance"""
+		return self[obj](obj, *args, **kwargs)
+
+	def __getitem__(self, obj):
+		for c in self._to_class(obj).mro():
+			dlt = self._get(c)
+			if dlt is not None:
+				return dlt
+		else:
+			raise KeyError(repr(obj))
+
+	def get(self, obj, default=None):
+		for c in self._to_class(obj).mro():
+			dlt = self._get(c)
+			if dlt is not None:
+				return dlt
+		else:
+			return default
+
+	def _get(self, cls):
+		return self._d.get(self._to_name(cls))
+
+	@staticmethod
+	def _to_class(obj):
+		if inspect.isclass(obj):
+			return obj
+		else:
+			return obj.__class__
+
+	@staticmethod
+	def _to_name(key):
+		if inspect.isclass(key):
+			name = key.__module__ + '.' + key.__name__
+		else:
+			TypeError("Expected a class")
+		return name
+
+	def __repr__(self):
+		return repr(self._d)


### PR DESCRIPTION
Closes #130
Alternatives: #267 #131 

Adds a robust set of tools for rendering the content of an instance or class into a readable document.

This is accomplished with `DocLog`, `Content`, and `Template` objects. While each `DocLog` contains one template, it will hold many content attributes that fill the undefined fields of the template. The following example shows how these objects work together to document the name of a class or instance:

``` python
class GenericDocLog(DocLog):
    template = Template("{name}")
    # pulls the `__name__` attribute
    name = Content("__name__")

# by default input values are converted to classes
assert GenericDocLog(1).document() == "int"
assert GenericDocLog(int).document() == "int"
```

A series of `DocLog` types following this general format allow for detailed `HasTraits` documentation:

``` python
class A(HasTraits):
    i = Int(allow_none=True, default_value=1)
    j = Any(help='some help text for j').tag( data={'x':1}, info="foo")

    def __init__(self, *args, **kwargs):
        """The constructor for the class

        More details about the constructor"""
        pass

    @default('j')
    def h(self): pass

    @validate('j')
    def g(self, commit):
        return commit['value']

    @observe('i', 'j')
    def f(self, change):
        pass

print(help(A.__init__))
```

```
The constructor for the class

More details about the constructor

Traits of ``A`` Instances
-------------------------
i : an int
    :help: None
    :range: [-inf, inf]
    :read only: False
    :allow none: True

    **trait metadata:**
        None

    **event handlers:**
        * :meth:`A.f` : observes changes

j : any value
    :help: some help text for j
    :read only: False
    :allow none: False

    **trait metadata:**
        * info: 'foo'
        * data: {'x': 1}

    **event handlers:**
        * :meth:`A.h` : default value generator
        * :meth:`A.g` : validates values
        * :meth:`A.f` : observes changes
```
## To Do:
- finalize core features
- write tests for them
- more gracefully handle failures
- thoroughly document and comment
