### PR TITLE
Envvars

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -700,7 +700,7 @@ class Application(SingletonConfigurable):
         classes = tuple(self._classes_with_config_traits())
         loader = self._create_loader(argv, aliases, flags, classes=classes)
         self.cli_config = deepcopy(loader.load_config())
-        self.update_config(self.cli_config, skip_env=True)
+        self.update_config_with_env(self.cli_config, skip_env=True)
         # store unparsed args in extra_args
         self.extra_args = loader.extra_args
 
@@ -753,18 +753,24 @@ class Application(SingletonConfigurable):
                     filenames.append(loader.full_filename)
 
     @catch_config_error
-    def load_config_file(self, filename, path=None):
-        """Load config files by filename and path."""
+    def load_config_file(self, filename, path=None, skip_env=False):
+        """
+        Load config files by filename and path.
+
+        :param skip_env:
+            see :meth:`Configurable.update_config_with_env()`
+        """
         filename, ext = os.path.splitext(filename)
         new_config = Config()
-        for (config, filename) in self._load_config_files(filename, path=path, log=self.log,
+        for (config, filename) in self._load_config_files(
+            filename, path=path, log=self.log,
             raise_config_file_errors=self.raise_config_file_errors,
         ):
             new_config.merge(config)
             self._loaded_config_files.append(filename)
         # add self.cli_config to preserve CLI config priority
         new_config.merge(self.cli_config)
-        self.update_config(new_config)
+        self.update_config_with_env(new_config, skip_env=skip_env)
 
     def _classes_with_config_traits(self, classes=None):
         """

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -700,7 +700,7 @@ class Application(SingletonConfigurable):
         classes = tuple(self._classes_with_config_traits())
         loader = self._create_loader(argv, aliases, flags, classes=classes)
         self.cli_config = deepcopy(loader.load_config())
-        self.update_config(self.cli_config)
+        self.update_config(self.cli_config, skip_env=True)
         # store unparsed args in extra_args
         self.extra_args = loader.extra_args
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -210,12 +210,27 @@ class Configurable(HasTraits):
         section_names = self.section_names()
         self._load_config(change.new, traits=traits, section_names=section_names)
 
-    def update_config(self, config, skip_env=False):
+    def update_config(self, config):
         """
-        Update config and load the new values
+        Update config, load trait-values from `config` and overwrite any env-vars
+
+        - Simply delegates to :meth:`update_config_with_env()`.
+        - Use that method instead, if you don't want any env-vars to apply.
+        """
+        ## Had to split methods to preserve BW-compatibility for new `skip_env`.
+        self.update_config_with_env(config)
+
+    def update_config_with_env(self, config, skip_env=False):
+        """
+        Update config, apply `config` to traits and overwrite any env-vars
 
         :param skip_env:
-            when true, does configs apply even for traits with `envvar` metadata.
+            (relevant only for traits with `envvar` in metadata)
+            if true, config-values will NOT be overwriten by env-vars; note that
+            traits missing from `config`, will resolve to env-vars values,
+            regardless of this flag.
+
+        Note: merged configs in :attr:`config` will NOT contain env-var values.
         """
         # traitlets prior to 4.2 created a copy of self.config in order to trigger change events.
         # Some projects (IPython < 5) relied upon one side effect of this,

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -386,7 +386,7 @@ class Configurable(HasTraits):
 
                 env_var = trait.metadata.get('envvar')
                 if env_var:
-                    lines.append('Env-var: %s' % env_var)
+                    lines.append('#  Env-var: %s' % env_var)
 
                 if 'Enum' in type(trait).__name__:
                     # include Enum choices
@@ -426,7 +426,7 @@ class Configurable(HasTraits):
 
             env_var = trait.metadata.get('envvar')
             if env_var:
-                lines.append(indent(indent('Env-var: ``%s``' % env_var, 4)))
+                lines.append(indent('Env-var: ``%s``' % env_var, 4))
 
             # Default value
             try:

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -288,7 +288,7 @@ class Configurable(HasTraits):
 
         env_var = trait.metadata.get('envvar')
         if env_var:
-            env_info = 'Env-var: %s' % env_var
+            env_info = 'Environment variable: %s' % env_var
             lines.append(indent(env_info, 4))
 
         if inst is not None:
@@ -386,7 +386,10 @@ class Configurable(HasTraits):
 
                 env_var = trait.metadata.get('envvar')
                 if env_var:
-                    lines.append('#  Env-var: %s' % env_var)
+
+
+
+                    lines.append('#  Environment variable: %s' % env_var)
 
                 if 'Enum' in type(trait).__name__:
                     # include Enum choices
@@ -426,7 +429,7 @@ class Configurable(HasTraits):
 
             env_var = trait.metadata.get('envvar')
             if env_var:
-                lines.append(indent('Env-var: ``%s``' % env_var, 4))
+                lines.append(indent('Environment variable: ``%s``' % env_var, 4))
 
             # Default value
             try:

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -662,10 +662,10 @@ def test_env_vars_priority(monkeypatch):
 
         app = App()
         assert (app.a, app.b) == exp['init']
-        app.update_config(cfg, skip_env=True)
+        app.update_config_with_env(cfg, skip_env=True)
         assert (app.a, app.b) == exp['skp']
 
-        app.update_config(cfg, skip_env=False)
+        app.update_config_with_env(cfg, skip_env=False)
         assert (app.a, app.b) == exp['cfg']
 
         app.a = app.b = 'set'

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -718,19 +718,19 @@ def test_env_vars_priority(monkeypatch):
 
         conf = Conf()
         assert (conf.a, conf.b) == exp['init']
-        conf.update_config(cfg, skip_env=True)
+        conf.update_config_with_env(cfg, skip_env=True)
         assert (conf.a, conf.b) == exp['skp']
 
-        conf.update_config(cfg, skip_env=False)
+        conf.update_config_with_env(cfg, skip_env=False)
         assert (conf.a, conf.b) == exp['cfg']
 
         conf.a = conf.b = 'set'
         assert (conf.a, conf.b) == exp['set']
 
-        conf.update_config(cfg, skip_env=True)
+        conf.update_config_with_env(cfg, skip_env=True)
         assert (conf.a, conf.b) == exp['skp']
 
-        conf.update_config(cfg, skip_env=False)
+        conf.update_config_with_env(cfg, skip_env=False)
         assert (conf.a, conf.b) == exp['cfg']
 
         conf = Conf(a='set', b='set')

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -645,9 +645,9 @@ def check_meth():
 
 
 @mark.parametrize('check_meth', [
-    ('class_get_help', r'^    Env-var: MY_ENVVAR'),
-    ('class_config_section', r'^#  Env-var: MY_ENVVAR'),
-    ('class_config_rst_doc', r'^    Env-var: ``MY_ENVVAR``'),
+    ('class_get_help', r'^    Environment variable: MY_ENVVAR'),
+    ('class_config_section', r'^#  Environment variable: MY_ENVVAR'),
+    ('class_config_rst_doc', r'^    Environment variable: ``MY_ENVVAR``'),
 ])
 def test_environment_variable_comment_list(check_meth):
     import re

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -18,8 +18,8 @@ from traitlets.config.configurable import (
 )
 
 from traitlets.traitlets import (
-    Integer, Float, Unicode, List, Dict, Set, Enum, FuzzyEnum,
-    CaselessStrEnum, _deprecations_shown, validate,
+    Integer, CInt, Float, Unicode, List, Dict, Set, Enum, FuzzyEnum,
+    CaselessStrEnum, _deprecations_shown, validate, default
 )
 
 from traitlets.config.loader import Config
@@ -302,7 +302,6 @@ class TestConfigurable(TestCase):
         ## Check order of Default <--> Choices sections
         self.assertGreater(cls4_cfg.index(defaults_str),
                            cls4_cfg.index(enum_choices_str))
-
 
 
 class TestSingletonConfigurable(TestCase):
@@ -639,3 +638,88 @@ class TestLogger(TestCase):
         self.assertIn('Config option `totally_wrong` not recognized by `A`.', output)
         self.assertNotIn('Did you mean', output)
 
+
+def test_environment_variable_default(monkeypatch):
+    class A(Configurable):
+        b = CInt(allow_none=True).tag(config=True, envvar='MY_ENVVAR')
+
+    cfg = Config()
+    cfg.A.b = 2
+
+    a = A()
+    assert a.b == 0
+    a = A(config=cfg)
+    assert a.b == 2
+
+    monkeypatch.setenv('MY_ENVVAR', '1')
+
+    a = A()
+    assert a.b == 1  # env-var has precendance.
+
+    a = A(config=cfg)
+    assert a.b == 1  # env-var has precendance.
+
+    a.b = 3
+    assert a.b == 3  # Direct assignments override env-var.
+    a.b = None
+    assert a.b == None
+
+def test_env_vars_priority(monkeypatch):
+    class Conf(Configurable):
+        a = Unicode('def').tag(config=True, envvar='MY_ENVVAR')
+        b = Unicode().tag(config=True, envvar='MY_ENVVAR')
+        aliases = {'def': 'App.a', 'dyn': 'App.b'}
+
+        @default('b')
+        def set_a_dyn(self):
+            return 'dyn'
+
+    exp_no_envvar = {
+        'init': ('def', 'dyn'),  # values after "empty" construction
+        'set': ('set', 'set'),  # values after direct assignment
+        'cfg': ('cfg', 'cfg'),  # values after `update_config()
+        'skp': ('cfg', 'cfg'),  # values when `skip_env=True`
+    }
+    exp_with_envvar = {
+        'init': ('env', 'env'),
+        'set': ('set', 'set'),
+        'cfg': ('env', 'env'),
+        'skp': ('cfg', 'cfg'),
+    }
+
+
+    def check_priority(exp):
+        cfg = Config()
+        cfg.Conf.a = cfg.Conf.b = 'cfg'
+
+        conf = Conf()
+        assert (conf.a, conf.b) == exp['init']
+        conf.update_config(cfg, skip_env=True)
+        assert (conf.a, conf.b) == exp['skp']
+
+        conf.update_config(cfg, skip_env=False)
+        assert (conf.a, conf.b) == exp['cfg']
+
+        conf.a = conf.b = 'set'
+        assert (conf.a, conf.b) == exp['set']
+
+        conf.update_config(cfg, skip_env=True)
+        assert (conf.a, conf.b) == exp['skp']
+
+        conf.update_config(cfg, skip_env=False)
+        assert (conf.a, conf.b) == exp['cfg']
+
+        conf = Conf(a='set', b='set')
+        assert (conf.a, conf.b) == exp['set']
+
+        conf = Conf(config=cfg, a='set', b='set')
+        assert (conf.a, conf.b) == exp['set']
+
+        conf = Conf(config=cfg)
+        assert (conf.a, conf.b) == exp['cfg']
+
+
+
+    check_priority(exp_no_envvar)
+    monkeypatch.setenv('MY_ENVVAR', 'env')
+    check_priority(exp_with_envvar)

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2548,7 +2548,7 @@ def test_override_default():
         a = Unicode('hard default')
         def _a_default(self):
             return 'default method'
-    
+
     C._a_default = lambda self: 'overridden'
     c = C()
     assert c.a == 'overridden'
@@ -2559,7 +2559,7 @@ def test_override_default_decorator():
         @default('a')
         def _a_default(self):
             return 'default method'
-    
+
     C._a_default = lambda self: 'overridden'
     c = C()
     assert c.a == 'overridden'
@@ -2570,8 +2570,26 @@ def test_override_default_instance():
         @default('a')
         def _a_default(self):
             return 'default method'
-    
+
     c = C()
     c._a_default = lambda self: 'overridden'
     assert c.a == 'overridden'
 
+def test_envvar_override_default(monkeypatch):
+    class A(HasTraits):
+        b = CInt(allow_none=True).tag(config=True, envvar='MY_ENVVAR')
+
+    a = A()
+    assert a.b == 0
+
+    monkeypatch.setenv('MY_ENVVAR', '1')
+
+    a = A()
+    assert a.b == 1
+    a = A(a=2)
+    assert a.b == 1
+
+    a.b = 3
+    assert a.b == 3  # Direct assignments override env-var.
+    a.b = None
+    assert a.b == None


### PR DESCRIPTION
I believe I Implemented #99 for receiving trait-values from environment-variables with only minimal changes to the codebase.
The priority for the source of trait-values is the following (bottom wins):
1. program defaults (`trait.default_value`, *dynamic_defaults*),
2. config-files,
3. env-var,
4. command-line arguments,
5. values directly assigned.

## Example:

```python
class App(Application):
    a = Unicode('def').tag(config=True,
                           envvar='MY_ENVVAR')
    b = Unicode().tag(config=True,
                      envvar='MY_ENVVAR')
    aliases = {'a': 'App.a', 'b': 'App.b'}

    @default('b')
    def set_a_dyn(self):
        return 'def'


cfg = Config()
cfg.App.a = cfg.App.b = 'cfg'

app = App()
assert app.a == app.b == 'def'

app = App(config=cfg)
assert app.a == app.b == 'cfg'

app.parse_command_line(['-a=cmd', '-b=cmd'])
assert app.a == app.b == 'cmd'


os.environ['MY_ENVVAR'] = 'env'


app = App()
assert app.a == app.b == 'env'

app = App(config=cfg)
assert app.a == app.b == 'env'

app.parse_command_line(['-a=cmd', '-b=cmd'])
assert app.a == app.b == 'cmd'
```

And this is the help string:
```ipython
>>> print(App.class_get_trait_help(App.a))
--App.a=<Unicode>
    Env-var: MY_ENVVAR
    Default: 'def'
```

## Implementation:
The feature is implemented in 3 forward-dependent commits:

1. *trait-layer:* 
   The `TraitType.metadata['envvar']` stores the name of the environment-variable.
   That metadata is checked in `TraitType.get()`, just before defaults.
   If the env-var exists, its value fetched and cached in `_trait_values` dict, as a normal value.
   No specific effort is made for converting string env-vars - use of coercing traits is recommended.

2. *configurable-layer:* 
   the `Configurable._load_config()` does an exception for traits with an existing env-var;
   in that case, it does not load their values from configs but from the env-var.

3. *application-layer:* 
   the `Application.parse_command_line()` invokes `Configurable._load_config(skip_env=True)`
   to bypass the above rule for its command-line config-params.
   (the `skip_env` keywords had to be added on `update_config()` for this to work).


## Rational:
- *Dynamic defaults* (#158, #246) wouldn't achieve the desired functionality because configs would overwrite ENV-VAR values.
- Using a *metadata* at the trait-layer allows for config and app layers to do informed decisions.
- It satisfies the [@carreau's call for carefullness](ipython/traitlets/pull/246#issuecomment-230001157) on the precendence rule
and for automatic doc-generation in the presence of env-vars..

## Open issues:
- Documentation:  Where to describe the new capability?  Maybe collect all *metadata* usages in some place?
- Should we print the envvar-value in the help description, if var exists?
- Should we add a new `Configurable.skip_env` trait (not tagged as `config` of course)?
  I would vote for *yes. Otherwise, it's impossible to affect this behavior from the constructor, when a `config` object is given - as it is now, environment always applies, and it overwrites any configs.
  But adding a new special-purpose trait on `Configurable` class is too obtrusive for me to decide.
  [edit:] A cheaper alternative would be to add a special `skip_env` kwd in configurable's cstor.
- Is there any other code-path that needs to become env-aware?  Is `_load_config()` & `parse_command_line()` enough?