### PR TITLE
[WIP] Add Eventful Traits

### DIFF
--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,0 +1,4 @@
+{
+  "traitlets/config/tests/test_loader.py": true,
+  "traitlets/tests/test_traitlets.py": true
+}

--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,4 +1,0 @@
-{
-  "traitlets/config/tests/test_loader.py": true,
-  "traitlets/tests/test_traitlets.py": true
-}

--- a/traitlets/__init__.py
+++ b/traitlets/__init__.py
@@ -1,3 +1,4 @@
 from .traitlets import *
+from .eventful import *
 from .utils.importstring import import_item
 from ._version import version_info, __version__

--- a/traitlets/eventful.py
+++ b/traitlets/eventful.py
@@ -1,0 +1,249 @@
+from .utils.bunch import Bunch
+from contextlib import contextmanager
+from .utils.spectate import watched_type
+from traitlets import (TraitType, Dict,
+    List, Undefined, equivalent, Set)
+
+class Beforeback(object):
+
+    def __init__(self, trait, obj, etype, before):
+        self.trait = trait
+        self.obj = obj
+        self.etype = etype
+        self.before = before
+
+    def __call__(self, inst, call):
+        call = call.copy()
+        call.update(
+            trait=self.trait,
+            owner=self.obj,
+            type=self.etype)
+        return self.before(inst, call)
+
+class Afterback(object):
+
+    def __init__(self, trait, obj, etype, after):
+        self.trait = trait
+        self.obj = obj
+        self.etype = etype
+        self.after = after
+        self._notify = True
+
+    def silent_call(self, inst, answer):
+        self._notify = False
+        out = self(inst, answer)
+        self._notify = True
+        return out
+
+    def __call__(self, inst, answer):
+        if self.after is None:
+            result = answer['before']
+            if (isinstance(result, Redirect)
+                and result.origin is not None):
+                origin = result.origin
+            else:
+                origin = self.etype
+
+            event = (result(answer.value) if
+                callable(result) else result)
+        else:
+            event = after(inst, answer)
+
+        if event is not None and self._notify:
+            self.obj.notify_change(Bunch(
+                type=origin, event=event,
+                name=self.trait.name,
+                owner=self.obj))
+        return event
+
+class Redirect(object):
+
+    def __init__(self, inst, origin, target, args, kwargs):
+        self.origin = origin
+        spectator = inst.instance_spectator
+        registry = spectator._callback_registry
+        beforebacks, afterbacks = zip(
+            *registry.get(target, []))
+
+        hold = []
+        for b in beforebacks:
+            if b is not None:
+                call = Bunch(name=target,
+                    kwargs=kwargs.copy(),
+                    args=args[:])
+                bval = b(inst, call)
+            else:
+                bval = None
+            hold.append(bval)
+
+        def event_trigger(value):
+            for afterback, bval in zip(afterbacks, hold):
+                if afterback is not None:
+                    return (afterback.silent_call if
+                        isinstance(afterback, Afterback)
+                        else afterback)(inst, Bunch(
+                        before=bval, name=target, value=value))
+        self.trigger = event_trigger
+
+    def __call__(self, value):
+        return self.trigger(value)
+
+
+class Eventful(TraitType):
+
+    event_map = {}
+    type_name = 'WatchedType'
+
+    def __init__(self, *args, **kwargs):
+        super(Eventful, self).__init__(*args, **kwargs)
+        self._active_events = []
+        self.setup_events()
+
+    def event(self, type, on, before=None, after=None):
+        if before is None and after is None:
+            raise ValueError("No callbacks were provided for the event")
+        for method in (on if isinstance(on, (list, tuple)) else (on,)):
+            self._active_events.append((type, method, before, after))
+        return self
+
+    def setup_events(self):
+        for name, on in self.event_map.items():
+            for method in (on if isinstance(on, (tuple, list)) else (on,)):
+                before = getattr(self, "_before_"+name, None)
+                after = getattr(self, "_after_"+name, None)
+                if not (before is None and after is None):
+                    self.event(type=name, on=method,
+                        before=before, after=after)
+
+    def _register_defined_events(self, obj, value):
+        for e in self._active_events:
+            etype, on, before, after = e
+            value.instance_spectator.callback(on,
+                before=Beforeback(self, obj, etype, before),
+                after=Afterback(self, obj, etype, after))
+
+    def _validate(self, obj, value):
+        try:
+            getattr(obj, self.name).instance_spectator = None
+        except:
+            pass
+        value = super(Eventful, self)._validate(obj, value)
+        if value is not None:
+            value = self.watched_type(value)
+            self._register_defined_events(obj, value)
+        return value
+
+    def redirect_once(self, origin, target, inst, args=(), kwargs={}):
+        value = self.event_map[target]
+        target = value[0] if isinstance(value, (list, tuple)) else value
+        return Redirect(inst, origin, target, args, kwargs)
+
+    def redirect(self, origin, target, inst, args=None, kwargs=None):
+        value = self.event_map[target]
+        target = value[0] if isinstance(value, (list, tuple)) else value
+
+        if args is None and kwargs is not None:
+            args = [() for i in range(len(kwargs))]
+        elif kwargs is None and args is not None:
+            kwargs = [{} for i in range(len(args))]
+        if len(args) != len(kwargs):
+            raise ValueError("Uneven args (%s) and kwargs (%s) lists")
+
+        redirects = [Redirect(inst, origin, target, a, kw)
+            for a, kw in zip(args, kwargs)]
+        def redirect(value):
+            events = []
+            for r in redirects:
+                events.append(r(value))
+            return events
+        return redirect 
+
+    def class_init(self, cls, name):
+        super(Eventful, self).class_init(cls, name)
+        self.watched_type = watched_type(self.type_name,
+            self.klass, *(e[1] for e in self._active_events))
+
+
+class EDict(Eventful, Dict):
+
+    event_map = {
+        'setitem': ('__setitem__', 'setdefault'),
+        'delitem': ('__delitem__', 'pop'),
+        'update': 'update',
+        'clear': 'clear',
+    }
+    type_name = 'edict'
+
+    def _before_update(self, inst, call):
+        new = call.args[0]
+        new.update(call.kwargs)
+        call_list = []
+        return self.redirect(
+            None, 'setitem', inst,
+            args=new.items())
+
+    def _before_clear(self, inst, call):
+        return self.redirect(
+            None, 'delitem', inst,
+            args=inst.items())
+
+    @staticmethod
+    def before_setitem(inst, call):
+        """Expect call.args[0] = key"""
+        key, old = call.args[0], inst.get(call.args[0], Undefined)
+        def after_setitem(answered_value):
+            new = inst.get(key, Undefined)
+            if not equivalent(old, new):
+                return Bunch(key=key, old=old, new=new)
+        return after_setitem
+
+    _before_setitem = before_setitem
+    _before_delitem = before_setitem
+
+
+class EList(Eventful, List):
+
+    event_map = {
+        'append': 'append',
+        'extend': 'extend',
+        'setitem': '__setitem__',
+        'reverse': 'reverse',
+        'sort': 'sort',
+    }
+    type_name = 'elist'
+
+    def before_setitem(self, inst, index):
+        try:
+            old = inst[index]
+        except:
+            old = Undefined
+        def after_setitem(answered_value):
+            try:
+                new = inst[index]
+            except:
+                new = Undefined
+            if not equivalent(old, new):
+                return Bunch(index=index, old=old, new=new)
+        return after_setitem
+
+    def _before_setitem(self, inst, call):
+        return self.before_setitem(inst, call.args[0])
+
+    def rearrangement(self, origin, inst):
+        return self.redirect(origin, 'setitem', inst,
+            args=[(i,) for i in range(len(inst))])
+
+    def _before_reverse(self, inst, call):
+        return self.rearrangement(inst, 'reverse')
+
+    def _before_sort(self, inst, call):
+        return self.rearrangement(inst, 'sort')
+
+    def _before_extend(self, inst, call):
+        size = len(call.args[0])
+        return self.redirect('append', 'setitem', inst,
+            args=[(i+len(inst),) for i in range(size)])
+
+    def _before_append(self, inst, call):
+        return self.redirect_once('append',
+            'setitem', inst, (len(inst),))

--- a/traitlets/eventful.py
+++ b/traitlets/eventful.py
@@ -160,8 +160,14 @@ class Eventful(TraitType):
 
     def class_init(self, cls, name):
         super(Eventful, self).class_init(cls, name)
-        self.watched_type = watched_type(self.type_name,
-            self.klass, *(e[1] for e in self._active_events))
+        if getattr(self, 'klass', None) is not None:
+            self.watched_type = watched_type(self.type_name,
+                self.klass, *(e[1] for e in self._active_events))
+        else:
+            def dynamic_watched_type(value):
+                new = watched_type(self.type_name, type(value),
+                    *(e[1] for e in self._active_events))
+                return new(value)
 
 
 class EDict(Eventful, Dict):

--- a/traitlets/tests/test_eventful.py
+++ b/traitlets/tests/test_eventful.py
@@ -1,97 +1,246 @@
-from ..traitlets import HasTraits
+import copy
+from unittest import TestCase
+from ..traitlets import HasTraits, observe
 from ..eventful import Eventful, Bunch, Beforeback, Afterback, Redirect
 from ..utils import spectate
 
+
+class CopyClass(object):
+    def __new__(cls, old=None):
+        new = super(CopyClass, cls).__new__(cls)
+        if old is not None:
+            for key, value in old.__dict__.items():
+                setattr(new, key, value)
+        return new
+
+
 def test_beforeback():
-	class A(HasTraits):
-		# not a functional trait
-		e = Eventful()
+    trait = 'trait' # would be an Eventful trait
+    owner = 'owner' # would be a HasTraits instance
+    before = lambda inst, call: (inst, call)
+    bb = Beforeback(owner, trait, 'type', before)
 
-	before = lambda inst, call: (inst, call)
-	bb = Beforeback(A.e, 'type', before)
+    inst, call = bb(owner, Bunch())
+    assert call == Bunch(owner=owner,
+        type='type', trait=trait)
 
-	inst, call = bb(A(), Bunch())
-	assert call == Bunch(owner=inst,
-		type='type', trait=A.e)
 
-def test_afterback_value():
-	class A(HasTraits):
-		e = Eventful()
+class TestAfterback(TestCase):
 
-	a = A()
-	call = Bunch(name='func', args=(), kwargs={})
+    def test_afterback_value(self):
+        owner = HasTraits()
+        class FakeEventful(object):
+            def __init__(self):
+                self.name = 'name'
+        trait = FakeEventful()
+        value = 'value'
 
-	# beforeback returns a value for an afterback
-	before = lambda inst, call: (inst, call)
+        call = Bunch(name='func', args=(), kwargs={})
 
-	make_answer = lambda : Bunch(
-		before=before(a, call),
-		name='func', value=None)
+        # beforeback returns a value for an afterback
+        before = lambda inst, call: (inst, call)
+        after = lambda inst, answer: (inst, answer)
 
-	after = lambda inst, answer: (inst, answer)
-	ab = Afterback(A.e, 'type', after=after)
+        make_answer = lambda : Bunch(before=before(value, call),
+            name='placeholder_method_name', value=None)
 
-	answer = make_answer()
-	result = ab(a, answer)
-	assert result == (a, answer)
+        ab = Afterback(owner, trait, 'type', after)
 
-def test_afterback_closure():
-	class A(HasTraits):
-		# not a functional trait
-		e = Eventful()
+        answer = make_answer()
+        result = ab(value, answer)
+        assert result == (value, answer)
 
-	a = A()
-	call = Bunch(name='func', args=(), kwargs={})
+    def test_afterback_closure(self):
+        owner = HasTraits()
+        class FakeEventful(object):
+            def __init__(self):
+                self.name = 'name'
+        trait = FakeEventful()
+        value = 'value'
 
-	# beforeback returns a closure instead of a value
-	before = lambda inst, call: lambda value: (inst, call, value)
+        call = Bunch(name='func', args=(), kwargs={})
 
-	make_answer = lambda : Bunch(
-		before=before(a, call),
-		name='func', value=None)
+        # beforeback returns a closure instead of a value
+        before = lambda inst, call: lambda value: (inst, call, value)
 
-	# afterback must be None to trigger closure
-	ab = Afterback(A.e, 'type', after=None)
+        make_answer = lambda : Bunch(before=before(value, call),
+            name='placeholder_method_name', value=None)
 
-	result = ab(a, make_answer())
-	assert result == (a, call, None)
+        # afterback must be None to trigger closure
+        ab = Afterback(owner, trait, 'type', None)
+
+        result = ab(value, make_answer())
+        assert result == (value, call, None)
+
+    def test_afterback_notify(self):
+        log = []
+
+        class NotifyLogger(HasTraits):
+
+            def notify_change(self, change):
+                log.append(change)
+                super(NotifyLogger, self).notify_change(change)
+
+            @observe('trait_name', type='event_type')
+            def _log_change(self, change):
+                log.append(change)
+
+        owner = NotifyLogger()
+
+        class FakeEventful(object):
+            def __init__(self):
+                self.name = 'trait_name'
+
+        trait = FakeEventful()
+        
+        value = 'value'
+
+        before = lambda inst, call: call
+        after = lambda inst, answer: answer
+
+        call = Bunch(name='func', args=(), kwargs={})
+        make_answer = lambda : Bunch(
+            before=before(value, call),
+            name='func', value=None)
+
+        ab = Afterback(owner, trait, 'event_type', after)
+
+        answer = make_answer()
+
+        ab(value, answer)
+
+        change = Bunch(name='trait_name', owner=owner,
+            type='event_type', event=answer)
+
+        assert len(log) == 2
+
+        def check(logged):
+            assert logged == change
+        map(check, log)
 
 def test_redirect():
-	class A(object):
-		called_func_b = False
-		def func_a(self, a):
-			return a
-		def func_b(self, b):
-			self.called_func_b = True
-			return b
+    class Test(CopyClass):
+        target_method_called = False
+        target_beforeback_called = False
+        target_afterback_called = False
+        origin_method_called = False
+        origin_beforeback_called = False
+        origin_afterback_called = False
+        def origin(self, a):
+            self.origin_method_called = True
+            return a
+        def target(self, b):
+            self.target_method_called = True
+            return b + 1
 
-	wa = spectate.watched_type('WA', A, 'func_a', 'func_b')()
-	# beforeback returns a closure that returns method output
-	def last_before(inst, call):
-		def last_after(value):
-			print(value)
-			return value
-		return last_after
+    test = spectate.watched_type('WatchedTest', Test, 'origin', 'target')()
 
-	# register two beforebacks to test that
-	# the redirect returns results from both
-	wa.instance_spectator.callback('func_b', before=last_before)
-	wa.instance_spectator.callback('func_b', before=last_before)
+    def before_target(inst, call):
+        inst.target_beforeback_called = True
+        return call
+    def after_target(inst, answer):
+        inst.target_afterback_called = True
+        return (inst, answer.before, answer.value)
 
-	def first_before(inst, call):
-		# redirect to trigger the before/after backs of func_b
-		return Redirect(inst, 'func_a', 'func_b', call.args, call.kwargs)
+    test.instance_spectator.callback('target', before_target, after_target)
 
-	captured_from_redirect = []
+    def is_not_target(inst, call):
+        # redirect should not trigger this
+        assert False
 
-	def first_after(inst, answer):
-		out = answer.before(answer.value)
-		captured_from_redirect.extend(out)
-		return out
+    test.instance_spectator.callback('target', is_not_target)
 
-	wa.instance_spectator.callback('func_a', before=first_before, after=first_after)
+    def before_origin(inst, call):
+        inst.origin_beforeback_called = True
+        r = Redirect('origin', 'target', inst, call.args, call.kwargs)
+        assert inst.target_beforeback_called
+        return call, r
+    def after_origin(inst, answer):
+        assert inst.origin_method_called
+        assert not test.target_method_called
 
-	wa.func_a(1)
+        call, redirect = answer.before
+        out = redirect(answer.value)
 
-	assert captured_from_redirect == [1, 1]
-	assert not wa.called_func_b
+        call.update(name='target')
+        assert inst.target_afterback_called
+        assert out == (inst, call, answer.value)
+        inst.origin_afterback_called = True
+
+    test.instance_spectator.callback('origin', before_origin, after_origin)    
+
+    test.origin(0)
+
+    assert test.origin_beforeback_called
+    assert test.origin_afterback_called
+
+
+class TestEvenftul(TestCase):
+
+    def test_builtin_event_registration(self):
+        class Test(CopyClass):
+            def long_method_name(self):
+                pass
+        class MyEventful(Eventful):
+            klass = Test
+            event_map = {'method': 'long_method_name'}
+            def _before_method(self, inst, call): pass
+            def _after_method(self, inst, answer): pass
+
+        e = MyEventful(Test())
+        assert len(e._active_events) == 1
+        assert e._active_events[0] == (
+            'method', 'long_method_name',
+            e._before_method, e._after_method)
+
+    def test_user_event_registration(self):
+        class Test(CopyClass):
+            def long_method_name(self):
+                pass
+
+        e = Eventful(default_value=Test())
+        before = lambda inst, call: None
+        after = lambda inst, answer: None
+        e.event('method', 'long_method_name', before, after)
+        assert len(e._active_events) == 1
+        assert e._active_events[0] == (
+            'method', 'long_method_name',
+            before, after)
+
+    def test_watched_type_creation(self):
+        class Test(CopyClass):
+            def long_method_name(self):
+                pass
+
+        before = lambda inst, call: None
+        after = lambda inst, answer: None
+
+        class MyHasTraits(HasTraits):
+            e = Eventful(default_value=Test()
+                    ).event('method',
+                        'long_method_name',
+                        before, after
+                    )
+        method = MyHasTraits.e.watched_type.long_method_name
+        assert isinstance(method, spectate.MethodSpectator)
+
+    def test_watched_type_wrapping(self):
+        class Test(CopyClass):
+            def long_method_name(self):
+                pass
+
+        before = lambda inst, call: None
+        after = lambda inst, answer: None
+
+        class MyHasTraits(HasTraits):
+            e = Eventful(default_value=Test()
+                    ).event('method',
+                        'long_method_name',
+                        before, after
+                    )
+        mht = MyHasTraits()
+        value = mht.e
+        assert isinstance(value, spectate.WatchedType)
+        reg = mht.e.instance_spectator._callback_registry
+        callbacks = tuple(c.func for c in reg['long_method_name'][0])
+        assert callbacks == (before, after)

--- a/traitlets/tests/test_eventful.py
+++ b/traitlets/tests/test_eventful.py
@@ -1,0 +1,44 @@
+from ..traitlets import HasTraits
+from ..eventful import Eventful, Bunch, Beforeback, Afterback
+
+def test_beforeback():
+	class A(HasTraits):
+		e = Eventful()
+
+	before = lambda inst, call: (inst, call)
+	bb = Beforeback(A.e, 'type', before)
+
+	inst, call = bb(A(), Bunch())
+	assert call == Bunch(owner=inst,
+		type='type', trait=A.e)
+
+def test_afterback():
+	class A(HasTraits):
+		e = Eventful()
+
+	a = A()
+	call = Bunch(name='func', args=(), kwargs={})
+
+	# beforeback returns a value for an afterback
+	before = lambda inst, call: (inst, call)
+
+	make_answer = lambda : Bunch(
+		before=before(a, call),
+		name='func', value=None)
+
+	after = lambda inst, answer: (inst, answer)
+	ab = Afterback(A.e, 'type', after)
+
+	answer = make_answer()
+	result = ab(a, answer)
+	assert result == (a, answer)
+
+	# beforeback returns a closure instead of a value
+	before = lambda inst, call: lambda value: (inst, call, value)
+
+	# afterback must be None to trigger closure
+	ab = Afterback(A.e, 'type', None)
+
+	answer = make_answer()
+	result = ab(a, answer)
+	assert result == (a, call, None)

--- a/traitlets/tests/test_eventful.py
+++ b/traitlets/tests/test_eventful.py
@@ -1,8 +1,10 @@
 from ..traitlets import HasTraits
-from ..eventful import Eventful, Bunch, Beforeback, Afterback
+from ..eventful import Eventful, Bunch, Beforeback, Afterback, Redirect
+from ..utils import spectate
 
 def test_beforeback():
 	class A(HasTraits):
+		# not a functional trait
 		e = Eventful()
 
 	before = lambda inst, call: (inst, call)
@@ -12,7 +14,7 @@ def test_beforeback():
 	assert call == Bunch(owner=inst,
 		type='type', trait=A.e)
 
-def test_afterback():
+def test_afterback_value():
 	class A(HasTraits):
 		e = Eventful()
 
@@ -27,18 +29,69 @@ def test_afterback():
 		name='func', value=None)
 
 	after = lambda inst, answer: (inst, answer)
-	ab = Afterback(A.e, 'type', after)
+	ab = Afterback(A.e, 'type', after=after)
 
 	answer = make_answer()
 	result = ab(a, answer)
 	assert result == (a, answer)
 
+def test_afterback_closure():
+	class A(HasTraits):
+		# not a functional trait
+		e = Eventful()
+
+	a = A()
+	call = Bunch(name='func', args=(), kwargs={})
+
 	# beforeback returns a closure instead of a value
 	before = lambda inst, call: lambda value: (inst, call, value)
 
-	# afterback must be None to trigger closure
-	ab = Afterback(A.e, 'type', None)
+	make_answer = lambda : Bunch(
+		before=before(a, call),
+		name='func', value=None)
 
-	answer = make_answer()
-	result = ab(a, answer)
+	# afterback must be None to trigger closure
+	ab = Afterback(A.e, 'type', after=None)
+
+	result = ab(a, make_answer())
 	assert result == (a, call, None)
+
+def test_redirect():
+	class A(object):
+		called_func_b = False
+		def func_a(self, a):
+			return a
+		def func_b(self, b):
+			self.called_func_b = True
+			return b
+
+	wa = spectate.watched_type('WA', A, 'func_a', 'func_b')()
+	# beforeback returns a closure that returns method output
+	def last_before(inst, call):
+		def last_after(value):
+			print(value)
+			return value
+		return last_after
+
+	# register two beforebacks to test that
+	# the redirect returns results from both
+	wa.instance_spectator.callback('func_b', before=last_before)
+	wa.instance_spectator.callback('func_b', before=last_before)
+
+	def first_before(inst, call):
+		# redirect to trigger the before/after backs of func_b
+		return Redirect(inst, 'func_a', 'func_b', call.args, call.kwargs)
+
+	captured_from_redirect = []
+
+	def first_after(inst, answer):
+		out = answer.before(answer.value)
+		captured_from_redirect.extend(out)
+		return out
+
+	wa.instance_spectator.callback('func_a', before=first_before, after=first_after)
+
+	wa.func_a(1)
+
+	assert captured_from_redirect == [1, 1]
+	assert not wa.called_func_b

--- a/traitlets/utils/bunch.py
+++ b/traitlets/utils/bunch.py
@@ -23,3 +23,6 @@ class Bunch(dict):
         names.extend(self.keys())
         return names
 
+    def copy(self):
+        return Bunch(self)
+

--- a/traitlets/utils/sentinel.py
+++ b/traitlets/utils/sentinel.py
@@ -11,7 +11,8 @@ class Sentinel(object):
         if docstring:
             self.__doc__ = docstring
 
-
     def __repr__(self):
         return str(self.module)+'.'+self.name
 
+    def __str__(self):
+    	return self.name

--- a/traitlets/utils/spectate.py
+++ b/traitlets/utils/spectate.py
@@ -1,0 +1,170 @@
+import six
+import types
+import inspect
+from .bunch import Bunch
+
+
+
+def getargspec(func):
+    if isinstance(func, types.FunctionType) or isinstance(func, types.MethodType):
+        return inspect.getargspec(func)
+    else:
+        # no signature introspection is available for this type
+        return inspect.ArgSpec(None, 'args', 'kwargs', None)
+
+
+class WatchedType(object):
+    """An eventful base class purely for introspection"""
+    pass
+
+
+class Spectator(object):
+
+    def __init__(self, base, subclass):
+        self.base = base
+        self.subclass = subclass
+        self._callback_registry = {}
+
+    def callback(self, name, before=None, after=None):
+        if not isinstance(getattr(self.subclass, name), MethodSpectator):
+            raise ValueError("No method specator for '%s'" % name)
+        if before is None and after is None:
+            raise ValueError("No pre or post '%s' callbacks were given" % name)
+        elif ((before is not None and not callable(before))
+            or (after is not None and not callable(after))):
+            raise ValueError("Expected a callables")
+
+        if name in self._callback_registry:
+            l = self._callback_registry[name]
+        else:
+            l = []
+            self._callback_registry[name] = l
+        l.append((before, after))
+
+    def remove_callback(self, name, before=None, after=None):
+        if name in self._callback_registry:
+            l = self._callback_registry[name]
+        else:
+            l = []
+            self._callback_registry[name] = l
+        l.remove((before, after))
+
+    def wrapper(self, name, args, kwargs):
+        """A callback made prior to calling the given base method
+
+        Parameters
+        ----------
+        name: str
+            The name of the method that will be called
+        args: tuple
+            The arguments that will be passed to the base method
+        kwargs: dict
+            The keyword args that will be passed to the base method
+        """
+        if name in self._callback_registry:
+            beforebacks, afterbacks = zip(*self._callback_registry.get(name, []))
+
+            hold = []
+            for b in beforebacks:
+                if b is not None:
+                    call = Bunch(name=name,
+                        kwargs=kwargs.copy(),
+                        args=args[:])
+                    v = b(args[0], call)
+                else:
+                    v = None
+                hold.append(v)
+
+            out = getattr(self.base, name)(*args, **kwargs)
+
+            for a, bval in zip(afterbacks, hold):
+                if a is not None:
+                    a(args[0], Bunch(before=bval,
+                        name=name, value=out))
+                elif callable(bval):
+                    # the beforeback's return value was an
+                    # afterback that expects to be called
+                    bval(out)
+            return out
+        else:
+            return getattr(self.base, name)(*args, **kwargs)
+
+
+class MethodSpectator(object):
+
+    _compile_count = 0
+    _src_str = """def {name}({signature}):
+    args, varargs, kwargs = [{args}], {varargs}, {keywords}
+    args.extend(varargs)
+    return args[0].instance_spectator.wrapper(
+        '{name}', tuple(args), kwargs.copy())"""
+
+    def __init__(self, base, name):
+        self.base, self.name = base, name
+        aspec = getargspec(self.basemethod)
+        self.defaults = aspec.defaults
+        self.code, self.defaults = self._code(aspec)
+
+    @property
+    def basemethod(self):
+        return getattr(self.base, self.name)
+
+    def _code(self, aspec):
+        # list values were repred - remove quotes
+        args = str(aspec.args)[1:-1].replace("'", "")
+        signature = args + (", " if args else "")
+        if aspec.varargs is not None:
+            signature += '*' + aspec.varargs + ', '
+        if aspec.keywords is not None:
+            signature += '**' + aspec.keywords
+        if signature.endswith(', '):
+            signature = signature[:-2]
+        src = self._src_str.format(name=self.name,
+            signature=signature, args=args,
+            varargs=aspec.varargs or (),
+            keywords=aspec.keywords or {})
+        filename = "watched-method-gen-%d" % self._compile_count
+        code = compile(src, filename, 'single')
+        MethodSpectator._compile_count += 1
+        return code, aspec.defaults
+
+    def new_wrapper(self, inst):
+        evaldict = {}
+        eval(self.code, evaldict)
+        # extract wrapper by name
+        new = evaldict[self.name]
+        # assign docstring and defaults
+        new.__doc__ = self.basemethod.__doc__
+        new.__defaults__ = self.defaults
+        return types.MethodType(new, inst)
+
+    def __call__(self, *args, **kwargs):
+        return self.new_wrapper(None, self.base)(*args, **kwargs)
+
+    def __get__(self, inst, cls):
+        if inst is None:
+            return self
+        elif inst.instance_spectator is None:
+            return types.MethodType(self.basemethod, inst)
+        else:
+            return self.new_wrapper(inst)
+
+
+def watched_type(name, base, *notify_on):
+    classdict = base.__dict__.copy()
+
+    def __new__(cls, *args, **kwargs):
+        inst = base.__new__(cls, *args, **kwargs)
+        object.__setattr__(inst, 'instance_spectator', Spectator(base, cls))
+        return inst
+
+    classdict['__new__'] = __new__
+
+    for method in notify_on:
+        if not hasattr(base, method):
+            raise ValueError("Cannot notify on '%s', because '%s' "
+                "instances lack this method" % (method, base.__name__))
+        else:
+            classdict[method] = MethodSpectator(base, method)
+
+    return type(name, (base, WatchedType), classdict)

--- a/traitlets/utils/tests/test_spectate.py
+++ b/traitlets/utils/tests/test_spectate.py
@@ -1,0 +1,80 @@
+import inspect
+from unittest import TestCase
+from ..spectate import watched_type, WatchedType, MethodSpectator, Spectator, Bunch
+
+def test_watched_type():
+	WatchedList = watched_type(
+		'WatchedList', list, 'append')
+
+	assert WatchedList.__name__ == 'WatchedList'
+	assert issubclass(WatchedList, list)
+	assert issubclass(WatchedList, WatchedType)
+	assert isinstance(WatchedList.append, MethodSpectator)
+
+	wl = WatchedList()
+	assert hasattr(wl, 'instance_spectator')
+	assert isinstance(wl.instance_spectator, Spectator)
+
+def test_method_spectator():
+	MethodSpectator._compile_count = 0
+	WatchedList = watched_type(
+		'WatchedList', list, 'append')
+	assert MethodSpectator._compile_count == 1
+	append = WatchedList.append
+
+	assert append.basemethod is list.append
+	assert append.name == 'append'
+
+	wl = WatchedList()
+	wl.append(1)
+	wl.append(2)
+	assert wl == [1, 2]
+
+	class Thing(object):
+		def func(self, a, b, c=None, d=None, *e, **f):
+			pass
+
+	WatchedThing = watched_type('WatchedThing', Thing, 'func')
+	assert MethodSpectator._compile_count == 2
+	assert (inspect.getargspec(Thing().func) ==
+		inspect.getargspec(WatchedThing().func))
+
+def expected_answer(func, *args, **kwargs):
+	name = func.__name__
+	inspect.getargspec(func)
+
+
+def test_spectator():
+	hold = []
+	def beforeback(inst, call):
+		return call
+	def afterback(inst, answer):
+		hold.append(answer)
+
+	class Thing(object):
+		def func(self, a, b, c=None, d=None, *e, **f):
+			return self, a, b, c, d, e, f
+
+	condense = lambda *a, **kw: (a, kw)
+
+	def verify_answer(inst, name, a, b, c=None, d=None, *e, **f):
+		getattr(inst, name)(a, b, c, d, *e, **f)
+		args, kwargs = condense(inst, a, b, c, d, *e, **f)
+		assert hold[-1] == Bunch(
+			name=name,
+			value=(inst, a, b, c, d, e, f),
+			before=Bunch(
+				name=name,
+				args=args,
+				kwargs=kwargs))
+
+	WatchedThing = watched_type('WatchedThing', Thing, 'func')
+	wt = WatchedThing()
+
+	wt.instance_spectator.callback('func',
+		before=beforeback, after=afterback)
+
+	verify_answer(wt, 'func', 1, 2, c=3)
+	verify_answer(wt, 'func', 1, 2, d=3)
+	verify_answer(wt, 'func', 1, 2, 3, 4, 5)
+	verify_answer(wt, 'func', 1, 2, d=3, f=4)

--- a/traitlets/utils/tests/test_spectate.py
+++ b/traitlets/utils/tests/test_spectate.py
@@ -44,7 +44,7 @@ class Thing(object):
 		return inst,  a, b, c, d, e, f
 
 def check_answer(checklist, inst, name, a, b, c=None, d=None, *e, **f):
-	args, kwargs = condense(inst, a, b, c, d, *e, **f)
+	args, kwargs = condense(a, b, c, d, *e, **f)
 	checklist.append(Bunch(
 		name=name,
 		value=(inst, a, b, c, d, e, f),

--- a/traitlets/utils/tests/test_spectate.py
+++ b/traitlets/utils/tests/test_spectate.py
@@ -1,5 +1,4 @@
 import inspect
-from unittest import TestCase
 from ..spectate import watched_type, WatchedType, MethodSpectator, Spectator, Bunch
 
 def test_watched_type():
@@ -41,8 +40,8 @@ def test_method_spectator():
 
 
 class Thing(object):
-	def func(self, a, b, c=None, d=None, *e, **f):
-		return self, a, b, c, d, e, f
+	def func(inst, a, b, c=None, d=None, *e, **f):
+		return inst,  a, b, c, d, e, f
 
 def check_answer(checklist, inst, name, a, b, c=None, d=None, *e, **f):
 	args, kwargs = condense(inst, a, b, c, d, *e, **f)


### PR DESCRIPTION
# Summary

An alternative to #278 

While #278 enables custom events to be built into `TraitType` subclasses, via custom classes with event hooks. This pull request exposes a generic `Eventful` base class for automatically creating event hooks for the desired type. Eventful subclasses need only defined these three class attributes:

+ `event_map` used to distribute notifications to `@observer` handlers:
	+ `{'setitem': '__setitem__'}` maps `obj.a[k] = v` to `@observer('a', type='setitem')`
+ `klass` (optional) the base class from which eventful classes are created:
	+ `klass` can also by inferred from the type of a default value.
	+ To create an eventful dictionary `klass` should be `dict`
+ `type_name` the name of the eventful type:
	+ `type(obj.a).__name__ == type_name`

# Callbacks & Redirects
	
To make callbacks that trigger before, and after an event (hereafter referred to as beforebacks and afterbacks respectively) define methods `_before_<event-type>` or `_after_<event-type>` on `Eventful` subclasses (e.g. `_before_setitem` and `_after_setitem`).

### Beforebacks
+ Signature: `(inst, call)`
	1. `inst`: the value to be set on the trait.
	2. `call`: a bunch with the keys:
		+ `name`: name of the method called
		+ `args`: the arguments that method was called with
		+ `kwargs`: the keyword arguments the method was called with
+ Return: `None`, value, or an afterback
	1. If `None` no notifications are distributed to `@observer` handlers.
	1. The value is distributed to `@observer` handlers under `change['event']`
	2. The afterback is a callable with a signature `(returned)`
		+ `returned is the output of the called method.
		+ The afterback returns `None` to prevent notifications, or a value as in [ii].

### Afterbacks
+ Signature: `(inst, answer)`
	1. `inst`: the value to be set on the trait.
	2. `call`: a bunch with the keys:
		+ `name`: name of the method called
		+ `value`: the value returned by that call
		+ `before`: if a beforeback was defined, this is the value it returned.
+ Return: `None` or a value
	1. `None` prevents notifications
	2. Any other value gets distributed to `@observer` handlers under `change['event']`

Beforebacks and Afterbacks give you the tools to create your notifications, however it's often the case that an object's method acts like it wraps several other method calls (e.g. `dict.update` acts like it wraps calls to `dict.__setitem__`). To accommodate this there are `Redirect` objects which are callable and can be returned by a beforeback in order to trigger one or more notifiers.

# Examples

We can easily create an `Eventful` subclass which notifies when new items are assigned:

```python
class EItems(Eventful):
    
    # we will infer the class from a default value
    event_map = {'setitem': ('__setitem__')}
    type_name = 'eitems'
    
    @staticmethod
    def _before_setitem(inst, call):
        """Expect call.args[0] = key"""
        key, = call.args[0]
        try:
            old = inst[key]
         except:
            old = Undefined
        return key, old
    
    @staticmethod
    def _after_setitem(inst, answer):
        key, old = answer.before
        if inst[key] != old:
            return Bunch(key=key, old=old, new=new)
```

We also include basic implementations for eventful lists and eventful dictionaries:

+ [eventful dictionary](https://github.com/rmorshea/traitlets/blob/61918970a51c2abdb4d0164148975a3da5016365/traitlets/eventful.py#L190-L223)
+ [eventful list](https://github.com/rmorshea/traitlets/blob/61918970a51c2abdb4d0164148975a3da5016365/traitlets/eventful.py#L226-L271)