### PR TITLE
style(cfg): apply review items in #385 for gen-config

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -365,7 +365,7 @@ class Configurable(HasTraits):
                 # Truncate help to first line + "See also Original.trait"
                 if trait.help:
                     lines.append(c(trait.help.split('\n', 1)[0]))
-                lines.append('#  See also %s.%s' % (defining_class.__name__, name))
+                lines.append('#  See also: %s.%s' % (defining_class.__name__, name))
 
             lines.append('# c.%s.%s = %s' % (cls.__name__, name, default_repr))
             lines.append('')

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -438,13 +438,13 @@ class TestApplication(TestCase):
         self.assertIn('# c.NoTraits.i', conf_txt)
         self.assertIn('# c.NoTraits.j', conf_txt)
         self.assertIn('# c.NoTraits.n', conf_txt)
-        self.assertIn('#  See also Foo.j', conf_txt)
-        self.assertIn('#  See also Bar.b', conf_txt)
+        self.assertIn('#  See also: Foo.j', conf_txt)
+        self.assertIn('#  See also: Bar.b', conf_txt)
         self.assertEqual(conf_txt.count('Details about i.'), 1)
 
         # inherited traits, parent not in class list:
         self.assertIn("# c.NoTraits.from_hidden", conf_txt)
-        self.assertNotIn('#  See also NotInConfig.', conf_txt)
+        self.assertNotIn('#  See also: NotInConfig.', conf_txt)
         self.assertEqual(conf_txt.count('Details about from_hidden.'), 1)
         self.assertNotIn("NotInConfig", conf_txt)
 


### PR DESCRIPTION
Minor changes in the formatting of the generated sample configuration-file,
as reviewed by @ankostis on #385.

The differences in the generated config-file are shown below for this code:

```python
import traitlets.config as trtc
import traitlets as trt

class C(trtc.Configurable):
    a = trt.Enum(['aa', 'BB'], help='1st help line.\n\nOther lines.').tag(config=True)

class A(trtc.Application, C):
    pass

print(A().generate_config_file())
```

## Wihtout this PR:
```python
#------------------------------------------------------------------------------
# A(Application, C) configuration
#------------------------------------------------------------------------------
## This is an application.

## 1st help line.
#  See also C.a
# c.A.a = traitlets.Undefined
```

## WITH this PR:
```python
THIS PR:
##------------------------------------------------------------------------------
## A(Application, C) configuration
##------------------------------------------------------------------------------
## This is an application.

## 1st help line.
#  See also: C.a
#c.A.a = traitlets.Undefined
```