### PR TITLE
BUG: remove redundant call to List.validate_elements

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2422,9 +2422,6 @@ class List(Container):
 
         return super(List, self).validate_elements(obj, value)
 
-    def validate(self, obj, value):
-        return super(List, self).validate(obj, value)
-
 
 class Set(List):
     """An instance of a Python set."""

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2423,9 +2423,7 @@ class List(Container):
         return super(List, self).validate_elements(obj, value)
 
     def validate(self, obj, value):
-        value = super(List, self).validate(obj, value)
-        value = self.validate_elements(obj, value)
-        return value
+        return super(List, self).validate(obj, value)
 
 
 class Set(List):


### PR DESCRIPTION
Because of the ``super()`` call and the fact that ``validate_elements()`` is called from ``Container.validate()``, this validation does not need to be done again manually.