### PR TITLE
undeprecate `_trait_default`

### DIFF
--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -118,11 +118,12 @@ by notification type.
         def handler_all(self, change):
             pass
 
-Deprecation of magic method for dynamic defaults generation
------------------------------------------------------------
+dynamic defaults generation with decorators
+-------------------------------------------
 
 The use of the magic methods ``_{trait}_default`` for dynamic default
-generation is deprecated, in favor a new ``@default`` method decorator.
+generation is not deprecated, but a new ``@default`` method decorator
+is added.
 
 **Example:**
 

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -439,7 +439,7 @@ class TestConfigContainers(TestCase):
 
         # reset deprecation limiter
         _deprecations_shown.clear()
-        with expected_warnings(["use @default decorator instead\\."]):
+        with expected_warnings([]):
             class DefaultConfigurable(Configurable):
                 a = Integer(config=True)
                 def _config_default(self):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -161,7 +161,7 @@ class TestTraitType(TestCase):
 
         assert obj.x == 5
 
-        with expected_warnings(['@default', '@validate', '@observe']) as w:
+        with expected_warnings(['@validate', '@observe']) as w:
             class ShouldWarn(HasTraits):
                 x = Integer()
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -427,9 +427,6 @@ class TraitType(BaseDescriptor):
     def subclass_init(self, cls):
         if '_%s_default' % self.name in cls.__dict__:
             method = getattr(cls, '_%s_default' % self.name)
-            if not isinstance(method, EventHandler):
-                _deprecated_method(method, cls, '_%s_default' % self.name,
-                    "use @default decorator instead.")
             cls._trait_default_generators[self.name] = method
 
     def __init__(self, default_value=Undefined, allow_none=False, read_only=None, help=None,


### PR DESCRIPTION
After upgrading several applications to the 4.1 API, requiring the default decorator results in a bunch of redundant code.

Since the signature and behavior are unchanged, just remove the deprecation message on default-value generators.

I won't propose undeprecating change/validate methods, since their signatures change with the decorators.