### PR TITLE
Bless config metadata in trait constructors

### DIFF
--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -439,7 +439,7 @@ class TestConfigContainers(TestCase):
 
         # reset deprecation limiter
         _deprecations_shown.clear()
-        with expected_warnings(['metadata should be set using the \.tag\(\) method', "use @default decorator instead\\."]):
+        with expected_warnings(["use @default decorator instead\\."]):
             class DefaultConfigurable(Configurable):
                 a = Integer(config=True)
                 def _config_default(self):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -432,7 +432,8 @@ class TraitType(BaseDescriptor):
                     "use @default decorator instead.")
             cls._trait_default_generators[self.name] = method
 
-    def __init__(self, default_value=Undefined, allow_none=False, read_only=None, help=None, **kwargs):
+    def __init__(self, default_value=Undefined, allow_none=False, read_only=None, help=None,
+        config=None, **kwargs):
         """Declare a traitlet.
 
         If *allow_none* is True, None is a valid value in addition to any
@@ -472,6 +473,8 @@ class TraitType(BaseDescriptor):
                 self.metadata = kwargs
         else:
             self.metadata = self.metadata.copy()
+        if config is not None:
+            self.metadata['config'] = config
 
         # We add help to the metadata during a deprecation period so that
         # code that looks for the help string there can find it.


### PR DESCRIPTION
After updating many applications to the 4.1 API, requiring `.tag(config=True)` does not seem to be an improvement, plus the definition of the config metadata is defined in this package.

Blessing the longstanding behavior makes upgrading a lot less tedious.