### PR TITLE
whitelist traitlets exports

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -69,6 +69,7 @@ __all__ = [
     'default',
     'validate',
     'observe',
+    'observe_compat',
     'link',
     'directional_link',
     'dlink',
@@ -83,7 +84,8 @@ __all__ = [
     'BaseDescriptor',
     'TraitType',
 ]
-# any TraitType subclass will be added automatically
+
+# any TraitType subclass (that doesn't start with _) will be added automatically
 
 #-----------------------------------------------------------------------------
 # Basic classes
@@ -2901,10 +2903,13 @@ class Callable(TraitType):
         else:
             self.error(obj, value)
 
-# add all TraitType subclasses to export
-# avoid iterating through globals while defining variables
 def _add_all():
+    """add all trait types to `__all__`
+
+    do in a function to avoid iterating through globals while defining local variables
+    """
     for _name, _value in globals().items():
-        if isinstance(_value, type) and issubclass(_value, TraitType):
+        if not _name.startswith('_') and isinstance(_value, type) and issubclass(_value, TraitType):
             __all__.append(_name)
+
 _add_all()

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -63,6 +63,28 @@ from .utils.bunch import Bunch
 
 SequenceTypes = (list, tuple, set, frozenset)
 
+# exports:
+
+__all__ = [
+    'default',
+    'validate',
+    'observe',
+    'link',
+    'directional_link',
+    'dlink',
+    'Undefined',
+    'All',
+    'NoDefaultSpecified',
+    'TraitError',
+    'HasDescriptors',
+    'HasTraits',
+    'MetaHasDescriptors',
+    'MetaHasTraits',
+    'BaseDescriptor',
+    'TraitType',
+]
+# any TraitType subclass will be added automatically
+
 #-----------------------------------------------------------------------------
 # Basic classes
 #-----------------------------------------------------------------------------
@@ -368,7 +390,7 @@ class BaseDescriptor(object):
 
     Notes
     -----
-    This implements Python's descriptor prototol.
+    This implements Python's descriptor protocol.
 
     This class is the base class for all such descriptors.  The
     only magic we use is a custom metaclass for the main :class:`HasTraits`
@@ -2878,3 +2900,11 @@ class Callable(TraitType):
             return value
         else:
             self.error(obj, value)
+
+# add all TraitType subclasses to export
+# avoid iterating through globals while defining variables
+def _add_all():
+    for _name, _value in globals().items():
+        if isinstance(_value, type) and issubclass(_value, TraitType):
+            __all__.append(_name)
+_add_all()


### PR DESCRIPTION
avoids accidentally making internal utilities such as `class_of`, etc. appear to be public