### PR TITLE
disable cross-validation of defaults

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -519,7 +519,8 @@ class TraitType(BaseDescriptor):
                 raise TraitError("No default value found for "
                     "the '%s' trait named '%s' of %r" % (
                     type(self).__name__, self.name, obj))
-            value = self._validate(obj, default)
+            with obj.cross_validation_lock:
+                value = self._validate(obj, default)
             obj._trait_values[self.name] = value
             obj.notify_change(Bunch(
                 name=self.name,


### PR DESCRIPTION
it causes loads of problems with nontrivial validation/observer combinations, including prematurely validating unused values and infinite recursion.

Given that validation of default values should only have an effect when those default values are initially invalid, there seems to be little benefit to introducing the complexity of validating defaults that may not be used.

With this change, ipywidgets tests pass again.

Closes #363
closes #435

#435 is an attempt to fix the problems without removing cross-validation of defaults. I think it's probably better to not cross-validate defaults, but it does get reported as a bug (#428), so we might give it a try.