### PR TITLE
Don't warn about correctly decorated default-value generators

### DIFF
--- a/traitlets/tests/_warnings.py
+++ b/traitlets/tests/_warnings.py
@@ -4,10 +4,15 @@
 __all__ = ['all_warnings', 'expected_warnings']
 
 from contextlib import contextmanager
+import inspect
+import os
+import re
 import sys
 import warnings
-import inspect
-import re
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 @contextmanager
@@ -55,7 +60,8 @@ def all_warnings():
         except AttributeError:
             pass
 
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as w, \
+            mock.patch.dict(os.environ, {'TRAITLETS_ALL_DEPRECATIONS': '1'}):
         warnings.simplefilter("always")
         yield w
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -139,6 +139,46 @@ class TestTraitType(TestCase):
         self.assertEqual(a.x, 11)
         self.assertEqual(a._trait_values, {'x': 11})
 
+    def test_deprecated_method_warnings(self):
+
+        with expected_warnings([]):
+            class ShouldntWarn(HasTraits):
+                x = Integer()
+                @default('x')
+                def _x_default(self):
+                    return 10
+
+                @validate('x')
+                def _x_validate(self, proposal):
+                    return proposal.value
+
+                @observe('x')
+                def _x_changed(self, change):
+                    pass
+
+            obj = ShouldntWarn()
+            obj.x = 5
+
+        assert obj.x == 5
+
+        with expected_warnings(['@default', '@validate', '@observe']) as w:
+            class ShouldWarn(HasTraits):
+                x = Integer()
+
+                def _x_default(self):
+                    return 10
+
+                def _x_validate(self, value, _):
+                    return value
+
+                def _x_changed(self):
+                    pass
+
+            obj = ShouldWarn()
+            obj.x = 5
+
+        assert obj.x == 5
+
     def test_dynamic_initializer(self):
 
         class A(HasTraits):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -427,8 +427,9 @@ class TraitType(BaseDescriptor):
     def subclass_init(self, cls):
         if '_%s_default' % self.name in cls.__dict__:
             method = getattr(cls, '_%s_default' % self.name)
-            _deprecated_method(method, cls, '_%s_default' % self.name,
-                "use @default decorator instead.")
+            if not isinstance(method, EventHandler):
+                _deprecated_method(method, cls, '_%s_default' % self.name,
+                    "use @default decorator instead.")
             cls._trait_default_generators[self.name] = method
 
     def __init__(self, default_value=Undefined, allow_none=False, read_only=None, help=None, **kwargs):


### PR DESCRIPTION
and test that deprecated-method warnings are shown when they should be and not shown when they shouldn't