### PR TITLE
Support callable subcommands

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -379,11 +379,29 @@ after :command:`git`, and are called with the form :command:`command subcommand
 
     $ ipython qtconsole --profile myprofile
 
-Subcommands are specified as a dictionary on :class:`~traitlets.config.Application`
-instances, mapping subcommand names to two-tuples containing:
 
-1. The application class for the subcommand, or a string which can be imported
-   to give this.
+.. currentmodule::  traitlets.config
+
+Subcommands are specified as a dictionary on :class:`~traitlets.config.Application`
+instances, mapping *subcommand names* to two-tuples containing these:
+
+1. A subclass of :class:`Application` to handle the subcommand.
+   This can be specified as:
+   - simply as a class, where its :meth:`SingletonConfigurable.instance()`
+     will be invoked (straight-forward, but loads subclasses on import time);
+   - as a string which can be imported to produce the above class;
+   - as a factory function accepting a single argument like that::
+
+       app_factory(parent_app: Application) -> Application
+
+     .. note::
+        The return value of the facory above is an *instance*, not a class,
+        son the :meth:`SingletonConfigurable.instance()` is not invoked
+        in this case.
+
+   In all cases, the instanciated app is stored in :attr:`Application.subapp`
+   and its :meth:`Application.initialize()` is invoked.
+
 2. A short description of the subcommand for use in help output.
 
 To see a list of the available aliases, flags, and subcommands for a configurable

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -324,6 +324,10 @@ that are single characters, in which case they can be specified with a single ``
 Flags and aliases are declared by specifying ``flags`` and ``aliases``
 attributes as dictionaries on subclasses of :class:`~traitlets.config.Application`.
 
+A key in both those dictionaries might be a string or tuple of strings.
+One-character strings are converted into "short" options (like ``-v``); longer strings
+are "long" options (like ``--verbose``).
+
 Aliases
 *******
 
@@ -337,6 +341,9 @@ to specify the whole class name:
     $ ipython --profile='myprofile'
     # are equivalent to
     $ ipython --BaseIPythonApplication.profile='myprofile'
+
+When specifying ``alias`` dictionary in code, the values might be the strings
+like ``'Class.trait'`` or two-tuples like ``('Class.trait', "Some help message")``.
 
 Flags
 *****
@@ -373,7 +380,7 @@ after :command:`git`, and are called with the form :command:`command subcommand
     $ ipython qtconsole --profile myprofile
 
 Subcommands are specified as a dictionary on :class:`~traitlets.config.Application`
-instances, mapping subcommand names to 2-tuples containing:
+instances, mapping subcommand names to two-tuples containing:
 
 1. The application class for the subcommand, or a string which can be imported
    to give this.

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -468,18 +468,24 @@ class Application(SingletonConfigurable):
     @catch_config_error
     def initialize_subcommand(self, subc, argv=None):
         """Initialize a subcommand with argv."""
-        subapp,help = self.subcommands.get(subc)
+        subapp, _ = self.subcommands.get(subc)
 
         if isinstance(subapp, six.string_types):
             subapp = import_item(subapp)
-        elif isinstance(subapp, callable):
-            subapp = subapp()
 
-        # clear existing instances
-        self.__class__.clear_instance()
-        # instantiate
-        self.subapp = subapp.instance(parent=self)
-        # and initialize subapp
+        ## Cannot issubclass() on a non-type (SOhttp://stackoverflow.com/questions/8692430)
+        if isinstance(subapp, type) and issubclass(subapp, Application):
+            # Clear existing instances before...
+            self.__class__.clear_instance()
+            # instantiating subapp...
+            self.subapp = subapp.instance(parent=self)
+        elif callable(subapp):
+            # or ask factory to create it...
+            self.subapp = subapp(self)
+        else:
+            raise AssertionError('Invalid mappings for subcommand %s!' % subc)
+
+        # ... and finally initialize subapp.
         self.subapp.initialize(argv)
 
     def flatten_flags(self):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -472,6 +472,8 @@ class Application(SingletonConfigurable):
 
         if isinstance(subapp, six.string_types):
             subapp = import_item(subapp)
+        elif isinstance(subapp, callable):
+            subapp = subapp()
 
         # clear existing instances
         self.__class__.clear_instance()

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -253,6 +253,13 @@ class Configurable(HasTraits):
             header = '%s=<%s>' % (header, trait.__class__.__name__)
         #header = "--%s.%s=<%s>" % (cls.__name__, trait.name, trait.__class__.__name__)
         lines.append(header)
+
+        if helptext is None:
+            helptext = trait.help
+        if helptext != '':
+            helptext = '\n'.join(wrap_paragraphs(helptext, 76))
+            lines.append(indent(helptext, 4))
+
         if inst is not None:
             lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))
         else:
@@ -268,11 +275,6 @@ class Configurable(HasTraits):
             # include Enum choices
             lines.append(indent('Choices: %r' % (trait.values,)))
 
-        if helptext is None:
-            helptext = trait.help
-        if helptext != '':
-            helptext = '\n'.join(wrap_paragraphs(helptext, 76))
-            lines.append(indent(helptext, 4))
         return '\n'.join(lines)
 
     @classmethod

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -227,11 +227,14 @@ class Configurable(HasTraits):
         return '\n'.join(final_help)
 
     @classmethod
-    def class_get_trait_help(cls, trait, inst=None):
-        """Get the help string for a single trait.
+    def class_get_trait_help(cls, trait, inst=None, helptext=None):
+        """Get the helptext string for a single trait.
 
-        If `inst` is given, it's current trait values will be used in place of
-        the class default.
+        :param inst:
+            If given, it's current trait values will be used in place of
+            the class default.
+        :param helptext:
+            If not given, uses the `help` attribute of the current trait.
         """
         assert inst is None or isinstance(inst, cls)
         lines = []
@@ -265,10 +268,11 @@ class Configurable(HasTraits):
             # include Enum choices
             lines.append(indent('Choices: %r' % (trait.values,)))
 
-        help = trait.help
-        if help != '':
-            help = '\n'.join(wrap_paragraphs(help, 76))
-            lines.append(indent(help, 4))
+        if helptext is None:
+            helptext = trait.help
+        if helptext != '':
+            helptext = '\n'.join(wrap_paragraphs(helptext, 76))
+            lines.append(indent(helptext, 4))
         return '\n'.join(lines)
 
     @classmethod

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -66,7 +66,7 @@ class MyApp(Application):
 
     aliases = Dict({
                     ('fooi', 'i') : 'Foo.i',
-                    ('j', 'fooj') : 'Foo.j',
+                    ('j', 'fooj') : ('Foo.j', "`j` terse help msg"),
                     'name' : 'Foo.name',
                     'la': 'Foo.la',
                     'tb': 'Bar.tb',
@@ -194,7 +194,7 @@ class TestApplication(TestCase):
         class TestApp(Application):
             value = Unicode().tag(config=True)
             config_file_loaded = Bool().tag(config=True)
-            aliases = {'v': 'TestApp.value'}
+            aliases = {'v': ('TestApp.value', 'some help')}
         app = TestApp()
         with TemporaryDirectory() as td:
             config_file = pjoin(td, name)

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -35,20 +35,20 @@ class MyConfigurable(Configurable):
 mc_help=u"""MyConfigurable(Configurable) options
 ------------------------------------
 --MyConfigurable.a=<Integer>
-    Default: 1
     The integer a.
+    Default: 1
 --MyConfigurable.b=<Float>
-    Default: 1.0
-    The integer b."""
+    The integer b.
+    Default: 1.0"""
 
 mc_help_inst=u"""MyConfigurable(Configurable) options
 ------------------------------------
 --MyConfigurable.a=<Integer>
-    Current: 5
     The integer a.
+    Current: 5
 --MyConfigurable.b=<Float>
-    Current: 4.0
-    The integer b."""
+    The integer b.
+    Current: 4.0"""
 
 # On Python 3, the Integer trait is a synonym for Int
 if PY3:
@@ -71,8 +71,8 @@ class Bar(Foo):
 foo_help=u"""Foo(Configurable) options
 -------------------------
 --Foo.a=<Int>
-    Default: 0
     The integer a.
+    Default: 0
 --Foo.b=<Unicode>
     Default: 'nope'
 --Foo.fdict=<key-1>=<value-1>...
@@ -83,15 +83,15 @@ foo_help=u"""Foo(Configurable) options
 bar_help=u"""Bar(Foo) options
 ----------------
 --Bar.a=<Int>
-    Default: 0
     The integer a.
+    Default: 0
 --Bar.bdict <key-1>=<value-1>...
     Default: {}
 --Bar.bset <set-item-1>...
     Default: set()
 --Bar.c=<Float>
-    Default: 0.0
     The string c.
+    Default: 0.0
 --Bar.fdict=<key-1>=<value-1>...
     Default: {}
 --Bar.flist=<list-item-1>...


### PR DESCRIPTION
Subcommands might be classes, strings (name of classes) and now Callables with a single argument: the parent Application instance (i.e. to read configs from).

That way it is possible to create different subcommands based on the same Application-class just with different constructor arguments.

I could not fins any test-cases about subcommands, so this PR is not considered finished - submitted for discussion.