### PR TITLE
follow mro for trait default generators

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2496,6 +2496,39 @@ def test_super_bad_args():
     assert not hasattr(obj, 'b')
 
 
+def test_default_mro():
+    """Verify that default values follow mro"""
+    class Base(HasTraits):
+        trait = Unicode('base')
+        attr = 'base'
+
+    class A(Base):
+        pass
+
+    class B(Base):
+        trait = Unicode('B')
+        attr = 'B'
+
+    class AB(A, B):
+        pass
+
+    class BA(B, A):
+        pass
+
+    assert 'trait' in Base._trait_default_generators
+    assert 'trait' not in A._trait_default_generators
+    assert 'trait' in B._trait_default_generators
+    assert 'trait' not in AB._trait_default_generators
+    assert 'trait' not in BA._trait_default_generators
+
+    assert A().trait == 'base'
+    assert A().attr == 'base'
+    assert BA().trait == 'B'
+    assert BA().attr == 'B'
+    assert AB().trait == 'B'
+    assert AB().attr == 'B'
+
+
 def test_cls_self_argument():
     class X(HasTraits):
         def __init__(__self, cls, self):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1462,7 +1462,7 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         Walk the MRO to resolve the correct default generator according to inheritance.
         """
         for c in cls.mro():
-            if name in getattr(c, '_trait_default_generators', {}):
+            if name in c.__dict__.get('_trait_default_generators', {}):
                 return c._trait_default_generators[name]
         raise KeyError("No default generator for trait %r found in %r" % (name, cls.mro()))
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -490,7 +490,7 @@ class TraitType(BaseDescriptor):
             value = obj._trait_values[self.name]
         except KeyError:
             # Check for a dynamic initializer.
-            default = cls._get_trait_default_generator(self.name)(obj)
+            default = obj.trait_defaults(self.name)
             if default is Undefined:
                 raise TraitError("No default value found for "
                     "the '%s' trait named '%s' of %r" % (


### PR DESCRIPTION
adds a regression test.

This appears to have been broken by the new default value generators, which don't resolve correctly on the mro.

From the looks of it, `_trait_default_generators` on classes should not include inherited generators, and lookups should instead walk the dicts on the mro every time.

cc @rmorshea