### PR TITLE
feat(conf): explain which singleton is already instanciated

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -505,8 +505,8 @@ class SingletonConfigurable(LoggingConfigurable):
             return cls._instance
         else:
             raise MultipleInstanceError(
-                'Multiple incompatible subclass instances of '
-                '%s are being created.' % cls.__name__
+                "An incompatible sibling of '%s' is already instanciated"
+                " as singleton: %s" % (cls.__name__, type(cls._instance).__name__)
             )
 
     @classmethod


### PR DESCRIPTION
Improve the message when signleton instanciation fails because configurables already exist, by printing which is the offending class.  Without this PR, in case there are many subclass candidates for a singleton, you need a debugger to identify which one has been instantiated on run-time. 

This is the new error message:

    An incompatible sibling of 'MyClass' is already instanciated as singleton: TerminalIPythonApp

instead of just:

    Multiple incompatible subclass instances of MyClass are being created.