### PR TITLE
Fix error with documentation build on RTD

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda
 dependencies:
   - python=3
-  - ipython-genutils
+  - ipython_genutils
   - sphinx
   - sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-ipython-genutils
+ipython_genutils
 Sphinx
-sphinx-rtd-theme
+sphinx_rtd_theme
 -e ../.


### PR DESCRIPTION
Change dashes to underscores in package names for `environment.yml` and `requirements.txt`.

