### PR TITLE
Consolidated TraitType Defaults Into One Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 \#*#
 .#*
 .coverage
+.cache

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -212,6 +212,11 @@ class TestTraitType(TestCase):
         foo = Foo()
         self.assertEqual(foo.bar, 1)
 
+    def test_union_trait_default_value(self):
+        class Foo(HasTraits):
+            bar = Union([Dict(), Int()])
+        self.assertEqual(Foo().bar, {})
+
     def test_deprecated_metadata_access(self):
         class MyIntTT(TraitType):
             metadata = {'a': 1, 'b': 2}
@@ -1488,7 +1493,7 @@ class UnionListTrait(HasTraits):
 
     value = List(Int() | Bool())
 
-class TestUnionListTrait(HasTraits):
+class TestUnionListTrait(TraitTestBase):
 
     obj = UnionListTrait()
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -414,20 +414,15 @@ class TraitType(BaseDescriptor):
     """
 
     metadata = {}
-    default_value = Undefined
     allow_none = False
     read_only = False
     info_text = 'any value'
+    default_value = Undefined
 
     def class_init(self, cls, name):
         super(TraitType, self).class_init(cls, name)
-        if self.name not in cls._trait_default_generators:
-            if hasattr(self, 'make_dynamic_default'):
-                cls._trait_default_generators[self.name] = (
-                    lambda obj: self.make_dynamic_default())
-            elif self.default_value is not Undefined:
-                cls._trait_default_generators[self.name] = (
-                    lambda obj : self.default_value)
+        if self.name is not None and self.name not in cls._trait_default_generators:
+            cls._trait_default_generators[self.name] = self.default
 
     def subclass_init(self, cls):
         if '_%s_default' % self.name in cls.__dict__:
@@ -482,9 +477,21 @@ class TraitType(BaseDescriptor):
         if help is not None:
             self.metadata['help'] = help
 
+    def default(self, obj=None):
+        """The default generator for this trait
+
+        Notes
+        -----
+        This method is registered to HasTraits classes during ``class_init``
+        in the same way that dynamic defaults defined by ``@default`` are.
+        """
+        if hasattr(self, 'make_dynamic_default'):
+            return self.make_dynamic_default()
+        else:
+            return self.default_value
+
     def get_default_value(self):
         """DEPRECATED: Retrieve the static default value for this trait.
-
         Use self.default_value instead
         """
         warn("get_default_value is deprecated in traitlets 4.0: use the .default_value attribute", DeprecationWarning,
@@ -505,13 +512,12 @@ class TraitType(BaseDescriptor):
             value = obj._trait_values[self.name]
         except KeyError:
             # Check for a dynamic initializer.
-            try:
-                dgen = cls._trait_default_generators[self.name]
-            except:
+            default = cls._trait_default_generators[self.name](obj)
+            if default is Undefined:
                 raise TraitError("No default value found for "
                     "the '%s' trait named '%s' of %r" % (
                     type(self).__name__, self.name, obj))
-            value = self._validate(obj, dgen(obj))
+            value = self._validate(obj, default)
             obj._trait_values[self.name] = value
             return value
         except Exception:
@@ -1787,9 +1793,18 @@ class Union(TraitType):
         Union([Float(), Bool(), Int()]) attempts to validate the provided values
         with the validation function of Float, then Bool, and finally Int.
         """
-        self.trait_types = trait_types
+        self.trait_types = list(trait_types)
         self.info_text = " or ".join([tt.info() for tt in self.trait_types])
         super(Union, self).__init__(**kwargs)
+
+    def default(self, obj=None):
+        default = super(Union, self).default(obj)
+        for t in self.trait_types:
+            if default is Undefined:
+                default = t.default(obj)
+            else:
+                break
+        return default
 
     def class_init(self, cls, name):
         for trait_type in self.trait_types:
@@ -1819,15 +1834,6 @@ class Union(TraitType):
             return Union(self.trait_types + other.trait_types)
         else:
             return Union(self.trait_types + [other])
-
-    def make_dynamic_default(self):
-        if self.default_value is not Undefined:
-            return self.default_value
-        for trait_type in self.trait_types:
-            if trait_type.default_value is not Undefined:
-                return trait_type.default_value
-            elif hasattr(trait_type, 'make_dynamic_default'):
-                return trait_type.make_dynamic_default()
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #344
-------------

+ New method ``TraitType.default`` which acts exactly like the methods defined by `@default`.
	+ Due to #332, all default values are "dynamic" in the sense that they are made upon request. I created a new method that mirrors the name scheme of `@default` to help indicate this.
+ Fixes a test case inheriting from HasTraits instead of TestCase, which masked #344.
+ New test for `Union` defaults defined by "subtraits".

Note
-----
`TraitType.default` could be built into `make_dynamic_default` by extending its signature, but I'm slightly averse to this idea simply for the sake of uniformity between `TraitType.default` and `@default`, and the fact that the name `make_dynamic_default` is now redundant. If we choose to prefer `default` to `make_dynamic_default`, then the functionality of `make_dynamic_default` will be redundant too and would be on a track towards deprecation.
