### PR TITLE
feat(app): provide help-functions also as generators of text-lines

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -492,6 +492,15 @@ class Application(SingletonConfigurable):
                 yield indent(dedent(help.strip()))
         yield ''
 
+    def emit_help_epilogue(self, classes):
+        """Yield the very bottom lines of the help message.
+
+        If classes=False (the default), print `--help-all` msg.
+        """
+        if not classes:
+            yield "To see all available configurables, use `--help-all`."
+            yield ''
+
     def print_help(self, classes=False):
         """Print the help for each Configurable class in self.classes.
 
@@ -526,9 +535,8 @@ class Application(SingletonConfigurable):
         for l in self.emit_examples():
             yield l
 
-        if not classes:
-            yield "To see all available configurables, use `--help-all`."
-            yield ''
+        for l in self.emit_help_epilogue(classes):
+            yield l
 
     def document_config_options(self):
         """Generate rST format documentation for the config options this application

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -378,10 +378,11 @@ class Application(SingletonConfigurable):
                 ))
 
     def print_alias_help(self):
+        """Print the alias parts of the help."""
         print('\n'.join(self.emit_alias_help()))
 
     def emit_alias_help(self):
-        """Print the alias part of the help."""
+        """Yield the lines for alias part of the help."""
         if not self.aliases:
             return
 
@@ -420,10 +421,11 @@ class Application(SingletonConfigurable):
                 raise
 
     def print_flag_help(self):
+        """Print the flag part of the help."""
         print('\n'.join(self.emit_flag_help()))
 
     def emit_flag_help(self):
-        """Print the flag part of the help."""
+        """Yield the lines for the flag part of the help."""
         if not self.flags:
             return
 
@@ -448,9 +450,11 @@ class Application(SingletonConfigurable):
                 raise
 
     def print_options(self):
+        """Print the options part of the help."""
         print('\n'.join(self.emit_options_help()))
 
     def emit_options_help(self):
+        """Yield the lines for the options part of the help."""
         if not self.flags and not self.aliases:
             return
         header = 'Options'
@@ -467,10 +471,11 @@ class Application(SingletonConfigurable):
         yield ''
 
     def print_subcommands(self):
+        """Print the subcommand part of the help."""
         print('\n'.join(self.emit_subcommands_help()))
 
     def emit_subcommands_help(self):
-        """Print the subcommand part of the help."""
+        """Yield the lines for the subcommand part of the help."""
         if not self.subcommands:
             return
 
@@ -495,7 +500,7 @@ class Application(SingletonConfigurable):
         print('\n'.join(self.emit_help(classes=classes)))
 
     def emit_help(self, classes=False):
-        """Print the help for each Configurable class in self.classes.
+        """Yield the help-lines for each Configurable class in self.classes.
 
         If classes=False (the default), only flags and aliases are printed.
         """


### PR DESCRIPTION
- The new functions allow for for GUIs/DataEntry/help-utilities to replicate config-param documentation
  functionality selectively,  without relying on STDOUT-context capturers.
- Since the old `print_xxx()` functions were public API, they are left in place, although they are not used anywhere in this codebase.
- Factored out help *epilogue* message about "see --help-all" as a separate customizable function.