### PR TITLE
Merge class config dicts when flattening flags

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -522,7 +522,12 @@ class Application(SingletonConfigurable):
                 # exactly one descendent, promote flag section
                 if len(children) == 1:
                     cls = children[0]
-                newflag[cls] = subdict
+
+                if cls in newflag:
+                    newflag[cls].update(subdict)
+                else:
+                    newflag[cls] = subdict
+
             if not isinstance(key, tuple):
                 key = (key, )
             for k in key:


### PR DESCRIPTION
Closes ipython/ipython#10088

This is not a technically correct fix, but it's probably good enough for any cases in our code. The whole `flatten_flags` method seems like a very awkward workaround to make one priority ordering more important than another. It only 'flattens' one level of inheritance, and it ignores that parent classes may be instantiated. It skips over any parent class with multiple configurable children.