### PR TITLE
use pip_install in readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,8 +2,7 @@ conda:
     file: docs/environment.yml
 python:
     version: 3
-    setup_py_install: true
-    pip install: true
+    pip_install: true
 formats:
     - epub
     - pdf


### PR DESCRIPTION
not setup_py_install which is unreliable and may not take higher priority than already-installed versions of the package.