### PR TITLE
feat(cfg): write also enum choices when generating config.py files

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -310,10 +310,14 @@ class Configurable(HasTraits):
 
         for name, trait in sorted(cls.class_own_traits(config=True).items()):
             lines.append(c(trait.help))
+
             if 'Enum' in type(trait).__name__:
                 # include Enum choices
                 lines.append('#  Choices: %r' % (trait.values,))
-            lines.append('#c.%s.%s = %s' % (cls.__name__, name, trait.default_value_repr()))
+
+            dvr = trait.default_value_repr()
+            lines.append(indent('#  Default: %s' % dvr, 4))
+            lines.append('#c.%s.%s = %s' % (cls.__name__, name, dvr))
             lines.append('')
         return '\n'.join(lines)
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -309,6 +309,9 @@ class Configurable(HasTraits):
 
         for name, trait in sorted(cls.class_own_traits(config=True).items()):
             lines.append(c(trait.help))
+            if 'Enum' in type(trait).__name__:
+                # include Enum choices
+                lines.append('#  Choices: %r' % (trait.values,))
             lines.append('#c.%s.%s = %s' % (cls.__name__, name, trait.default_value_repr()))
             lines.append('')
         return '\n'.join(lines)

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -260,6 +260,10 @@ class Configurable(HasTraits):
             helptext = '\n'.join(wrap_paragraphs(helptext, 76))
             lines.append(indent(helptext, 4))
 
+        if 'Enum' in trait.__class__.__name__:
+            # include Enum choices
+            lines.append(indent('Choices: %r' % (trait.values,)))
+
         if inst is not None:
             lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))
         else:
@@ -271,9 +275,6 @@ class Configurable(HasTraits):
                 if len(dvr) > 64:
                     dvr = dvr[:61]+'...'
                 lines.append(indent('Default: %s' % dvr, 4))
-        if 'Enum' in trait.__class__.__name__:
-            # include Enum choices
-            lines.append(indent('Choices: %r' % (trait.values,)))
 
         return '\n'.join(lines)
 

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -17,7 +17,7 @@ from traitlets.config.configurable import (
 )
 
 from traitlets.traitlets import (
-    Integer, Float, Unicode, List, Dict, Set,
+    Integer, Float, Unicode, List, Dict, Set, Enum,
     _deprecations_shown,
 )
 
@@ -184,6 +184,14 @@ class TestConfigurable(TestCase):
     def test_help_inst(self):
         inst = MyConfigurable(a=5, b=4)
         self.assertEqual(MyConfigurable.class_get_help(inst), mc_help_inst)
+
+    def test_gen_enums_help_msg(self):
+        class MyConf(Configurable):
+            an_enum = Enum('Choice1 choice2'.split(),
+                     help="Many choices.").tag(config=True)
+        enum_values_str = "Choices: ['Choice1', 'choice2']"
+        self.assertIn(enum_values_str, MyConf.class_get_help())
+        self.assertIn(enum_values_str, MyConf.class_config_section())
 
 
 class TestSingletonConfigurable(TestCase):

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -185,13 +185,45 @@ class TestConfigurable(TestCase):
         inst = MyConfigurable(a=5, b=4)
         self.assertEqual(MyConfigurable.class_get_help(inst), mc_help_inst)
 
-    def test_gen_enums_help_msg(self):
+    def test_generated_config_enum_comments(self):
         class MyConf(Configurable):
             an_enum = Enum('Choice1 choice2'.split(),
-                     help="Many choices.").tag(config=True)
-        enum_values_str = "Choices: ['Choice1', 'choice2']"
-        self.assertIn(enum_values_str, MyConf.class_get_help())
-        self.assertIn(enum_values_str, MyConf.class_config_section())
+                           help="Many choices.").tag(config=True)
+
+        help_str = "Many choices."
+        enum_choices_str = "Choices: ['Choice1', 'choice2']"
+
+        self.assertIn(help_str, MyConf.class_get_help())
+        self.assertIn(enum_choices_str, MyConf.class_get_help())
+
+        self.assertIn(help_str, MyConf.class_config_section())
+        self.assertIn(enum_choices_str, MyConf.class_config_section())
+        ## Check order of Help-msg <--> Choices sections
+        self.assertGreater(MyConf.class_config_section().index(enum_choices_str),
+                           MyConf.class_config_section().index(help_str))
+
+        class MyConf2(Configurable):
+            an_enum = Enum('Choice1 choice2'.split(),
+                           default_value='choice2',
+                           help="Many choices.").tag(config=True)
+
+        defaults_str = "Default: 'choice2'"
+
+        self.assertIn(help_str, MyConf2.class_get_help())
+        self.assertIn(enum_choices_str, MyConf2.class_get_help())
+        self.assertIn(defaults_str, MyConf2.class_get_help())
+        ## Check order of Default <--> Choices sections
+        self.assertGreater(MyConf2.class_get_help().index(defaults_str),
+                           MyConf2.class_get_help().index(enum_choices_str))
+
+        self.assertIn(help_str, MyConf2.class_config_section())
+        self.assertIn(enum_choices_str, MyConf2.class_config_section())
+        self.assertIn(defaults_str, MyConf2.class_config_section())
+        ## Check order of Default <--> Choices sections
+        self.assertGreater(MyConf2.class_config_section().index(defaults_str),
+                           MyConf2.class_config_section().index(enum_choices_str))
+
+
 
 
 class TestSingletonConfigurable(TestCase):


### PR DESCRIPTION
When generating the `config.py` file, explain the available enum-choices in the comment-lines, like help-message does.

