### PR TITLE
add Application.show_config[_json]

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -8,15 +8,12 @@ from __future__ import print_function
 
 from collections import defaultdict, OrderedDict
 from copy import deepcopy
-import io
 import json
 import logging
 import os
 import pprint
 import re
 import sys
-
-from decorator import decorator
 
 from traitlets.config.configurable import Configurable, SingletonConfigurable
 from traitlets.config.loader import (
@@ -371,14 +368,10 @@ class Application(SingletonConfigurable):
             print(classname)
             for traitname in sorted(class_config):
                 value = class_config[traitname]
-                sio = io.StringIO()
-                pprint.pprint(value, stream=sio)
-                vs = sio.getvalue()
-                sys.stdout.write('  .%s = ' % traitname)
-                if '\n' in vs.strip():
-                    sys.stdout.write('\n')
-                    vs = indent(vs, 4)
-                sys.stdout.write(vs)
+                print('  .{} = {}'.format(
+                    traitname,
+                    pprint.pformat(value, compact=True, indent=4),
+                ))
 
     def print_alias_help(self):
         """Print the alias part of the help."""

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -248,21 +248,21 @@ class Application(SingletonConfigurable):
     # this must be a dict of two-tuples, the first element being the Config/dict
     # and the second being the help string for the flag
     flags = {
-        'debug': {
+        'debug': ({
             'Application': {
                 'log_level': logging.DEBUG,
             },
-        },
-        'show-config': {
+        }, "Set log-level to debug, for the most verbose logging."),
+        'show-config': ({
             'Application': {
                 'show_config': True,
             },
-        },
-        'show-config-json': {
+        }, "Show the application's configuration (human-readable format)"),
+        'show-config-json': ({
             'Application': {
                 'show_config_json': True,
             },
-        },
+        }, "Show the application's configuration (json format)"),
     }
 
     # subcommands for launching other applications
@@ -346,6 +346,8 @@ class Application(SingletonConfigurable):
         if self.show_config_json:
             json.dump(self.config, sys.stdout,
                       indent=1, sort_keys=True, default=repr)
+            # add trailing newline
+            sys.stdout.write('\n')
             return
 
         if self._loaded_config_files:

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -366,11 +366,15 @@ class Application(SingletonConfigurable):
             if not class_config:
                 continue
             print(classname)
+            pformat_kwargs = dict(indent=4)
+            if sys.version_info >= (3,4):
+                # use compact pretty-print on Pythons that support it
+                pformat_kwargs['compact'] = True
             for traitname in sorted(class_config):
                 value = class_config[traitname]
                 print('  .{} = {}'.format(
                     traitname,
-                    pprint.pformat(value, compact=True, indent=4),
+                    pprint.pformat(value, **pformat_kwargs),
                 ))
 
     def print_alias_help(self):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -343,8 +343,16 @@ class Application(SingletonConfigurable):
 
     def start_show_config(self):
         """start function used when show_config is True"""
+        config = self.config.copy()
+        # exclude show_config flags from displayed config
+        for cls in self.__class__.mro():
+            if cls.__name__ in config:
+                cls_config = config[cls.__name__]
+                cls_config.pop('show_config', None)
+                cls_config.pop('show_config_json', None)
+
         if self.show_config_json:
-            json.dump(self.config, sys.stdout,
+            json.dump(config, sys.stdout,
                       indent=1, sort_keys=True, default=repr)
             # add trailing newline
             sys.stdout.write('\n')
@@ -356,11 +364,11 @@ class Application(SingletonConfigurable):
                 print('  ' + f)
             print()
 
-        for classname in sorted(self.config):
-            print(classname)
-            class_config = self.config[classname]
+        for classname in sorted(config):
+            class_config = config[classname]
             if not class_config:
                 continue
+            print(classname)
             for traitname in sorted(class_config):
                 value = class_config[traitname]
                 sio = io.StringIO()


### PR DESCRIPTION
setting this value will skip Application start and show loaded config on stdout, instead.


if `show_config_json` is given, it will be json-formatted.

- [x] tests

Applications can inherit the default flags from `traitlets.config.application.default_flags`,
but this can be triggered immediately with:

    any-jupyter-command --Application.show_config=True

cc @rgbkrk