### PR TITLE
notify on default creation

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -523,6 +523,12 @@ class TraitType(BaseDescriptor):
                     type(self).__name__, self.name, obj))
             value = self._validate(obj, default)
             obj._trait_values[self.name] = value
+            obj.notify_change(Bunch(
+                name=self.name,
+                value=value,
+                owner=obj,
+                type='default',
+            ))
             return value
         except Exception:
             # This should never be reached.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1171,7 +1171,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
 
         # Now static ones
         magic_name = '_%s_changed' % name
-        if hasattr(self, magic_name):
+        if change.type == "change" and hasattr(self, magic_name):
             class_value = getattr(self.__class__, magic_name)
             if not isinstance(class_value, ObserveHandler):
                 _deprecated_method(class_value, self.__class__, magic_name,


### PR DESCRIPTION
# Summary

Notify upon the creation of a default value. The current scheme for this event report is:

```python
{
    'name': <the trait's name>,
    'owner': <it's HasTraits object>,
    'value': <default value>
    'type': 'default',
}
```

# A Possible Use Case

An `@access` decorator that acts like `@property` but has the added benefits of `traitlets` validation.

```python
class AccessHandler(DefaultHandler):
    """An event handler that allows a trait to act like a getter"""

    def instance_init(self, obj):
        obj.observe(
            self._reset,
            self.trait_names,
            "default",
            self.metadata
        )

    @staticmethod
    def _reset(change):
        # this reset will cause the default mechanism
        # to reactivate whenever the trait is accessed
        del change.owner._trait_values[change.name]
```

## TODO

+ needs tests
