### PR TITLE
Validates a correctly formatted FQDN if using string type verificatio…

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2750,12 +2750,19 @@ class TCPAddress(TraitType):
 
     def validate(self, obj, value):
         if isinstance(value, tuple):
-            if len(value) == 2:
-                if isinstance(value[0], six.string_types) and isinstance(value[1], int):
-                    port = value[1]
-                    if port >= 0 and port <= 65535:
-                        return value
-        self.error(obj, value)
+        if len(value) == 2:
+            if isinstance(value[0], six.string_types) and isinstance(value[1], int):
+                host = value[0]
+                port = value[1]
+                host_valid = False
+                port_valid = False
+                if port >= 0 and port <= 65535:
+                    port_valid = True
+                if  len(host) <= 255 and re.search('(?:\A\w[\d|\w|-]{0,63}(\Z|\.))+', host):
+                    host_valid = True
+                if host_valid == True and port_valid == True:
+                    return value
+        self.error(obj, value)  
 
 class CRegExp(TraitType):
     """A casting compiled regular expression trait.


### PR DESCRIPTION
from RFC 1035
https://tools.ietf.org/html/rfc1035
The labels must follow the rules for ARPANET host names.  They must
start with a letter, end with a letter or digit, and have as interior
characters only letters, digits, and hyphen.  There are also some
restrictions on the length.  Labels must be 63 characters or less.