### PR TITLE
Fix parsing of deprecated list options failing with empty strings

### DIFF
--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -543,7 +543,7 @@ class CommandLineConfigLoader(ConfigLoader):
 
         elif isinstance(rhs, (list, tuple)):
             value = None
-            if len(rhs) == 1:
+            if len(rhs) == 1 and len(rhs[0]) > 0:
                 # check for deprecated --Class.trait="['a', 'b', 'c']"
                 r = rhs[0]
                 if (

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -345,6 +345,13 @@ class TestArgParseKVCL(TestKeyValueCL):
         self.assertEqual(config.CSub.d, [1, 'BBB'])
         self.assertEqual(config.CSub.e, [1, 'a', 'bcd'])
 
+    def test_seq_traits_single_empty_string(self):
+        cl = self.klass(log=log, classes=(CBase, ))
+        aliases = {'seqopt': 'CBase.c'}
+        argv = ['--seqopt', '']
+        config = cl.load_config(argv, aliases=aliases)
+        self.assertEqual(config.CBase.c, [''])
+
     def test_dict_traits(self):
         cl = self.klass(log=log, classes=(CBase, CSub))
         aliases = {'D': 'CBase.adict', 'E': 'CSub.bdict'}


### PR DESCRIPTION
When a list trait is aliased, and a single empty-string is given in command-line, like this:
```
foo -=seq-option=""
```
The `traitlets.config.loader` fails when attempting to parse it as `[deprecated, list, format]`, with this error:
```
  File "/home/user/traitlets/config/application.py", line 702, in parse_command_line
    self.cli_config = deepcopy(loader.load_config())
  File "/home/user/traitlets/config/loader.py", line 804, in load_config
    self._convert_to_config()
  File "/home/user/traitlets/config/loader.py", line 947, in _convert_to_config
    self._exec_config_str(k, v, trait=trait)
  File "/home/user/traitlets/config/loader.py", line 542, in _exec_config_str
    (r[0] == '[' and r[-1] == ']') or
IndexError: string index out of range
```

- The fix consists of skipping deprecated-list parsing on zero-length strings.
- A TC is included proving the problem is fixed.