### PR TITLE
fix(help): a yield had been forgotten from #405

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -530,7 +530,7 @@ class Application(SingletonConfigurable):
                     yield ''
 
             for cls in help_classes:
-                cls.class_print_help()
+                yield cls.class_get_help()
                 yield ''
         for l in self.emit_examples():
             yield l


### PR DESCRIPTION
+ Yielded lines and printed for class-options text were out of order.
+ End-results was `--help-all` to print header orphan at the bottom:
```
Class Options
=============
<many empty lines>
```