### PR TITLE
update pip before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
     - 3.6-dev
 sudo: false
 install:
-    - pip install .
+    - pip install --upgrade pip && pip install .
     - pip install traitlets[test] pytest-cov codecov pytest-warnings --upgrade
 script:
     - py.test --cov traitlets -v traitlets


### PR DESCRIPTION
As per https://github.com/kennethreitz/requests/issues/4006 the default version of `pip` used by travis is 6.x.x which has a problem installing requests. Even if that issue is resolved, we should probably be using the latest version of `pip` anyway.