### PR TITLE
WIP  Eventful dict and custom events

### DIFF
--- a/traitlets/eventful.py
+++ b/traitlets/eventful.py
@@ -1,0 +1,52 @@
+
+# void functions used as a callback placeholders.
+def _default_pre_set(self, key, value):
+    return value
+
+def _default_post_set(self, key, value):
+    pass
+
+def _default_pre_del(self, key):
+    pass
+
+def _default_post_del(self, key):
+    pass
+
+
+class edict(dict):
+
+    pre_set = _default_pre_set
+    post_set = _default_post_set
+    pre_del = _default_pre_del
+    post_del = _default_post_del
+
+    def pop(self, key):
+        self.pre_del(key)
+        ret =  dict.pop(self, key)
+        self.post_del(key)
+        return ret
+
+    def popitem(self):
+        key = next(iter(self))
+        return key, self.pop(key)
+
+    def update(self, other_dict):
+        for (key, value) in other_dict.items():
+            self[key] = value
+
+    def clear(self):
+        for key in list(self.keys()):
+            del self[key]
+
+    def __setitem__(self, key, value):
+        value = self.pre_set(key, value)
+        ret = dict.__setitem__(self, key, value)
+        self.post_set(key, value)
+        return ret
+
+    def __delitem__(self, key):
+        value = self.pre_del(key)
+        ret = dict.__delitem__(self, key)
+        value = self.post_del(key)
+        return ret
+

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -22,14 +22,14 @@ from traitlets import (
     TraitError, Union, All, Undefined, Type, This, Instance, TCPAddress,
     List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
-    observe_compat, BaseDescriptor, HasDescriptors,
+    observe_compat, BaseDescriptor, HasDescriptors, rollback_change
 )
 
 import six
 
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')
-    return dict(zip(change_names, ordered_values))
+    return dict(zip(change_names, ordered_values), rollback=rollback_change)
 
 #-----------------------------------------------------------------------------
 # Helper classes for testing

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1116,7 +1116,8 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
                 self.notify_change = lambda x: None
                 for name, changes in cache.items():
                     for change in changes[::-1]:
-                        change.rollback(change)
+                        if 'rollback' in change:
+                            change.rollback(change)
                 cache = {}
                 raise e
             finally:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2632,6 +2632,10 @@ class EDict(TraitType):
         def pre_set(k, v):
             if k in evdict:
                 getattr(obj, self._cache_name())[k] = evdict[k]
+            # validating a copy of the attribute with the deleted key
+            value = getattr(obj, self.name).copy()
+            value[k] = v
+            self._validate(obj, value)
             return v
         return pre_set
 
@@ -2652,6 +2656,10 @@ class EDict(TraitType):
         def pre_del(k):
             if k in evdict:
                 getattr(obj, self._cache_name())[k] = evdict[k]
+                # validating a copy of the attribute with the deleted key
+                value = getattr(obj, self.name).copy()
+                del value[k]
+                self._validate(obj, value)
         return pre_del
 
     def _post_del(self, obj, evdict):


### PR DESCRIPTION
``` python
from traitlets import *

class Foo(HasTraits):
    bar = EDict()

    @observe('bar', type='element_set')
    def o_change(self, change):
        print(change)

    @observe('bar', type='element_del')
    def o_changes(self, change):
        print(change)

foo = Foo()

foo.bar['key'] = 'value'
del foo.bar['key']
```

```
{'owner': <__main__.Foo object at 0x107e65510>, 'new': 'value', 'type': 'element_set', 'name': 'bar', 'key': 'key'}
{'owner': <__main__.Foo object at 0x107e65510>, 'type': 'element_del', 'name': 'bar', 'key': 'key'}
```

The basic `change` event dictionary now contains the method to rollback the change which is not hardcoded anymore, so that this event type is not special.

This is backward incompatible for people who were calling `notify_change` directly with the old requirements for the dict content since traitlets now expect the rollback method as part of the dict.
