### PR TITLE
Bounded numeric traits

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1174,6 +1174,28 @@ class TestLong(TraitTestBase):
         self.assertEqual(type(self.obj.value), long)
 
 
+class MinBoundLongTrait(HasTraits):
+    value = Long(99 if six.PY3 else long(99), min=5)
+
+class TestMinBoundLong(TraitTestBase):
+    obj = MinBoundLongTrait()
+
+    _default_value = 99 if six.PY3 else long(99)
+    _good_values   = [5, 10L]
+    _bad_values    = [4, -10L]
+
+
+class MaxBoundLongTrait(HasTraits):
+    value = Long(5 if six.PY3 else long(5), max=10)
+
+class TestMaxBoundLong(TraitTestBase):
+    obj = MaxBoundLongTrait()
+
+    _default_value = 5 if six.PY3 else long(5)
+    _good_values   = [10, -2L]
+    _bad_values    = [11, 20L]
+
+
 class IntegerTrait(HasTraits):
     value = Integer(1)
 
@@ -1190,6 +1212,28 @@ class TestInteger(TestLong):
 
         self.obj.value = long(100)
         self.assertEqual(type(self.obj.value), int)
+
+
+class MinBoundIntegerTrait(HasTraits):
+    value = Integer(5, min=3)
+
+class TestMinBoundInteger(TraitTestBase):
+    obj = MinBoundIntegerTrait()
+
+    _default_value = 5
+    _good_values   = 3, 20
+    _bad_values    = [2, -10]
+
+
+class MaxBoundIntegerTrait(HasTraits):
+    value = Integer(1, max=3)
+
+class TestMaxBoundInteger(TraitTestBase):
+    obj = MaxBoundIntegerTrait()
+
+    _default_value = 1
+    _good_values   = 3, -2
+    _bad_values    = [4, 10]
 
 
 class FloatTrait(HasTraits):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1315,7 +1315,8 @@ class TestCFloat(TraitTestBase):
 
     _default_value = 99.0
     _good_values   = [10, 10.0, 10.5, '10.0', '10', '-10', '10.0', u'10']
-    _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j]
+    _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j,
+                      200.1, '200.1']
 
     def coerce(self, v):
         return float(v)

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -18,7 +18,7 @@ from pytest import mark
 
 from traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
+    Int, Long, CLong, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
@@ -1194,6 +1194,21 @@ class TestMaxBoundLong(TraitTestBase):
     _default_value = 5 if six.PY3 else long(5)
     _good_values   = [10, -2]
     _bad_values    = [11, 20]
+
+
+class CLongTrait(HasTraits):
+    value = CLong('5')
+
+class TestCLong(TraitTestBase):
+    obj = CLongTrait()
+
+    _default_value = 5 if six.PY3 else long(5)
+    _good_values   = ['10', '-10', u'10', u'-10', 10, 10.0, -10.0, 10.1]
+    _bad_values    = ['ten', u'ten', [10], {'ten': 10},(10,),
+                      None, 1j, '10.1', u'10.1']
+
+    def coerce(self, n):
+        return int(n) if six.PY3 else long(n)
 
 
 class IntegerTrait(HasTraits):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -18,9 +18,9 @@ from pytest import mark
 
 from traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, CInt, Long, CLong, Integer, Float, Complex, Bytes, Unicode, TraitError,
-    Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
-    ObjectName, DottedObjectName, CRegExp, link, directional_link,
+    Int, CInt, Long, CLong, Integer, Float, CFloat, Complex, Bytes, Unicode,
+    TraitError, Union, All, Undefined, Type, This, Instance, TCPAddress,
+    List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
     observe_compat, BaseDescriptor, HasDescriptors,
 )
@@ -1303,6 +1303,22 @@ class TestFloat(TraitTestBase):
                       u'-10', u'10L', u'-10L', u'10.1', u'-10.1', 201.0]
     if not six.PY3:
         _bad_values.extend([long(10), long(-10)])
+
+
+class CFloatTrait(HasTraits):
+
+    value = CFloat('99.0', max=200.0)
+
+class TestCFloat(TraitTestBase):
+
+    obj = CFloatTrait()
+
+    _default_value = 99.0
+    _good_values   = [10, 10.0, 10.5, '10.0', '10', '-10', '10.0', u'10']
+    _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j]
+
+    def coerce(self, v):
+        return float(v)
 
 
 class ComplexTrait(HasTraits):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1181,8 +1181,8 @@ class TestMinBoundLong(TraitTestBase):
     obj = MinBoundLongTrait()
 
     _default_value = 99 if six.PY3 else long(99)
-    _good_values   = [5, 10L]
-    _bad_values    = [4, -10L]
+    _good_values   = [5, 10]
+    _bad_values    = [4, -10]
 
 
 class MaxBoundLongTrait(HasTraits):
@@ -1192,8 +1192,8 @@ class TestMaxBoundLong(TraitTestBase):
     obj = MaxBoundLongTrait()
 
     _default_value = 5 if six.PY3 else long(5)
-    _good_values   = [10, -2L]
-    _bad_values    = [11, 20L]
+    _good_values   = [10, -2]
+    _bad_values    = [11, 20]
 
 
 class IntegerTrait(HasTraits):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1163,6 +1163,17 @@ class TestCInt(TraitTestBase):
         return int(n)
 
 
+class MinBoundCIntTrait(HasTraits):
+    value = CInt('5', min=3)
+
+class TestMinBoundCInt(TestCInt):
+    obj = MinBoundCIntTrait()
+
+    _default_value = 5
+    _good_values   = [3, 3.0, '3']
+    _bad_values    = [2.6, 2, -3, -3.0]
+
+
 class LongTrait(HasTraits):
 
     value = Long(99 if six.PY3 else long(99))
@@ -1224,6 +1235,17 @@ class TestCLong(TraitTestBase):
 
     def coerce(self, n):
         return int(n) if six.PY3 else long(n)
+
+
+class MaxBoundCLongTrait(HasTraits):
+    value = CLong('5', max=10)
+
+class TestMaxBoundCLong(TestCLong):
+    obj = MaxBoundCLongTrait()
+
+    _default_value = 5 if six.PY3 else long(5)
+    _good_values   = [10, '10', 10.3]
+    _bad_values    = [11.0, '11']
 
 
 class IntegerTrait(HasTraits):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -18,7 +18,7 @@ from pytest import mark
 
 from traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, Long, CLong, Integer, Float, Complex, Bytes, Unicode, TraitError,
+    Int, CInt, Long, CLong, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
@@ -1146,6 +1146,21 @@ class TestInt(TraitTestBase):
                       u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', -200]
     if not six.PY3:
         _bad_values.extend([long(10), long(-10), 10*sys.maxint, -10*sys.maxint])
+
+
+class CIntTrait(HasTraits):
+    value = CInt('5')
+
+class TestCInt(TraitTestBase):
+    obj = CIntTrait()
+
+    _default_value = 5
+    _good_values   = ['10', '-10', u'10', u'-10', 10, 10.0, -10.0, 10.1]
+    _bad_values    = ['ten', u'ten', [10], {'ten': 10},(10,),
+                      None, 1j, '10.1', u'10.1']
+
+    def coerce(self, n):
+        return int(n)
 
 
 class LongTrait(HasTraits):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1869,9 +1869,11 @@ class CInt(Int):
 
     def validate(self, obj, value):
         try:
-            return int(value)
+            value = int(value)
         except:
             self.error(obj, value)
+        return _validate_bounds(self, obj, value)
+
 
 if six.PY2:
     class Long(TraitType):
@@ -1904,9 +1906,10 @@ if six.PY2:
 
         def validate(self, obj, value):
             try:
-                return long(value)
+                value = long(value)
             except:
                 self.error(obj, value)
+            return _validate_bounds(self, obj, value)
 
 
     class Integer(TraitType):
@@ -1957,7 +1960,7 @@ class Float(TraitType):
                  allow_none=None, **kwargs):
         self.min = kwargs.pop('min', -float('inf'))
         self.max = kwargs.pop('max', float('inf'))
-        super(Float, self).__init__(default_value=default_value, 
+        super(Float, self).__init__(default_value=default_value,
                                     allow_none=allow_none, **kwargs)
 
     def validate(self, obj, value):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1968,11 +1968,7 @@ class Float(TraitType):
             value = float(value)
         if not isinstance(value, float):
             self.error(obj, value)
-        if value > self.max or value < self.min:
-            raise TraitError("The value of the '%s' trait of %s instance should "
-                             "be between %s and %s, but a value of %s was "
-                             "specified" % (self.name, class_of(obj),
-                                            self.min, self.max, value))
+        value = _validate_bounds(self, obj, value)
         return value
 
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1860,8 +1860,7 @@ class Int(TraitType):
     def validate(self, obj, value):
         if not isinstance(value, int):
             self.error(obj, value)
-        value = _validate_bounds(self, obj, value)
-        return value
+        return _validate_bounds(self, obj, value)
 
 
 class CInt(Int):
@@ -1968,8 +1967,7 @@ class Float(TraitType):
             value = float(value)
         if not isinstance(value, float):
             self.error(obj, value)
-        value = _validate_bounds(self, obj, value)
-        return value
+        return _validate_bounds(self, obj, value)
 
 
 class CFloat(Float):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1977,9 +1977,11 @@ class CFloat(Float):
 
     def validate(self, obj, value):
         try:
-            return float(value)
+            value = float(value)
         except:
             self.error(obj, value)
+        return _validate_bounds(self, obj, value)
+
 
 class Complex(TraitType):
     """A trait for complex numbers."""


### PR DESCRIPTION
Prior to this PR, the `Integer` and `Long` traitlets with bounds did not actually validate that a value fell within the bounds in Python 2 (issue #259). This does not apply to Python 3, where Long and Integer are just aliases of `Int`.

In its current state, this PR adds bounds checking for `Integer` and `Long`.

*Feedback request*: To avoid repeating code, I have factored out a private top level function called `_validate_bounds`. This would make more sense as a method in a `Number` superclass that `Integer`, `Long` etc. inherit from. Since this is a major-ish change, it would be great to have feedback.

Remaining work:
- [x]  Bounds checking for casting traits, e.g. CLong
- [x]  Use `_validate_bounds` method in existing traitlets, e.g. `Float`. 



