### PR TITLE
Add factory method on Application for customizing the Loader parsing cmd-line args

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -33,15 +33,15 @@ import six
 #-----------------------------------------------------------------------------
 # merge flags&aliases into options
 option_description = """
-The options below are convenience aliases to configurable class parameters, 
-as listed in the "Equivalent to" line for each option, below.
-Use '--help-all' to see all configurable class-parameters for some command.
-""".strip() # trim newlines of front and back
+The options below are convenience aliases to configurable class-options,
+as listed in the "Equivalent to" description-line of the aliases.
+To see all configurable class-options for some <cmd>, use:
+    <cmd> --help-all
+""".strip()  # trim newlines of front and back
 
 keyvalue_description = """
-To set the configurable class parameters listed in the sections below, 
-use command-line arguments like this: 
-    --Class.trait=value
+The command-line option below sets the respective configurable class-parameter:
+    --Class.parameter=value
 This line is evaluated in Python, so simple expressions are allowed.
 For instance, to set `C.a=[0,1,2]`, you may type this:
     --C.a='range(3)' 
@@ -374,7 +374,6 @@ class Application(SingletonConfigurable):
             return
         lines = ['Options']
         lines.append('=' * len(lines[0]))
-        lines.append('')
         for p in wrap_paragraphs(self.option_description):
             lines.append(p)
             lines.append('')
@@ -390,7 +389,6 @@ class Application(SingletonConfigurable):
 
         lines = ["Subcommands"]
         lines.append('=' * len(lines[0]))
-        lines.append('')
         for p in wrap_paragraphs(self.subcommand_description.format(
                     app=self.name)):
             lines.append(p)
@@ -414,8 +412,8 @@ class Application(SingletonConfigurable):
         if classes:
             help_classes = self._classes_with_config_traits()
             if help_classes:
-                print("Class parameters")
-                print("================")
+                print("Class options")
+                print("=============")
                 for p in wrap_paragraphs(self.keyvalue_description):
                     print(p)
                     print()

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -6,46 +6,45 @@
 
 from __future__ import print_function
 
+from collections import defaultdict, OrderedDict
 from copy import deepcopy
 import json
 import logging
 import os
 import re
 import sys
-from collections import defaultdict, OrderedDict
-
-from decorator import decorator
-
 from traitlets.config.configurable import Configurable, SingletonConfigurable
 from traitlets.config.loader import (
     KVArgParseConfigLoader, PyFileConfigLoader, Config, ArgumentError, ConfigFileNotFound, JSONFileConfigLoader
 )
-
 from traitlets.traitlets import (
     Bool, Unicode, List, Enum, Dict, Instance, TraitError, observe, observe_compat, default,
 )
+
+from decorator import decorator
+from ipython_genutils import py3compat
 from ipython_genutils.importstring import import_item
 from ipython_genutils.text import indent, wrap_paragraphs, dedent
-from ipython_genutils import py3compat
-
 import six
+
 
 #-----------------------------------------------------------------------------
 # Descriptions for the various sections
 #-----------------------------------------------------------------------------
-
 # merge flags&aliases into options
 option_description = """
-Arguments that take values are actually convenience aliases to full
-Configurables, whose aliases are listed on the help line. For more information
-on full configurables, see '--help-all'.
+The options below are convenience aliases to configurable class parameters, 
+as listed in the "Equivalent to" line for each option, below.
+Use '--help-all' to see all configurable class-parameters for some command.
 """.strip() # trim newlines of front and back
 
 keyvalue_description = """
-Parameters are set from command-line arguments of the form:
-`--Class.trait=value`.
-This line is evaluated in Python, so simple expressions are allowed, e.g.::
-`--C.a='range(3)'` For setting C.a=[0,1,2].
+To set the configurable class parameters listed in the sections below, 
+use command-line arguments like this: 
+    --Class.trait=value
+This line is evaluated in Python, so simple expressions are allowed.
+For instance, to set `C.a=[0,1,2]`, you may type this:
+    --C.a='range(3)' 
 """.strip() # trim newlines of front and back
 
 # sys.argv can be missing, for example when python is embedded. See the docs
@@ -374,7 +373,7 @@ class Application(SingletonConfigurable):
         if not self.flags and not self.aliases:
             return
         lines = ['Options']
-        lines.append('-'*len(lines[0]))
+        lines.append('=' * len(lines[0]))
         lines.append('')
         for p in wrap_paragraphs(self.option_description):
             lines.append(p)
@@ -390,7 +389,7 @@ class Application(SingletonConfigurable):
             return
 
         lines = ["Subcommands"]
-        lines.append('-'*len(lines[0]))
+        lines.append('=' * len(lines[0]))
         lines.append('')
         for p in wrap_paragraphs(self.subcommand_description.format(
                     app=self.name)):
@@ -416,8 +415,7 @@ class Application(SingletonConfigurable):
             help_classes = self._classes_with_config_traits()
             if help_classes:
                 print("Class parameters")
-                print("----------------")
-                print()
+                print("================")
                 for p in wrap_paragraphs(self.keyvalue_description):
                     print(p)
                     print()

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -44,7 +44,7 @@ The command-line option below sets the respective configurable class-parameter:
     --Class.parameter=value
 This line is evaluated in Python, so simple expressions are allowed.
 For instance, to set `C.a=[0,1,2]`, you may type this:
-    --C.a='range(3)' 
+    --C.a='range(3)'
 """.strip() # trim newlines of front and back
 
 # sys.argv can be missing, for example when python is embedded. See the docs
@@ -438,7 +438,7 @@ class Application(SingletonConfigurable):
 
     def print_description(self):
         """Print the application description."""
-        for p in wrap_paragraphs(self.description):
+        for p in wrap_paragraphs(self.description or self.__doc__):
             print(p)
             print()
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -530,6 +530,10 @@ class Application(SingletonConfigurable):
                 flags[k] = (newflag, help)
         return flags, aliases
 
+    def _create_loader(self, argv, aliases, flags, classes):
+        return KVArgParseConfigLoader(argv, aliases, flags, classes=classes,
+                                      log=self.log)
+
     @catch_config_error
     def parse_command_line(self, argv=None):
         """Parse the command line arguments."""
@@ -567,9 +571,7 @@ class Application(SingletonConfigurable):
         # flatten flags&aliases, so cl-args get appropriate priority:
         flags,aliases = self.flatten_flags()
         classes = tuple(self._classes_with_config_traits())
-        loader = KVArgParseConfigLoader(argv=argv, aliases=aliases,
-                                        flags=flags, log=self.log,
-                                        classes=classes)
+        loader = self._create_loader(argv, aliases, flags, classes=classes)
         self.cli_config = deepcopy(loader.load_config())
         self.update_config(self.cli_config)
         # store unparsed args in extra_args

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -289,7 +289,7 @@ class Configurable(HasTraits):
         breaker = '#' + '-'*78
         parent_classes = ','.join(p.__name__ for p in cls.__bases__)
         s = "# %s(%s) configuration" % (cls.__name__, parent_classes)
-        lines = [breaker, s, breaker, '']
+        lines = [breaker, s, breaker]
         # get the description trait
         desc = cls.class_traits().get('description')
         if desc:

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -552,7 +552,7 @@ class CommandLineConfigLoader(ConfigLoader):
                             lhs, rhs)
                     )
                     value = self._parse_config_value(r)
-                
+
             if value is None:
                 value = [self._parse_config_value(r) for r in rhs]
         else:
@@ -732,7 +732,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
 class ArgParseConfigLoader(CommandLineConfigLoader):
     """A loader that uses the argparse module to load from the command line."""
 
-    def __init__(self, argv=None, aliases=None, flags=None, log=None, classes=None,
+    def __init__(self, argv=None, aliases=None, flags=None, log=None, classes=(),
                  *parser_args, **parser_kw):
         """Create a config loader for use with argparse.
 
@@ -767,7 +767,7 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
         self.argv = argv
         self.aliases = aliases or {}
         self.flags = flags or {}
-        self.classes = classes or ()
+        self.classes = classes
 
         self.parser_args = parser_args
         self.version = parser_kw.pop("version", None)

--- a/traitlets/tests/utils.py
+++ b/traitlets/tests/utils.py
@@ -1,6 +1,6 @@
+from subprocess import Popen, PIPE
 import sys
 
-from subprocess import Popen, PIPE
 
 def get_output_error_code(cmd):
     """Get stdout, stderr, and exit code from running a command"""
@@ -35,5 +35,5 @@ def check_help_all_output(pkg, subcommand=None):
     assert rc == 0, err
     assert "Traceback" not in err
     assert "Options" in out
-    assert "Class parameters" in out
+    assert "Class options" in out
     return out, err


### PR DESCRIPTION
Add capability to modify the the Loader used to parse cmd-lines used by `Application` class (currently the `KVArgParseConfigLoader` class) *without* fully reimplementing `Application.parse_command_line()` method.

### Rationale
With the above customization it is easier to modify the *argparse* parser, which has been enabled by #322.
A case where the above is needed arrives in projects with multiple sub-cmds, where some cmd-names clash, and argparse "conflicts" occur (when adding the same option, twice).  

While the [*argparse* constructor](https://docs.python.org/3.6/library/argparse.html#argumentparser-objects) offers the [`conflict_handler='resolve'`](https://docs.python.org/3.6/library/argparse.html#conflict-handler) strategy,and there exists an [`argparse` factory](/ipython/traitlets/blob/master/traitlets/config/loader.py#L802-L804) method on the Loder, there is no equivalent factory method on the Application for the Loader itself - that means that you cannot modify the former factory by switching Loader implementations.

An alternative would be to add all `*argparse_args` and `**argparse_kwds` on`Application` class, and pass them when constructing the Loader, which should then pass them to `argparse`, but a) this violates blatantly the Demeter law adding dead weight for most cases, and b) it should be *easier* to override the Loader, which might be necessary for other cases.
