### PR TITLE
Has Trait Value Method

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -764,6 +764,12 @@ class TestHasTraits(TestCase):
         self.assertEqual(sorted(A.class_trait_names()),['f','i'])
         self.assertTrue(a.has_trait('f'))
         self.assertFalse(a.has_trait('g'))
+
+    def test_has_trait_value(self):
+        class A(HasTraits):
+            i = Int()
+            f = Float()
+        a = A()
         self.assertFalse(a.has_trait_value('f'))
         self.assertFalse(a.has_trait_value('g'))
         a.i = 1

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -764,6 +764,12 @@ class TestHasTraits(TestCase):
         self.assertEqual(sorted(A.class_trait_names()),['f','i'])
         self.assertTrue(a.has_trait('f'))
         self.assertFalse(a.has_trait('g'))
+        self.assertFalse(a.has_trait_value('f'))
+        self.assertFalse(a.has_trait_value('g'))
+        a.i = 1
+        a.f
+        self.assertTrue(a.has_trait_value('i'))
+        self.assertTrue(a.has_trait_value('f'))
 
     def test_trait_metadata_deprecated(self):
         with expected_warnings(['metadata should be set using the \.tag\(\) method']):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -765,17 +765,17 @@ class TestHasTraits(TestCase):
         self.assertTrue(a.has_trait('f'))
         self.assertFalse(a.has_trait('g'))
 
-    def test_has_trait_value(self):
+    def test_trait_has_value(self):
         class A(HasTraits):
             i = Int()
             f = Float()
         a = A()
-        self.assertFalse(a.has_trait_value('f'))
-        self.assertFalse(a.has_trait_value('g'))
+        self.assertFalse(a.trait_has_value('f'))
+        self.assertFalse(a.trait_has_value('g'))
         a.i = 1
         a.f
-        self.assertTrue(a.has_trait_value('i'))
-        self.assertTrue(a.has_trait_value('f'))
+        self.assertTrue(a.trait_has_value('i'))
+        self.assertTrue(a.trait_has_value('f'))
 
     def test_trait_metadata_deprecated(self):
         with expected_warnings(['metadata should be set using the \.tag\(\) method']):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1438,7 +1438,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         """Returns True if the object has a trait with the specified name."""
         return isinstance(getattr(self.__class__, name, None), TraitType)
 
-    def has_trait_value(self, name):
+    def trait_has_value(self, name):
         """Returns True if the specified trait has a value.
 
         This will return false even if ``getattr`` would return a
@@ -1453,9 +1453,9 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
                 i = Int()
 
             mc = MyClass()
-            assert not mc.has_trait_value("i")
+            assert not mc.trait_has_value("i")
             mc.i # generates a default value
-            assert mc.has_trait_value("i")
+            assert mc.trait_has_value("i")
         """
         return name in self._trait_values
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1439,7 +1439,24 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         return isinstance(getattr(self.__class__, name, None), TraitType)
 
     def has_trait_value(self, name):
-        """Return True if the specified trait has a value (not it's default)"""
+        """Return sTrue if the specified trait has a value.
+
+        This will return false even if ``getattr`` would return a
+        dynamically generated default value. These default values
+        will be recognized as existing only after they have been
+        generated.
+
+        Example
+
+        .. code-block:: python
+            class MyClass(HasTraits):
+                i = Int()
+
+            mc = MyClass()
+            assert not mc.has_trait_value("i")
+            mc.i # generates a default value
+            assert mc.has_trait_value("i")
+        """
         return name in self._trait_values
 
     def trait_values(self, **metadata):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1438,6 +1438,10 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         """Returns True if the object has a trait with the specified name."""
         return isinstance(getattr(self.__class__, name, None), TraitType)
 
+    def has_trait_value(self, name):
+        """Return True if the specified trait has a value (not it's default)"""
+        return name in self._trait_values
+
     def trait_values(self, **metadata):
         """A ``dict`` of trait names and their values.
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1439,7 +1439,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         return isinstance(getattr(self.__class__, name, None), TraitType)
 
     def has_trait_value(self, name):
-        """Return sTrue if the specified trait has a value.
+        """Returns True if the specified trait has a value.
 
         This will return false even if ``getattr`` would return a
         dynamically generated default value. These default values


### PR DESCRIPTION
A method to check whether a trait has a value yet (not including its default). This is related to a part of ipywidget's sliders which have circular validation dependencies between their `min`, `max` and `value` traits. Solving this problem requires something akin to `hasattr` which does not currently exist. This PR changes that by adding a `has_trait_value` method.

Associated ipywidgets issue: https://github.com/jupyter-widgets/ipywidgets/pull/1409

cc: @minrk, @ellisonbg, @jasongrout - see the above issue to determine how breaking this change to traitlets' validation will be to the rest of the jupyter stack - there may have been other places that exploited this lack of validation for default values.

