### PR TITLE
Change dict must have a name key

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -768,8 +768,9 @@ def observe(*names, **kwargs):
     """A decorator which can be used to observe Traits on a class.
 
     The handler passed to the decorator will be called with one ``change``
-    dict argument. The change dictionary at least holds a 'type' key,
-    corresponding to the type of notification.
+    dict argument. The change dictionary at least holds a 'type' key and a
+    'name' key, corresponding respectively to the type of notification and the
+    name of the attribute that triggered the notification.
 
     Other keys may be passed depending on the value of 'type'. In the case
     where type is 'change', we also have the following keys:


### PR DESCRIPTION
The generic `notify_change` uses the `name` key. This is something I noticed as I was looking at eventful.