### PR TITLE
generate all config, not just new traits on each class

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -648,8 +648,6 @@ class Application(SingletonConfigurable):
                     loaded.append(config)
                     filenames.append(loader.full_filename)
 
-
-
     @catch_config_error
     def load_config_file(self, filename, path=None):
         """Load config files by filename and path."""
@@ -662,7 +660,6 @@ class Application(SingletonConfigurable):
         # add self.cli_config to preserve CLI config priority
         new_config.merge(self.cli_config)
         self.update_config(new_config)
-
 
     def _classes_with_config_traits(self, classes=None):
         """
@@ -681,7 +678,7 @@ class Application(SingletonConfigurable):
         if classes is None:
             classes = self.classes
 
-        cls_to_config = OrderedDict( (cls, bool(cls.class_traits(config=True)))
+        cls_to_config = OrderedDict( (cls, bool(cls.class_own_traits(config=True)))
                               for cls
                               in self._classes_inc_parents(classes))
 
@@ -702,12 +699,14 @@ class Application(SingletonConfigurable):
             if inc_yes:
                 yield cl
 
-    def generate_config_file(self):
+    def generate_config_file(self, classes=None):
         """generate default config file from Configurables"""
         lines = ["# Configuration file for %s." % self.name]
         lines.append('')
-        for cls in self._classes_with_config_traits():
-            lines.append(cls.class_config_section())
+        classes = self.classes if classes is None else classes
+        config_classes = list(self._classes_with_config_traits(classes))
+        for cls in config_classes:
+            lines.append(cls.class_config_section(config_classes))
         return '\n'.join(lines)
 
     def exit(self, exit_status=0):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -666,7 +666,7 @@ class Application(SingletonConfigurable):
 
     def _classes_with_config_traits(self, classes=None):
         """
-        Yields only classes with own traits, and their subclasses.
+        Yields only classes with configurable traits, and their subclasses.
 
         :param classes:
             The list of classes to iterate; if not set, uses :attr:`classes`.
@@ -681,7 +681,7 @@ class Application(SingletonConfigurable):
         if classes is None:
             classes = self.classes
 
-        cls_to_config = OrderedDict( (cls, bool(cls.class_own_traits(config=True)))
+        cls_to_config = OrderedDict( (cls, bool(cls.class_traits(config=True)))
                               for cls
                               in self._classes_inc_parents(classes))
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -283,7 +283,7 @@ class Application(SingletonConfigurable):
         if cls not in self.classes:
             if self.classes is cls.classes:
                 # class attr, assign instead of insert
-                cls.classes = [cls] + self.classes
+                self.classes = [cls] + self.classes
             else:
                 self.classes.insert(0, self.__class__)
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -218,7 +218,7 @@ class Configurable(HasTraits):
         """
         assert inst is None or isinstance(inst, cls)
         final_help = []
-        base_classes = ','.join(p.__name__ for p in cls.__bases__)
+        base_classes = ', '.join(p.__name__ for p in cls.__bases__)
         final_help.append(u'%s(%s) options' % (cls.__name__, base_classes))
         final_help.append(len(final_help[0])*u'-')
         for k, v in sorted(cls.class_traits(config=True).items()):
@@ -343,6 +343,8 @@ class Configurable(HasTraits):
             lines.append('')
 
         for name, trait in sorted(cls.class_traits(config=True).items()):
+            default_repr = trait.default_value_repr()
+
             if classes:
                 defining_class = cls._defining_class(trait, classes)
             else:
@@ -351,19 +353,18 @@ class Configurable(HasTraits):
                 # cls owns the trait, show full help
                 if trait.help:
                     lines.append(c(trait.help))
+                if 'Enum' in type(trait).__name__:
+                    # include Enum choices
+                    lines.append('#  Choices: %r' % (trait.values,))
+                lines.append('#  Default: %s' % default_repr)
             else:
                 # Trait appears multiple times and isn't defined here.
                 # Truncate help to first line + "See also Original.trait"
                 if trait.help:
                     lines.append(c(trait.help.split('\n', 1)[0]))
-                lines.append('# See also %s.%s' % (defining_class.__name__, name))
-            if 'Enum' in type(trait).__name__:
-                # include Enum choices
-                lines.append('#  Choices: %r' % (trait.values,))
+                lines.append('#  See also %s.%s' % (defining_class.__name__, name))
 
-            dvr = trait.default_value_repr()
-            lines.append('#  Default: %s' % dvr)
-            lines.append('# c.%s.%s = %s' % (cls.__name__, name, dvr))
+            lines.append('# c.%s.%s = %s' % (cls.__name__, name, default_repr))
             lines.append('')
         return '\n'.join(lines)
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -362,7 +362,7 @@ class Configurable(HasTraits):
                 lines.append('#  Choices: %r' % (trait.values,))
 
             dvr = trait.default_value_repr()
-            lines.append(indent('#  Default: %s' % dvr, 4))
+            lines.append('#  Default: %s' % dvr)
             lines.append('# c.%s.%s = %s' % (cls.__name__, name, dvr))
             lines.append('')
         return '\n'.join(lines)
@@ -398,7 +398,7 @@ class Configurable(HasTraits):
                     dvr = dvr[:61]+'...'
                 # Double up backslashes, so they get to the rendered docs
                 dvr = dvr.replace('\\n', '\\\\n')
-                lines.append('    Default: ``%s``' % dvr)
+                lines.append(indent('Default: ``%s``' % dvr, '#   '))
                 lines.append('')
 
             help = trait.help or 'No description'

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -399,7 +399,7 @@ class Configurable(HasTraits):
                     dvr = dvr[:61]+'...'
                 # Double up backslashes, so they get to the rendered docs
                 dvr = dvr.replace('\\n', '\\\\n')
-                lines.append(indent('Default: ``%s``' % dvr, '#   '))
+                lines.append(indent('Default: ``%s``' % dvr, 4))
                 lines.append('')
 
             help = trait.help or 'No description'

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -308,7 +308,7 @@ class Configurable(HasTraits):
             lines.append(c(desc))
             lines.append('')
 
-        for name, trait in sorted(cls.class_own_traits(config=True).items()):
+        for name, trait in sorted(cls.class_traits(config=True).items()):
             lines.append(c(trait.help))
 
             if 'Enum' in type(trait).__name__:
@@ -329,7 +329,7 @@ class Configurable(HasTraits):
         """
         lines = []
         classname = cls.__name__
-        for k, trait in sorted(cls.class_own_traits(config=True).items()):
+        for k, trait in sorted(cls.class_traits(config=True).items()):
             ttype = trait.__class__.__name__
 
             termline = classname + '.' + trait.name

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -327,7 +327,10 @@ class Configurable(HasTraits):
 
         # section header
         breaker = '#' + '-' * 78
-        parent_classes = ', '.join(p.__name__ for p in cls.__bases__)
+        parent_classes = ', '.join(
+            p.__name__ for p in cls.__bases__
+            if issubclass(p, Configurable)
+        )
 
         s = "# %s(%s) configuration" % (cls.__name__, parent_classes)
         lines = [breaker, s, breaker]

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -424,22 +424,23 @@ class TestApplication(TestCase):
         app.classes.append(NoTraits)
 
         conf_txt = app.generate_config_file()
+        print(conf_txt)
         self.assertIn('The integer b.', conf_txt)
-        self.assertIn('# Foo ', conf_txt)
+        self.assertIn('# Foo(Configurable)', conf_txt)
         self.assertNotIn('# Configurable', conf_txt)
-        self.assertIn('# NoTraits(Foo,Bar)', conf_txt)
+        self.assertIn('# NoTraits(Foo, Bar)', conf_txt)
 
         # inherited traits, parent in class list:
         self.assertIn('# c.NoTraits.i', conf_txt)
         self.assertIn('# c.NoTraits.j', conf_txt)
         self.assertIn('# c.NoTraits.n', conf_txt)
-        self.assertIn('# See also Foo.j', conf_txt)
-        self.assertIn('# See also Bar.b', conf_txt)
+        self.assertIn('#  See also Foo.j', conf_txt)
+        self.assertIn('#  See also Bar.b', conf_txt)
         self.assertEqual(conf_txt.count('Details about i.'), 1)
 
         # inherited traits, parent not in class list:
         self.assertIn("# c.NoTraits.from_hidden", conf_txt)
-        self.assertNotIn('# See also NotInConfig.', conf_txt)
+        self.assertNotIn('#  See also NotInConfig.', conf_txt)
         self.assertEqual(conf_txt.count('Details about from_hidden.'), 1)
         self.assertNotIn("NotInConfig", conf_txt)
 

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -33,13 +33,18 @@ from traitlets.config.application import (
 )
 
 from ipython_genutils.tempdir import TemporaryDirectory
-from traitlets.traitlets import (
+from traitlets import (
+    HasTraits,
     Bool, Unicode, Integer, List, Tuple, Set, Dict
 )
 
 class Foo(Configurable):
 
-    i = Integer(0, help="The integer i.").tag(config=True)
+    i = Integer(0, help="""
+    The integer i.
+
+    Details about i.
+    """).tag(config=True)
     j = Integer(1, help="The integer j.").tag(config=True)
     name = Unicode(u'Brian', help="First name.").tag(config=True)
     la = List([]).tag(config=True)
@@ -114,7 +119,7 @@ class TestApplication(TestCase):
         app = MyApp()
         self.assertEqual(app.name, u'myapp')
         self.assertEqual(app.running, False)
-        self.assertEqual(app.classes, [MyApp,Bar,Foo])
+        self.assertEqual(app.classes, [MyApp, Bar, Foo])
         self.assertEqual(app.config_file, u'')
 
     def test_mro_discovery(self):
@@ -406,17 +411,37 @@ class TestApplication(TestCase):
         assert 'The integer b.' in app.generate_config_file()
 
     def test_generate_config_file_classes_to_include(self):
-        class NoTraits(Foo, Bar):
+        class NotInConfig(HasTraits):
+            from_hidden = Unicode('x', help="""From hidden class
+            
+            Details about from_hidden.
+            """).tag(config=True)
+
+        class NoTraits(Foo, Bar, NotInConfig):
             pass
 
         app = MyApp()
         app.classes.append(NoTraits)
+
         conf_txt = app.generate_config_file()
         self.assertIn('The integer b.', conf_txt)
-        self.assertIn('# Bar(Configurable)', conf_txt)
-        self.assertIn('# Foo(Configurable)', conf_txt)
+        self.assertIn('# Foo ', conf_txt)
         self.assertNotIn('# Configurable', conf_txt)
         self.assertIn('# NoTraits(Foo,Bar)', conf_txt)
+
+        # inherited traits, parent in class list:
+        self.assertIn('# c.NoTraits.i', conf_txt)
+        self.assertIn('# c.NoTraits.j', conf_txt)
+        self.assertIn('# c.NoTraits.n', conf_txt)
+        self.assertIn('# See also Foo.j', conf_txt)
+        self.assertIn('# See also Bar.b', conf_txt)
+        self.assertEqual(conf_txt.count('Details about i.'), 1)
+
+        # inherited traits, parent not in class list:
+        self.assertIn("# c.NoTraits.from_hidden", conf_txt)
+        self.assertNotIn('# See also NotInConfig.', conf_txt)
+        self.assertEqual(conf_txt.count('Details about from_hidden.'), 1)
+        self.assertNotIn("NotInConfig", conf_txt)
 
     def test_multi_file(self):
         app = MyApp()


### PR DESCRIPTION
using class_own_traits splits up config for classes with parents, and hides some config options entirely if traits are defined in base classes not in the final `classes` list.

The change has not been released, so this restores the behavior of all released traitlets versions.