### PR TITLE
Suppress Redundant Configurable Validation

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -77,9 +77,6 @@ class Configurable(HasTraits):
 
         config = kwargs.pop('config', None)
 
-        # load kwarg traits, other than config
-        super(Configurable, self).__init__(**kwargs)
-
         # load config
         if config is not None:
             # We used to deepcopy, but for now we are trying to just save
@@ -94,11 +91,8 @@ class Configurable(HasTraits):
             # allow _config_default to return something
             self._load_config(self.config)
 
-        # Ensure explicit kwargs are applied after loading config.
-        # This is usually redundant, but ensures config doesn't override
-        # explicitly assigned values.
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        # load kwarg traits, other than config
+        super(Configurable, self).__init__(**kwargs)
 
     #-------------------------------------------------------------------------
     # Static trait notifiations
@@ -173,6 +167,7 @@ class Configurable(HasTraits):
                         msg += u"  Did you mean `{matches}`?".format(matches=matches[0])
                     elif len(matches) >= 1:
                         msg +="  Did you mean one of: `{matches}`?".format(matches=', '.join(sorted(matches)))
+                    print(msg)
                     warn(msg)
 
     @observe('config')

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -183,7 +183,6 @@ class Configurable(HasTraits):
                         msg += u"  Did you mean `{matches}`?".format(matches=matches[0])
                     elif len(matches) >= 1:
                         msg +="  Did you mean one of: `{matches}`?".format(matches=', '.join(sorted(matches)))
-                    print(msg)
                     warn(msg)
 
     @observe('config')

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -6,6 +6,7 @@
 
 import logging
 import sys
+import warnings
 from unittest import TestCase
 
 from pytest import mark


### PR DESCRIPTION
Closes #390

## Summary

Configurables currently make a redundant series of `setattr` calls on themselves to override config values with those that have been explicitly hard-coded in the constructor. In the past this was required due to the timing of descriptor initialization via `instance_init`, which occurred in `HasTraits.__init__`. Now though, descriptor initialization occurs in `HasTraits.__new__` via `setup_instance`. Thus we can remove the redundant `setattr` in `Configurable.__init__` and simply use `super().__init__(**kwargs)` instead.

## Todo

1. I'm encountering a test failure complaining that a warning for a mistyped section did not occur. However, pytest shows that `stderr` received a call with the exact warning required by the test. This is specific to Python 3 since it requires `TestCase.assertLogs`.
2. Add a test case.

cc: @jasongrout 