### PR TITLE
Extendable TraitType Tags and Validators

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -116,6 +116,43 @@ class TestTraitType(TestCase):
         # should pass chained validators
         a.b = Z(1, 1)
 
+    def test_extend_allows(self):
+        def less_than(n):
+            def validator(trait, value):
+                if value < n:
+                    return value
+                else:
+                    raise TraitError("%s is not less than %s" % (value, n))
+            return validator
+
+        def greater_than(n):
+            def validator(trait, value):
+                if value > n:
+                    return value
+                else:
+                    raise TraitError("%s is not greater than %s" % (value, n))
+            return validator
+
+        class A(HasTraits):
+            i = Int(5).allows(less_than(10))
+
+        class B(A):
+            i = Int(5, extends='allows').allows(greater_than(0))
+
+        a = A()
+        self.assertRaises(TraitError, setattr, a, 'i', 15)
+
+        b = B()
+        self.assertRaises(TraitError, setattr, b, 'i', -5)
+        self.assertRaises(TraitError, setattr, b, 'i', 15)
+
+    def test_extend_tags(self):
+        class A(HasTraits):
+            i = Int().tag(x=1)
+        class B(A):
+            i = Int(extends='tags').tag(y=2)
+        self.assertEqual(B.i.metadata, {'x':1, 'y':2})
+
     def test_info(self):
         class A(HasTraits):
             tt = TraitType

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -97,6 +97,25 @@ class TestTraitType(TestCase):
             tt = MyIntTT('bad default')
         self.assertRaises(TraitError, B)
 
+    def test_allows(self):
+        class Z(object):
+            def __init__(self, x, y):
+                self.x, self.y = x, y
+
+        def test_x(trait, value):
+            if getattr(value, 'x', None) != 1:
+                raise TraitError("'x' must be 1")
+            return value
+
+        class A(HasTraits):
+            b = TraitType().allows(test_x, y=1)
+
+        a = A()
+        self.assertRaises(TraitError, setattr, a, 'b', Z(0, 1))
+        self.assertRaises(TraitError, setattr, a, 'b', Z(1, 0))
+        # should pass chained validators
+        a.b = Z(1, 1)
+
     def test_info(self):
         class A(HasTraits):
             tt = TraitType


### PR DESCRIPTION
Depends on #335

Extend chained validators:

``` python
def less_than(n):
    def validator(trait, value):
        if value < n:
            return value
        else:
            raise TraitError("%s is not less than %s" % (value, n))
    return validator

def greater_than(n):
    def validator(trait, value):
        if value > n:
            return value
        else:
            raise TraitError("%s is not greater than %s" % (value, n))
    return validator

class A(HasTraits):
    i = Int(5).allows(less_than(10))

class B(A):
    i = Int(5, extends='allows').allows(greater_than(0))

a = A()
a.i = -5 # pass
a.i = 15 # raise

b = B()
b.i = -5 # raise
b.i = 15 # raise
```

Extend trait metadata:

``` python
class A(HasTraits):
    i = Int().tag(x=1)
class B(A):
    i = Int(extends='tags').tag(y=2)

B.i.metadata # {'x':1, 'y':2}
```
