### PR TITLE
Update examples to use an IPython config option which still exists

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -282,13 +282,13 @@ By default, values are assigned in much the same way as in a config file:
 
 .. code-block:: bash
 
-    $ ipython --InteractiveShell.use_readline=False --BaseIPythonApplication.profile='myprofile'
+    $ ipython --InteractiveShell.autoindent=False --BaseIPythonApplication.profile='myprofile'
 
 Is the same as adding:
 
 .. sourcecode:: python
 
-    c.InteractiveShell.use_readline=False
+    c.InteractiveShell.autoindent=False
     c.BaseIPythonApplication.profile='myprofile'
 
 to your configuration file. Key/Value arguments *always* take a value, separated by '='

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -776,7 +776,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
     """A config loader that loads aliases and flags with argparse,
     but will use KVLoader for the rest.  This allows better parsing
     of common args, such as `ipython -c 'print 5'`, but still gets
-    arbitrary config with `ipython --InteractiveShell.use_readline=False`"""
+    arbitrary config with `ipython --InteractiveShell.autoindent=False`"""
 
     def _add_arguments(self, aliases=None, flags=None):
         self.alias_flags = {}


### PR DESCRIPTION
Low priority, but it helps make things clearer.