### PR TITLE
Use argparse to configure container-traits from command-line

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -565,8 +565,10 @@ class Application(SingletonConfigurable):
 
         # flatten flags&aliases, so cl-args get appropriate priority:
         flags,aliases = self.flatten_flags()
+        classes = tuple(self._classes_with_config_traits())
         loader = KVArgParseConfigLoader(argv=argv, aliases=aliases,
-                                        flags=flags, log=self.log)
+                                        flags=flags, log=self.log,
+                                        classes=classes)
         self.cli_config = deepcopy(loader.load_config())
         self.update_config(self.cli_config)
         # store unparsed args in extra_args

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -413,7 +413,7 @@ class Application(SingletonConfigurable):
         self.print_options()
 
         if classes:
-            help_classes = self._classes_in_config_sample()
+            help_classes = self._classes_with_config_traits()
             if help_classes:
                 print("Class parameters")
                 print("----------------")
@@ -636,7 +636,7 @@ class Application(SingletonConfigurable):
         self.update_config(new_config)
 
 
-    def _classes_in_config_sample(self):
+    def _classes_with_config_traits(self):
         """
         Yields only classes with own traits, and their subclasses.
 
@@ -672,7 +672,7 @@ class Application(SingletonConfigurable):
         """generate default config file from Configurables"""
         lines = ["# Configuration file for %s." % self.name]
         lines.append('')
-        for cls in self._classes_in_config_sample():
+        for cls in self._classes_with_config_traits():
             lines.append(cls.class_config_section())
         return '\n'.join(lines)
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -10,7 +10,15 @@ from copy import deepcopy
 import warnings
 
 from .loader import Config, LazyConfigValue, _is_section_key
-from traitlets.traitlets import HasTraits, Instance, observe, observe_compat, default
+from traitlets.traitlets import (
+    HasTraits,
+    Instance,
+    Container,
+    Dict,
+    observe,
+    observe_compat,
+    default,
+)
 from ipython_genutils.text import indent, dedent, wrap_paragraphs
 
 
@@ -227,7 +235,20 @@ class Configurable(HasTraits):
         """
         assert inst is None or isinstance(inst, cls)
         lines = []
-        header = "--%s.%s=<%s>" % (cls.__name__, trait.name, trait.__class__.__name__)
+        header = "--%s.%s" % (cls.__name__, trait.name)
+        if isinstance(trait, (Container, Dict)):
+            multiplicity = trait.metadata.get('multiplicity', 'append')
+            if isinstance(trait, Dict):
+                sample_value = '<key-1>=<value-1>'
+            else:
+                sample_value = '<%s-item-1>' % trait.__class__.__name__.lower()
+            if multiplicity == 'append':
+                header = "%s=%s..." % (header, sample_value)
+            else:
+                header = "%s %s..." % (header, sample_value)
+        else:
+            header = '%s=<%s>' % (header, trait.__class__.__name__)
+        #header = "--%s.%s=<%s>" % (cls.__name__, trait.name, trait.__class__.__name__)
         lines.append(header)
         if inst is not None:
             lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -738,10 +738,6 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
         self.clear()
         if argv is None:
             argv = self.argv
-        if aliases is None:
-            aliases = self.aliases
-        if flags is None:
-            flags = self.flags
         self._create_parser(aliases, flags)
         self._parse_args(argv)
         self._convert_to_config()

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -831,21 +831,18 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
         self.argparse_traits = argparse_traits = {}
         for cls in classes:
             for traitname, trait in cls.class_traits(config=True).items():
+                argname = '%s.%s' % (cls.__name__, traitname)
+                argparse_kwds = {'type': text_type}
                 if isinstance(trait, (Container, Dict)):
-                    argname = '%s.%s' % (cls.__name__, traitname)
                     multiplicity = trait.metadata.get('multiplicity', 'append')
-                    argparse_kwds = {}
                     if multiplicity == 'append':
                         argparse_kwds['action'] = multiplicity
                     else:
                         argparse_kwds['nargs'] = multiplicity
                     if isinstance(trait, Dict):
-                        argtype = fnt.partial(_kv_opt, traitname)
-                    else:
-                        argtype = text_type
-                    argparse_kwds['type'] = argtype
-                    argparse_traits[argname] = (trait, argparse_kwds)
-                    paa('--'+argname, **argparse_kwds)
+                        argparse_kwds['type'] = fnt.partial(_kv_opt, traitname)
+                argparse_traits[argname] = (trait, argparse_kwds)
+                paa('--'+argname, **argparse_kwds)
 
         for keys, traitname in aliases.items():
             if not isinstance(keys, tuple):

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -50,6 +50,7 @@ class Bar(Configurable):
     enabled = Bool(True, help="Enable bar.").tag(config=True)
     tb = Tuple(()).tag(config=True, multiplicity='*')
     aset = Set().tag(config=True, multiplicity='+')
+    adict = Dict().tag(config=True)
 
 
 class MyApp(Application):
@@ -68,6 +69,7 @@ class MyApp(Application):
                     'name' : 'Foo.name',
                     'la': 'Foo.la',
                     'tb': 'Bar.tb',
+                    'D': 'Bar.adict',
                     'enabled' : 'Bar.enabled',
                     'log-level' : 'Application.log_level',
                 })
@@ -131,6 +133,16 @@ class TestApplication(TestCase):
         app.init_bar()
         self.assertEqual(app.bar.aset, {'S1', 'S2'})
         self.assertEqual(app.bar.tb, ('AB', 2))
+
+    def test_config_dict_args(self):
+        app = MyApp()
+        app.parse_command_line("--Bar.adict k=1 -D=a=b -D 22=33".split())
+        config = app.config
+        self.assertDictEqual(config.Bar.adict,
+                {'k': 1, 'a': 'b', '22': 33})
+        app.init_bar()
+        self.assertEqual(app.bar.adict,
+                {'k': 1, 'a': 'b', '22': 33})
 
     def test_config_propagation(self):
         app = MyApp()

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -186,7 +186,6 @@ class TestApplication(TestCase):
             assert app.config.TestApp.value == 'cli'
             assert app.value == 'cli'
 
-    @skip('TO DEL? see https://github.com/ipython/traitlets/pull/322')
     def test_ipython_cli_priority(self):
         # this test is almost entirely redundant with above,
         # but we can keep it around in case of subtle issues creeping into

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -328,9 +328,10 @@ class TestArgParseKVCL(TestKeyValueCL):
 
     def test_seq_traits(self):
         cl = self.klass(log=log, classes=(CBase, CSub))
-        argv = ("--CBase.a A --CBase.a 2 --CBase.b 1 2 3 --CBase.c AA --CBase.c BB "
+        argv = ("--CBase.a A --CBase.a 2 --CBase.b 1 2 3 --a3 AA --CBase.c BB "
                 "--CSub.d 1 --CSub.d BBB --CSub.e 1 a bcd").split()
-        config = cl.load_config(argv)
+        aliases = {'a3': 'CBase.c', 'a5': 'CSub.e'}
+        config = cl.load_config(argv, aliases=aliases)
         self.assertEqual(config.CBase.a, ['A', 2])
         self.assertEqual(config.CBase.b, [1, 2, 3])
         self.assertEqual(config.CBase.c, ['AA', 'BB'])


### PR DESCRIPTION
- The idea was to  scan all conf-classes to collect `List/Set/Tuple/Dict` traits and use them to setup *argparse* for reading cmd-line args either with action='append' or nargs='*'`.
- Additionally, do the same for any matching aliases (for flags this does not make sense).
- But eventually had to feed all config-traits through *argparse* when classes are provided.
The reason is that any "regular"(not handled by *argparse*) trait with a name that is a prefix of some container-trait will get miss-classified as that container-trait (disabling this [`allow_abbrev`](https://docs.python.org/3/library/argparse.html#allow-abbrev) behavior is not supported in py2).


## Design
1. The `Application` on `parse_command_line()` uses its `classes` field to collects all relevant `HasTraits` classes and subclasses to push them into the `KVArgParseConfigLoader` constructor;
2. The `KVArgParseConfigLoader.load_config()` invokes `_add_arguments()` for all *list/Set/tuple* traits found on the collected classes , and appends them as *argparse* arguments according to the `multiplicity` metadata found on these traits:

    1. `multiplicity == 'append'`: use `add_argument(..., action='append')` (default if metadata missing);
    2.  `multiplicity == [ '*' | '+' | N ]`: use `add_argument(..., nargs=multiplicity)`.

3. During the above step, all container traits are collected in the new loder's field `argparse_traits` to be used in the next step to create the appropriate config-tree instance.
4. After *argparse* has parsed cmd-line arguments, the `KVArgParseConfigLoader._convert_to_config()` py-evaluates any lists-of-values (or list-of-tuples for `Dict` traits) one by one before creating and assigning the appropriate instance (i.e. `dict` for `Dict` traits) into the returned config-instance .

## Example
Assuming this 2 configurables + 1 app:

```python
class Base(Configurable): 
    a = List([]).tag(config=True)

class Sub(Base): 
    atuple = Tuple([]).tag(config=True, multiplicity='*')
    aset = Set(set()).tag(config=True, multiplicity='append')

class Cmd(Application):
    classes = [Sub]  ## Note on #289: frequently list given like that.
    aliases = {
        'a':  'Base.a', 
        'aa': 'Sub.a', 
        't':  'Sub.atuple', 
        's':  'Sub.aset'
    }
```

Then, in command-line it should be possible to enter all these commands:

```
cmd  --Base.a=1 -a=foo      ## Base.a = [1, 'foo']
cmd  --aa=1  --Sub.a=foo    ## Sub.a  = [1, 'foo']
cmd  -t 1 ab cd 4  --Sub.aset a  -s b  -s a  ## Sub.b = (1, 'ab', 'cd', 4), Sub.set = {'a', 'b'}
cmd  --Base.a=1 --Base.a=2  --Sub.a=foo      ## Base.a = [1, 2], Sub.a = ['foo']
```
* Notice that in the last case, `Sub` class trumps over any `Base` values.

For a `Dict` trait, the cmd-line syntax is this:

      cmd   --Base.adict kk=vv -D=key1=v1  -D key2=True -Dkey3="'True'"

resulting in this:

    Base.adict = {'kk': 'v', 'key1': 'v1', 'key2': True, 'key3: 'True'}


## Future
- Merge parts of `KVArgParseConfigLoader` into `ArgParseConfigLoader` class - actually I would try to compress the *loader* hierarchy.