### PR TITLE
Test on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 3.4
     - 2.7
     - 3.3
+    - 3.6-dev
 sudo: false
 install:
     - pip install .

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1018,6 +1018,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
 
     def __getstate__(self):
         d = self.__dict__.copy()
+        d.pop('notify_change', None)
         # event handlers stored on an instance are
         # expected to be reinstantiated during a
         # recall of instance_init during __setstate__
@@ -1124,11 +1125,6 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
                 self.notify_change = notify_change
                 self._cross_validation_lock = False
 
-                if isinstance(notify_change, types.MethodType):
-                    # Presence of the notify_change method
-                    # on __dict__ can cause memory leaks
-                    # and prevents pickleability
-                    self.__dict__.pop('notify_change')
                 # trigger delayed notifications
                 for changes in cache.values():
                     for change in changes:


### PR DESCRIPTION
The `__dict__.pop` causes a catastrophic runaway memory leak *sometimes* on Python 3.6 (I couldn't reproduce it by hand, but it always happened at the same place in the test suite).

I think what I have here is a better way to accomplish what the problematic line was doing, so it's a net improvement, anyway.
