### PR TITLE
Ensure config loader tests include unicode

### DIFF
--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -78,7 +78,7 @@ class TestFileCL(TestCase):
         self.assertEqual(config.D.C.value, 'hi there')
 
     def test_python(self):
-        fd, fname = mkstemp('.py')
+        fd, fname = mkstemp('.py', prefix=u'μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write(pyfile)
         f.close()
@@ -88,7 +88,7 @@ class TestFileCL(TestCase):
         self._check_conf(config)
 
     def test_json(self):
-        fd, fname = mkstemp('.json')
+        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write(json1file)
         f.close()
@@ -99,7 +99,7 @@ class TestFileCL(TestCase):
 
     def test_context_manager(self):
 
-        fd, fname = mkstemp('.json')
+        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write('{}')
         f.close()
@@ -118,7 +118,7 @@ class TestFileCL(TestCase):
         self.assertEqual(cl.config.MyAttr.value, value)
 
     def test_json_context_bad_write(self):
-        fd, fname = mkstemp('.json')
+        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write('{}')
         f.close()
@@ -164,7 +164,7 @@ class TestFileCL(TestCase):
         })
 
     def test_v2raise(self):
-        fd, fname = mkstemp('.json')
+        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write(json2file)
         f.close()


### PR DESCRIPTION
This PR adds unicode characters to the paths of the config loader tests. This reveals an exception on Windows:

```python
self = <traitlets.config.loader.PyFileConfigLoader object at 0x0000019D8035AD68>

    def _read_file_as_dict(self):
        """Load the config file into self.config, with recursive loading."""
        def get_config():
            """Unnecessary now, but a deprecation warning is more trouble than it's worth."""
            return self.config

        namespace = dict(
            c=self.config,
            load_subconfig=self.load_subconfig,
            get_config=get_config,
            __file__=self.full_filename,
        )
        fs_encoding = sys.getfilesystemencoding() or 'ascii'
>       conf_filename = self.full_filename.encode(fs_encoding)
E       UnicodeEncodeError: 'mbcs' codec can't encode characters in position 0--1: invalid character
```

On Windows, [`sys.getfilesystemencoding()`](https://docs.python.org/2/library/sys.html#sys.getfilesystemencoding) should not really be used to encode file paths.

> On Windows NT+, file names are Unicode natively, so no conversion is performed. getfilesystemencoding() still returns 'mbcs', as this is the encoding that applications should use when they explicitly want to convert Unicode strings to byte strings that are equivalent when used as file names.

Not entirely sure how to best solve this in a way that is compatible with all Python/OSes, so no solution suggested yet, but for a pure Windows solution I would just remove the encoding step (`conf_filename = self.full_filename` passes tests on Win/Python 3.6).