### PR TITLE
Enable deprecation warnings during test-suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 sudo: false
 install:
     - pip install .
-    - pip install traitlets[test] pytest-cov codecov
+    - pip install traitlets[test] pytest-cov codecov pytest-warnings
 script:
     - py.test --cov traitlets -v traitlets
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 sudo: false
 install:
     - pip install .
-    - pip install traitlets[test] pytest-cov codecov pytest-warnings
+    - pip install traitlets[test] pytest-cov codecov pytest-warnings --upgrade
 script:
     - py.test --cov traitlets -v traitlets
 after_success:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+filterwarnings=default


### PR DESCRIPTION
This requires pytest-warnings >=0.2