### PR TITLE
gen-config: minor fix getting class-doc when `description` trait empty

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -272,8 +272,8 @@ class Configurable(HasTraits):
         desc = cls.class_traits().get('description')
         if desc:
             desc = desc.default_value
-        else:
-            # no description trait, use __doc__
+        if not desc:
+            # no description from trait, use __doc__
             desc = getattr(cls, '__doc__', '')
         if desc:
             lines.append(c(desc))


### PR DESCRIPTION
The logic for printing description when conf-file is subtle becasue classes examined are not instantiated, and their values might be set later, and be missed. So this minor fix falls back to class-docstring when description` is empty.