### PR TITLE
Fix a bug in TraitType.default

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -486,9 +486,12 @@ class TraitType(BaseDescriptor):
         This method is registered to HasTraits classes during ``class_init``
         in the same way that dynamic defaults defined by ``@default`` are.
         """
-        if hasattr(self, 'make_dynamic_default'):
+        if self.default_value is not Undefined:
+            return self.default_value
+        elif hasattr(self, 'make_dynamic_default'):
             return self.make_dynamic_default()
         else:
+            # Undefined will raise in TraitType.get
             return self.default_value
 
     def get_default_value(self):


### PR DESCRIPTION
Fixes this unexpected error that results from improper logic in `TraitType.default` which returns `None` when it should be returning the value given to the keyword `default_value`.

```python
class Foo(HasTraits):
    bar = Instance(list, default_value=[])

# raises on master prior to fix
Foo().bar
```

