### PR TITLE
Alternative automatic documentation in the metaclass

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -763,6 +763,27 @@ class MetaHasDescriptors(type):
 class MetaHasTraits(MetaHasDescriptors):
     """A metaclass for HasTraits."""
 
+    def __new__(mcs, name, bases, classdict):
+        def sphinx(trait_name, trait):
+            return (
+                ':param {name}: {doc}\n:type {name}: :class:`{cls}`'.format(
+                    name=trait_name,
+                    doc=trait.help,
+                    cls=trait.__class__.__name__
+                )
+            )
+
+        doc_str = classdict.get('__doc__', '')
+        traits = {key: value for key, value in classdict.items()
+                  if isinstance(value, TraitType)}
+        if traits:
+            doc_str += '\n\nTraits:\n\n' + '\n'.join(
+                (sphinx(key, value) for key, value in traits.items())
+            )
+        classdict['__doc__'] = doc_str.strip()
+
+        return super(MetaHasTraits, mcs).__new__(mcs, name, bases, classdict)
+
     def setup_class(cls, classdict):
         cls._trait_default_generators = {}
         super(MetaHasTraits, cls).setup_class(classdict)


### PR DESCRIPTION
This is another approach to generating sphinx docs for `HasTraits` subclasses. It is an alternative to https://github.com/ipython/traitlets/pull/261

Documentation is generated at class definition by introspecting the class dictionary in the `MetaHasTraits` metaclass, giving something like this:

<img width="624" alt="screen shot 2016-08-05 at 12 22 15 pm" src="https://cloud.githubusercontent.com/assets/9453731/17450357/f6d55632-5b1c-11e6-9ae6-07086f947afe.png">

Right now the functionality is quite basic, but it could be expanded pretty easily:
- Rather than getting defined in the metaclass, `sphinx` could be a function of `TraitTypes`. That would allow custom documentation for different subclasses (e.g. `Instance` traits could add their `klass` to the docstring)
- Documentation isn't restricted to TraitTypes. We can introspect anything else in the `HasTraits` subclass (e.g. event handlers, or documentation-specific variables - something like `if classdict['_autodoc'] == False:`, then don't generate any docs...).
- You could also interrogate the environment to dynamically decide what format of docstrings to generate (for example, if you are in the jupyter notebook generate napoleon docs rather than sphinx docs)
