### PR TITLE
add rollback function to change dicts

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -28,7 +28,7 @@ from traitlets import (
 import six
 
 def change_dict(*ordered_values):
-    change_names = ('name', 'old', 'new', 'owner', 'type')
+    change_names = ('name', 'old', 'new', 'owner', 'type', 'rollback')
     return dict(zip(change_names, ordered_values))
 
 #-----------------------------------------------------------------------------
@@ -580,10 +580,10 @@ class TestObserveDecorator(TestCase):
         a.b = 0.0
         self.assertEqual(len(self._notify1),0)
         a.a = 10
-        change = change_dict('a', 0, 10, a, 'change')
+        change = change_dict('a', 0, 10, a, 'change', TraitType.rollback)
         self.assertTrue(change in self._notify1)
         a.b = 10.0
-        change = change_dict('b', 0.0, 10.0, a, 'change')
+        change = change_dict('b', 0.0, 10.0, a, 'change', TraitType.rollback)
         self.assertTrue(change in self._notify1)
         self.assertRaises(TraitError,setattr,a,'a','bad string')
         self.assertRaises(TraitError,setattr,a,'b','bad string')
@@ -604,7 +604,7 @@ class TestObserveDecorator(TestCase):
         a.a = 0
         self.assertEqual(len(self._notify1),0)
         a.a = 10
-        change = change_dict('a', 0, 10, a, 'change')
+        change = change_dict('a', 0, 10, a, 'change', TraitType.rollback)
         self.assertTrue(change in self._notify1)
         self.assertRaises(TraitError,setattr,a,'a','bad string')
 
@@ -641,9 +641,9 @@ class TestObserveDecorator(TestCase):
         self.assertEqual(len(self._notify2),0)
         b.a = 10
         b.b = 10.0
-        change = change_dict('a', 0, 10, b, 'change')
+        change = change_dict('a', 0, 10, b, 'change', TraitType.rollback)
         self.assertTrue(change in self._notify1)
-        change = change_dict('b', 0.0, 10.0, b, 'change')
+        change = change_dict('b', 0.0, 10.0, b, 'change', TraitType.rollback)
         self.assertTrue(change in self._notify2)
 
     def test_static_notify(self):
@@ -666,11 +666,11 @@ class TestObserveDecorator(TestCase):
         a.a = 0
         self.assertEqual(len(a._notify1),0)
         a.a = 10
-        change = change_dict('a', 0, 10, a, 'change')
+        change = change_dict('a', 0, 10, a, 'change', TraitType.rollback)
         self.assertTrue(change in a._notify1)
         a.b = 1
         self.assertEqual(len(a._notify_any), 2)
-        change = change_dict('b', 0, 1, a, 'change')
+        change = change_dict('b', 0, 1, a, 'change', TraitType.rollback)
         self.assertTrue(change in a._notify_any)
 
         class B(A):
@@ -683,9 +683,9 @@ class TestObserveDecorator(TestCase):
         b = B()
         b.a = 10
         b.b = 10.0
-        change = change_dict('a', 0, 10, b, 'change')
+        change = change_dict('a', 0, 10, b, 'change', TraitType.rollback)
         self.assertTrue(change in b._notify1)
-        change = change_dict('b', 0.0, 10.0, b, 'change')
+        change = change_dict('b', 0.0, 10.0, b, 'change', TraitType.rollback)
         self.assertTrue(change in b._notify2)
 
     def test_notify_args(self):
@@ -706,7 +706,7 @@ class TestObserveDecorator(TestCase):
 
         a.observe(callback1, 'a')
         a.a = 100
-        change = change_dict('a', 10, 100, a, 'change')
+        change = change_dict('a', 10, 100, a, 'change', TraitType.rollback)
         self.assertEqual(self.cb, change)
         self.assertEqual(len(a._trait_notifiers['a']['change']), 1)
         a.unobserve(callback1, 'a')


### PR DESCRIPTION
Adds a `'rollback'` key to change dicts that is called to reverse changes in case of a `TraitError`.

This enables rollbacks for different kinds of changes (e.g. element changes from eventful traits))