### PR TITLE
Fix overriding `_trait_default` method

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2547,3 +2547,26 @@ def test_cls_self_argument():
             pass
 
     x = X(cls=None, self=None)
+
+
+def test_override_default():
+    class C(HasTraits):
+        a = Unicode('hard default')
+        def _a_default(self):
+            return 'default method'
+    
+    C._a_default = lambda self: 'overridden'
+    c = C()
+    assert c.a == 'overridden'
+
+def test_override_default_decorator():
+    class C(HasTraits):
+        a = Unicode('hard default')
+        @default('a')
+        def _a_default(self):
+            return 'default method'
+    
+    C._a_default = lambda self: 'overridden'
+    c = C()
+    assert c.a == 'overridden'
+

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2564,3 +2564,14 @@ def test_override_default_decorator():
     c = C()
     assert c.a == 'overridden'
 
+def test_override_default_instance():
+    class C(HasTraits):
+        a = Unicode('hard default')
+        @default('a')
+        def _a_default(self):
+            return 'default method'
+    
+    c = C()
+    c._a_default = lambda self: 'overridden'
+    assert c.a == 'overridden'
+

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2527,12 +2527,6 @@ def test_default_mro():
     class BA(B, A):
         pass
 
-    assert 'trait' in Base._trait_default_generators
-    assert 'trait' not in A._trait_default_generators
-    assert 'trait' in B._trait_default_generators
-    assert 'trait' not in AB._trait_default_generators
-    assert 'trait' not in BA._trait_default_generators
-
     assert A().trait == 'base'
     assert A().attr == 'base'
     assert BA().trait == 'B'

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1519,13 +1519,14 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         -----
         Dynamically generated default values may
         depend on the current state of the object."""
+        for n in names:
+            if not self.has_trait(n):
+                raise TraitError("'%s' is not a trait of '%s' "
+                    "instances" % (n, type(self).__name__))
+
         if len(names) == 1 and len(metadata) == 0:
             return self._get_trait_default_generator(names[0])(self)
 
-        for n in names:
-            if not has_trait(self, n):
-                raise TraitError("'%s' is not a trait of '%s' "
-                    "instances" % (n, type(self).__name__))
         trait_names = self.trait_names(**metadata)
         trait_names.extend(names)
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1491,21 +1491,23 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         """
         return {name: getattr(self, name) for name in self.trait_names(**metadata)}
 
-    @classmethod
-    def _get_trait_default_generator(cls, name):
+    def _get_trait_default_generator(self, name):
         """Return default generator for a given trait
 
         Walk the MRO to resolve the correct default generator according to inheritance.
         """
+        method_name = '_%s_default' % name
+        if method_name in self.__dict__:
+            return getattr(self, method_name)
+        cls = self.__class__
         trait = getattr(cls, name)
         assert isinstance(trait, TraitType)
         # truncate mro to the class on which the trait is defined
         mro = cls.mro()
         mro = mro[:mro.index(trait.this_class) + 1]
         for c in mro:
-            method_name = '_%s_default' % name
             if method_name in c.__dict__:
-                return getattr(c, '_%s_default' % name)
+                return getattr(c, method_name)
             if name in c.__dict__.get('_trait_default_generators', {}):
                 return c._trait_default_generators[name]
         return trait.default

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1504,7 +1504,11 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
         assert isinstance(trait, TraitType)
         # truncate mro to the class on which the trait is defined
         mro = cls.mro()
-        mro = mro[:mro.index(trait.this_class) + 1]
+        try:
+            mro = mro[:mro.index(trait.this_class) + 1]
+        except ValueError:
+            # this_class not in mro
+            pass
         for c in mro:
             if method_name in c.__dict__:
                 return getattr(c, method_name)


### PR DESCRIPTION
Registering generators during class initialization prevents overriding these after the fact.
Move the logic to default resolution, rather than explicitly registering on every construction,
which doesn't allow expected behavior when modifying class or instance objects.