### PR TITLE
[WIP] Enforce Logical Inheritance From MustBeInstance

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1074,6 +1074,8 @@ class TestThis(TestCase):
 class TraitTestBase(TestCase):
     """A best testing class for basic trait types."""
 
+    bad_value_raises = TraitError
+
     def assign(self, value):
         self.obj.value = value
 
@@ -1090,9 +1092,11 @@ class TraitTestBase(TestCase):
         if hasattr(self, '_bad_values'):
             for value in self._bad_values:
                 try:
-                    self.assertRaises(TraitError, self.assign, value)
+                    self.assertRaises(self.bad_value_raises, self.assign, value)
                 except AssertionError:
-                    assert False, value
+                    trait_type = self.obj.__class__.value.__class__.__name__
+                    assert False, ("Setting the bad value %r to a '%s' trait should have "
+                        "raised a %r" % (value, trait_type, self.bad_value_raises.__name__))
 
     def test_default_value(self):
         if hasattr(self, '_default_value'):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -505,6 +505,7 @@ class TraitType(BaseDescriptor):
     allow_none = False
     read_only = False
     info_text = 'any value'
+    _use_builtin_dynamic_default = True
 
     def __init__(self, default_value=Undefined, allow_none=False, read_only=None, help=None, **kwargs):
         """Declare a traitlet.
@@ -598,8 +599,8 @@ class TraitType(BaseDescriptor):
                     method = getattr(obj, meth_name)
                     _deprecated_method(method, cls, meth_name, "use @default decorator instead.")
                     return method
-
-        return getattr(self, 'make_dynamic_default', None)
+        if self._use_builtin_dynamic_default:
+            return getattr(self, 'make_dynamic_default', None)
 
     def instance_init(self, obj):
         # If no dynamic initialiser is present, and the trait implementation or
@@ -1743,6 +1744,10 @@ class MustBeInstance(ClassBasedTraitType):
 
     info_text = None
 
+    @property
+    def _use_builtin_dynamic_default(self):
+        return not (self.default_args is None and self.default_kwargs is None)
+
     def __init__(self, default_value=Undefined, allow_none=False, read_only=None, help=None, **kwargs):
         if self._cast is None:
             self._cast = self.klass
@@ -1825,6 +1830,8 @@ class Instance(MustBeInstance):
     """
 
     klass = None
+
+    _use_builtin_dynamic_default = True
 
     def __init__(self, klass=None, args=None, kw=None, **kwargs):
         """Construct an Instance trait.


### PR DESCRIPTION
Many trait implementations perform the same typical validation check:

``` python
if isinstance(value, some_type):
    # value is of the right type
    return value
elif isinstance(value, casting_types):
    # value can be cast to the right type
    return some_type(value)
else:
    raise TraitError()
```

I've introduced a base class `MustBeInstance` which encapsulates this formula in a way such that most `TraitTypes` can subclass it, and hook into this kind of simple validation check. Everything from `Bool` to `List` now inherit from `MustBeInstance`.

Some example implementations:

``` python
# NumberBase simply enforces min
# and max values (e.g. `Int(min=0)`)
# and inherits from MustBeInstance
class Int(NumberBase):
    """An int trait."""

    klass = int
    default_value = 0

class Unicode(MustBeInstance):
    """A trait for unicode strings."""

    default_value = u''
    info_text = 'a unicode string'
    klass = six.text_type

    _cast_types = (bytes,)
    def _cast(self, value):
        try:
            return value.decode('ascii', 'strict')
        except UnicodeDecodeError:
            msg = "Could not decode {!r} for unicode trait '{}' of {} instance."
            raise TraitError(msg.format(value, self.name, nameit(obj)))
```

---

I've also added `nameit`, a new function for naming values - this is a substitute for `class_of`.

Indefinite naming:

``` python
>>> nameit(object())
'an object'
>>> nameit(object)
'an object'
>>> nameit(type(object))
'a type'
```

Definite naming:

``` python
 >>> nameit(object(), definite=True)
"the object at '0x10741f1b0'"
>>> nameit(object, definite=True)
"the type 'object'"
>>> nameit(type(object), definite=True)
"the type 'type'"
```
