### PR TITLE
Pin docs build to Python 3.5

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - conda
 dependencies:
-  - python=3
+  - python==3.5
   - ipython_genutils
   - sphinx
   - sphinx_rtd_theme


### PR DESCRIPTION
3.6 is currently failing for RTD. Pin to 3.5 for now.