### PR TITLE
Improve generated help and config messages

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -33,15 +33,15 @@ import six
 #-----------------------------------------------------------------------------
 # merge flags&aliases into options
 option_description = """
-The options below are convenience aliases to configurable class parameters, 
-as listed in the "Equivalent to" line for each option, below.
-Use '--help-all' to see all configurable class-parameters for some command.
-""".strip() # trim newlines of front and back
+The options below are convenience aliases to configurable class-options,
+as listed in the "Equivalent to" description-line of the aliases.
+To see all configurable class-options for some <cmd>, use:
+    <cmd> --help-all
+""".strip()  # trim newlines of front and back
 
 keyvalue_description = """
-To set the configurable class parameters listed in the sections below, 
-use command-line arguments like this: 
-    --Class.trait=value
+The command-line option below sets the respective configurable class-parameter:
+    --Class.parameter=value
 This line is evaluated in Python, so simple expressions are allowed.
 For instance, to set `C.a=[0,1,2]`, you may type this:
     --C.a='range(3)' 
@@ -374,7 +374,6 @@ class Application(SingletonConfigurable):
             return
         lines = ['Options']
         lines.append('=' * len(lines[0]))
-        lines.append('')
         for p in wrap_paragraphs(self.option_description):
             lines.append(p)
             lines.append('')
@@ -390,7 +389,6 @@ class Application(SingletonConfigurable):
 
         lines = ["Subcommands"]
         lines.append('=' * len(lines[0]))
-        lines.append('')
         for p in wrap_paragraphs(self.subcommand_description.format(
                     app=self.name)):
             lines.append(p)
@@ -414,8 +412,8 @@ class Application(SingletonConfigurable):
         if classes:
             help_classes = self._classes_with_config_traits()
             if help_classes:
-                print("Class parameters")
-                print("================")
+                print("Class options")
+                print("=============")
                 for p in wrap_paragraphs(self.keyvalue_description):
                     print(p)
                     print()

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -6,46 +6,45 @@
 
 from __future__ import print_function
 
+from collections import defaultdict, OrderedDict
 from copy import deepcopy
 import json
 import logging
 import os
 import re
 import sys
-from collections import defaultdict, OrderedDict
-
-from decorator import decorator
-
 from traitlets.config.configurable import Configurable, SingletonConfigurable
 from traitlets.config.loader import (
     KVArgParseConfigLoader, PyFileConfigLoader, Config, ArgumentError, ConfigFileNotFound, JSONFileConfigLoader
 )
-
 from traitlets.traitlets import (
     Bool, Unicode, List, Enum, Dict, Instance, TraitError, observe, observe_compat, default,
 )
+
+from decorator import decorator
+from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
 from ipython_genutils.text import indent, wrap_paragraphs, dedent
-from ipython_genutils import py3compat
-
 import six
+
 
 #-----------------------------------------------------------------------------
 # Descriptions for the various sections
 #-----------------------------------------------------------------------------
-
 # merge flags&aliases into options
 option_description = """
-Arguments that take values are actually convenience aliases to full
-Configurables, whose aliases are listed on the help line. For more information
-on full configurables, see '--help-all'.
+The options below are convenience aliases to configurable class parameters, 
+as listed in the "Equivalent to" line for each option, below.
+Use '--help-all' to see all configurable class-parameters for some command.
 """.strip() # trim newlines of front and back
 
 keyvalue_description = """
-Parameters are set from command-line arguments of the form:
-`--Class.trait=value`.
-This line is evaluated in Python, so simple expressions are allowed, e.g.::
-`--C.a='range(3)'` For setting C.a=[0,1,2].
+To set the configurable class parameters listed in the sections below, 
+use command-line arguments like this: 
+    --Class.trait=value
+This line is evaluated in Python, so simple expressions are allowed.
+For instance, to set `C.a=[0,1,2]`, you may type this:
+    --C.a='range(3)' 
 """.strip() # trim newlines of front and back
 
 # sys.argv can be missing, for example when python is embedded. See the docs
@@ -374,7 +373,7 @@ class Application(SingletonConfigurable):
         if not self.flags and not self.aliases:
             return
         lines = ['Options']
-        lines.append('-'*len(lines[0]))
+        lines.append('=' * len(lines[0]))
         lines.append('')
         for p in wrap_paragraphs(self.option_description):
             lines.append(p)
@@ -390,7 +389,7 @@ class Application(SingletonConfigurable):
             return
 
         lines = ["Subcommands"]
-        lines.append('-'*len(lines[0]))
+        lines.append('=' * len(lines[0]))
         lines.append('')
         for p in wrap_paragraphs(self.subcommand_description.format(
                     app=self.name)):
@@ -416,8 +415,7 @@ class Application(SingletonConfigurable):
             help_classes = self._classes_with_config_traits()
             if help_classes:
                 print("Class parameters")
-                print("----------------")
-                print()
+                print("================")
                 for p in wrap_paragraphs(self.keyvalue_description):
                     print(p)
                     print()

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -44,7 +44,7 @@ The command-line option below sets the respective configurable class-parameter:
     --Class.parameter=value
 This line is evaluated in Python, so simple expressions are allowed.
 For instance, to set `C.a=[0,1,2]`, you may type this:
-    --C.a='range(3)' 
+    --C.a='range(3)'
 """.strip() # trim newlines of front and back
 
 # sys.argv can be missing, for example when python is embedded. See the docs
@@ -438,7 +438,7 @@ class Application(SingletonConfigurable):
 
     def print_description(self):
         """Print the application description."""
-        for p in wrap_paragraphs(self.description):
+        for p in wrap_paragraphs(self.description or self.__doc__):
             print(p)
             print()
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -289,7 +289,7 @@ class Configurable(HasTraits):
         breaker = '#' + '-'*78
         parent_classes = ','.join(p.__name__ for p in cls.__bases__)
         s = "# %s(%s) configuration" % (cls.__name__, parent_classes)
-        lines = [breaker, s, breaker, '']
+        lines = [breaker, s, breaker]
         # get the description trait
         desc = cls.class_traits().get('description')
         if desc:

--- a/traitlets/tests/utils.py
+++ b/traitlets/tests/utils.py
@@ -1,6 +1,6 @@
+from subprocess import Popen, PIPE
 import sys
 
-from subprocess import Popen, PIPE
 
 def get_output_error_code(cmd):
     """Get stdout, stderr, and exit code from running a command"""
@@ -35,5 +35,5 @@ def check_help_all_output(pkg, subcommand=None):
     assert rc == 0, err
     assert "Traceback" not in err
     assert "Options" in out
-    assert "Class parameters" in out
+    assert "Class options" in out
     return out, err


### PR DESCRIPTION
- Assume a "user" viewpoint when explaining how configurables work - avoiding traitlets terminology where not necessary.
- Use `====` and `---` headers to denote hierarchical sections in the help message.
- Don't add blanklines below section-headers, `===` should be enough;
 this makes also the separation with the next section more visible.
- Distinguish "class-parameters" from "class-options" in the help-messages.
- Print `Application.__doc__` if no `app.description`.


For facilitating comparison, I'm providing sample help-msgs BEFORE and AFTER:

BEFORE:
```
Subcommands
-----------

Subcommands are launched as `co2dice cmd [args]`. For information on using
subcommand 'cmd', do: `co2dice cmd -h`.

project
    Commands to administer the storage repo of TA *projects*.
report
    Extract the report parameters from the co2mpas input/output files, or from *current-project*.

Options
-------

Arguments that take values are actually convenience aliases to full
Configurables, whose aliases are listed on the help line. For more information
on full configurables, see '--help-all'.

-d, --debug
    Log more logging, fail on configuration errors, and print configuration on each cmd startup.
    Equivalent to: [--Spec.log_level=0 --Application.log_level=0 --Cmd.raise_config_file_errors=True --Cmd.print_config=True]

Class parameters
----------------

Parameters are set from command-line arguments of the form:
`--Class.trait=value`. This line is evaluated in Python, so simple expressions
are allowed, e.g.:: `--C.a='range(3)'` For setting C.a=[0,1,2].

Application(SingletonConfigurable) options
------------------------------------------
--Application.log_level=<Enum>
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
```

AFTER:
```

Subcommands
===========
Subcommands are launched as `co2dice cmd [args]`. For information on using
subcommand 'cmd', do: `co2dice cmd -h`.

project
    Commands to administer the storage repo of TA *projects*.
report
    Extract the report parameters from the co2mpas input/output files, or from *current-project*.

Options
=======
The options below are convenience aliases to configurable class-options,
as listed in the "Equivalent to" description-line of the aliases.
To see all configurable class-options for some <cmd>, use:
    <cmd> --help-all

-d, --debug
    Log more logging, fail on configuration errors, and print configuration on each cmd startup.
    Equivalent to: [--Application.log_level=0 --Spec.log_level=0 --Cmd.print_config=True --Cmd.raise_config_file_errors=True]

Class options
=============
The command-line option below sets the respective configurable class-parameter:
    --Class.parameter=value
This line is evaluated in Python, so simple expressions are allowed.
For instance, to set `C.a=[0,1,2]`, you may type this:
    --C.a='range(3)'

Application(SingletonConfigurable) options
------------------------------------------
--Application.log_level=<Enum>
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
```