### PR TITLE
app: support flags/aliases given as (--long, -short) tuple

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -326,11 +326,11 @@ class Application(SingletonConfigurable):
                                   for m in alias)
 
                 # reformat first line
-                fhelp[0] = fhelp[0].replace(longname, alias)
+                fhelp[0] = fhelp[0].replace('--'+longname, alias)
                 lines.extend(fhelp)
-                lines.append(indent("Equivalent to: [%s]" % longname))
+                lines.append(indent("Equivalent to: [--%s]" % longname))
             except Exception as ex:
-                self.log.error('Failed collecting help-message for aias %r, due to: %s',
+                self.log.error('Failed collecting help-message for alias %r, due to: %s',
                                alias, ex)
                 raise
 
@@ -352,7 +352,7 @@ class Application(SingletonConfigurable):
                               for m in flags)
                 lines.append(flags)
                 lines.append(indent(dedent(fhelp.strip())))
-                cfg_list = ' '.join('%s.%s=%s' %(clname, prop, val)
+                cfg_list = ' '.join('--%s.%s=%s' %(clname, prop, val)
                             for clname, props_dict
                             in cfg.items() for prop, val in props_dict.items())
                 cfg_txt = "Equivalent to: [%s]" % cfg_list

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -331,7 +331,9 @@ class Application(SingletonConfigurable):
                 lines.append(indent("Equivalent to: [%s]" % longname))
             except Exception as ex:
                 self.log.error('Failed collecting help-message for aias %r, due to: %s',
-                               alias, ex, exc_info=1)
+                               alias, ex)
+                raise
+
         # lines.append('')
         print(os.linesep.join(lines))
 
@@ -357,7 +359,9 @@ class Application(SingletonConfigurable):
                 lines.append(indent(dedent(cfg_txt)))
             except Exception as ex:
                 self.log.error('Failed collecting help-message for flag %r, due to: %s',
-                               flags, ex, exc_info=1)
+                               flags, ex)
+                raise
+
         # lines.append('')
         print(os.linesep.join(lines))
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -404,7 +404,7 @@ class Application(SingletonConfigurable):
         self.print_options()
 
         if classes:
-            help_classes = self.classes
+            help_classes = self._classes_in_config_sample()
             if help_classes:
                 print("Class parameters")
                 print("----------------")

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -210,7 +210,8 @@ class Configurable(HasTraits):
         """
         assert inst is None or isinstance(inst, cls)
         final_help = []
-        final_help.append(u'%s options' % cls.__name__)
+        base_classes = ','.join(p.__name__ for p in cls.__bases__)
+        final_help.append(u'%s(%s) options' % (cls.__name__, base_classes))
         final_help.append(len(final_help[0])*u'-')
         for k, v in sorted(cls.class_traits(config=True).items()):
             help = cls.class_get_trait_help(v, inst)

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -786,25 +786,31 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
         if flags is None:
             flags = self.flags
         paa = self.parser.add_argument
-        for key,value in aliases.items():
-            if key in flags:
-                # flags
-                nargs = '?'
-            else:
-                nargs = None
-            if len(key) is 1:
-                paa('-'+key, '--'+key, type=text_type, dest=value, nargs=nargs)
-            else:
-                paa('--'+key, type=text_type, dest=value, nargs=nargs)
-        for key, (value, help) in flags.items():
-            if key in self.aliases:
-                #
-                self.alias_flags[self.aliases[key]] = value
-                continue
-            if len(key) is 1:
-                paa('-'+key, '--'+key, action='append_const', dest='_flags', const=value)
-            else:
-                paa('--'+key, action='append_const', dest='_flags', const=value)
+        for keys,value in aliases.items():
+            if not isinstance(keys, tuple):
+                keys = (keys, )
+            for key in keys:
+                if key in flags:
+                    # flags
+                    nargs = '?'
+                else:
+                    nargs = None
+                if len(key) is 1:
+                    paa('-'+key, '--'+key, type=text_type, dest=value, nargs=nargs)
+                else:
+                    paa('--'+key, type=text_type, dest=value, nargs=nargs)
+        for keys, (value, help) in flags.items():
+            if not isinstance(keys, tuple):
+                keys = (keys, )
+            for key in keys:
+                if key in self.aliases:
+                    #
+                    self.alias_flags[self.aliases[key]] = value
+                    continue
+                if len(key) is 1:
+                    paa('-'+key, '--'+key, action='append_const', dest='_flags', const=value)
+                else:
+                    paa('--'+key, action='append_const', dest='_flags', const=value)
 
     def _convert_to_config(self):
         """self.parsed_data->self.config, parse unrecognized extra args via KVLoader."""

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -214,10 +214,10 @@ class TestApplication(TestCase):
         with contextlib.redirect_stdout(stdout):
             app.print_flag_help()
         hmsg = stdout.getvalue()
-        self.assertIn("-e, --enable", hmsg)
-        self.assertIn("-d, --disable", hmsg)
-        self.assertIn("Equivalent to: [Bar.enabled=True]", hmsg)
-        self.assertIn("Equivalent to: [Bar.enabled=False]", hmsg)
+        self.assertRegex(hmsg, "(?<!-)-e, --enable\\b")
+        self.assertRegex(hmsg, "(?<!-)-d, --disable\\b")
+        self.assertIn("Equivalent to: [--Bar.enabled=True]", hmsg)
+        self.assertIn("Equivalent to: [--Bar.enabled=False]", hmsg)
 
     def test_aliases(self):
         app = MyApp()
@@ -249,11 +249,11 @@ class TestApplication(TestCase):
         with contextlib.redirect_stdout(stdout):
             app.print_alias_help()
         hmsg = stdout.getvalue()
-        self.assertIn("-i, --fooi", hmsg)
-        self.assertIn("-j, --fooj", hmsg)
-        self.assertIn("Equivalent to: [Foo.i]", hmsg)
-        self.assertIn("Equivalent to: [Foo.j]", hmsg)
-        self.assertIn("Equivalent to: [Foo.name]", hmsg)
+        self.assertRegex(hmsg, "(?<!-)-i, --fooi\\b")
+        self.assertRegex(hmsg, "(?<!-)-j, --fooj\\b")
+        self.assertIn("Equivalent to: [--Foo.i]", hmsg)
+        self.assertIn("Equivalent to: [--Foo.j]", hmsg)
+        self.assertIn("Equivalent to: [--Foo.name]", hmsg)
 
     def test_flag_clobber(self):
         """test that setting flags doesn't clobber existing settings"""

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -11,6 +11,7 @@ import io
 import json
 import logging
 import os
+import sys
 from io import StringIO
 from unittest import TestCase
 
@@ -205,7 +206,9 @@ class TestApplication(TestCase):
         app.init_bar()
         self.assertEqual(app.bar.enabled, True)
 
-    def test_flags_help(self):
+    @mark.skipif(sys.version_info < (3, 4),
+                 reason="Missing `contextlib.redirect_stdout` in python < 3.4!")
+    def test_flags_help_msg(self):
         app = MyApp()
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
@@ -238,7 +241,9 @@ class TestApplication(TestCase):
         app.init_foo()
         self.assertEqual(app.foo.j, 10)
 
-    def test_aliases_help(self):
+    @mark.skipif(sys.version_info < (3, 4),
+                 reason="Missing `contextlib.redirect_stdout` in python < 3.4!")
+    def test_aliases_help_msg(self):
         app = MyApp()
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -31,8 +31,8 @@ class MyConfigurable(Configurable):
     c = Unicode('no config')
 
 
-mc_help=u"""MyConfigurable options
-----------------------
+mc_help=u"""MyConfigurable(Configurable) options
+------------------------------------
 --MyConfigurable.a=<Integer>
     Default: 1
     The integer a.
@@ -40,8 +40,8 @@ mc_help=u"""MyConfigurable options
     Default: 1.0
     The integer b."""
 
-mc_help_inst=u"""MyConfigurable options
-----------------------
+mc_help_inst=u"""MyConfigurable(Configurable) options
+------------------------------------
 --MyConfigurable.a=<Integer>
     Current: 5
     The integer a.
@@ -89,7 +89,7 @@ class TestConfigurable(TestCase):
         self.assertTrue(c3.config is config)
         self.assertTrue(c1.config is c2.config)
         self.assertTrue(c2.config is c3.config)
-        
+
     def test_inheritance(self):
         config = Config()
         config.MyConfigurable.a = 2
@@ -179,7 +179,7 @@ class MyParent2(MyParent):
     pass
 
 class TestParentConfigurable(TestCase):
-    
+
     def test_parent_config(self):
         cfg = Config({
             'MyParent' : {
@@ -275,11 +275,11 @@ class Containers(Configurable):
     lis = List().tag(config=True)
     def _lis_default(self):
         return [-1]
-    
+
     s = Set().tag(config=True)
     def _s_default(self):
         return {'a'}
-    
+
     d = Dict().tag(config=True)
     def _d_default(self):
         return {'a' : 'b'}
@@ -346,22 +346,22 @@ class TestConfigContainers(TestCase):
         c.Containers.d.update({'e' : 'f'})
         obj = Containers(config=c)
         self.assertEqual(obj.d, {'a':'b', 'c':'d', 'e':'f'})
-    
+
     def test_update_twice(self):
         c = Config()
         c.MyConfigurable.a = 5
         m = MyConfigurable(config=c)
         self.assertEqual(m.a, 5)
-        
+
         c2 = Config()
         c2.MyConfigurable.a = 10
         m.update_config(c2)
         self.assertEqual(m.a, 10)
-        
+
         c2.MyConfigurable.a = 15
         m.update_config(c2)
         self.assertEqual(m.a, 15)
-    
+
     def test_update_self(self):
         """update_config with same config object still triggers config_changed"""
         c = Config()
@@ -371,7 +371,7 @@ class TestConfigContainers(TestCase):
         c.MyConfigurable.a = 10
         m.update_config(c)
         self.assertEqual(m.a, 10)
-    
+
     def test_config_default(self):
         class SomeSingleton(SingletonConfigurable):
             pass
@@ -388,9 +388,9 @@ class TestConfigContainers(TestCase):
 
         d1 = DefaultConfigurable()
         self.assertEqual(d1.a, 0)
-        
+
         single = SomeSingleton.instance(config=c)
-        
+
         d2 = DefaultConfigurable()
         self.assertIs(d2.config, single.config)
         self.assertEqual(d2.a, 5)
@@ -415,9 +415,9 @@ class TestConfigContainers(TestCase):
 
         d1 = DefaultConfigurable()
         self.assertEqual(d1.a, 0)
-        
+
         single = SomeSingleton.instance(config=c)
-        
+
         d2 = DefaultConfigurable()
         self.assertIs(d2.config, single.config)
         self.assertEqual(d2.a, 5)
@@ -429,14 +429,14 @@ class TestLogger(TestCase):
             foo = Integer(config=True)
             bar = Integer(config=True)
             baz = Integer(config=True)
-    
+
     @mark.skipif(not hasattr(TestCase, 'assertLogs'), reason='requires TestCase.assertLogs')
     def test_warn_match(self):
         logger = logging.getLogger('test_warn_match')
         cfg = Config({'A': {'bat': 5}})
         with self.assertLogs(logger, logging.WARNING) as captured:
             a = TestLogger.A(config=cfg, log=logger)
-        
+
         output = '\n'.join(captured.output)
         self.assertIn('Did you mean one of: `bar, baz`?', output)
         self.assertIn('Config option `bat` not recognized by `A`.', output)
@@ -444,7 +444,7 @@ class TestLogger(TestCase):
         cfg = Config({'A': {'fool': 5}})
         with self.assertLogs(logger, logging.WARNING) as captured:
             a = TestLogger.A(config=cfg, log=logger)
-        
+
         output = '\n'.join(captured.output)
         self.assertIn('Config option `fool` not recognized by `A`.', output)
         self.assertIn('Did you mean `foo`?', output)


### PR DESCRIPTION
+ Specify both short/long forms of flags & aliases at once.
+ Explain explicitely equivalence of flags/aliases.
+ Handle and log exceptions while printing flag/alias help-msgs - stacktrace was too convoluted otherwise.
+ FIX #296: print all relevant (sub)classes in help-msg.

An example of the new flags/aliases help message:

```
-f, --force
    Force various sub-commands perform their duties without complaints.
    Equivalent to: [Spec.force=True]
-v, --verbose
    Make various sub-commands increase their verbosity (not to be confused with --debug):
    Equivalent to: [Spec.verbose=True]
-d, --debug
    Log more logging, fail on configuration errors, and print configuration on each cmd startup.
    Equivalent to: [Cmd.raise_config_file_errors=True Cmd.print_config=True Spec.log_level=0 Application.log_level=0]
--log-level=<Enum>
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
    Equivalent to: [Application.log_level]
```