### PR TITLE
allow traits to parse string config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 .#*
 .coverage
 .cache
+htmlcov

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -9,7 +9,7 @@ from __future__ import print_function, absolute_import
 from copy import deepcopy
 import warnings
 
-from .loader import Config, LazyConfigValue, _is_section_key
+from .loader import Config, LazyConfigValue, DeferredConfigString, _is_section_key
 from traitlets.traitlets import (
     HasTraits,
     Instance,
@@ -165,6 +165,9 @@ class Configurable(HasTraits):
                         # without having to copy the initial value
                         initial = getattr(self, name)
                         config_value = config_value.get_value(initial)
+                    elif isinstance(config_value, DeferredConfigString):
+                        # DeferredEval tends to come from CLI/environment variables
+                        config_value = config_value.get_value(self.traits()[name])
                     # We have to do a deepcopy here if we don't deepcopy the entire
                     # config object. If we don't, a mutable config_value will be
                     # shared by all instances, effectively making it a class attribute.

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -317,8 +317,9 @@ class DeferredConfigString(text_type):
     in the configurable classes.
 
     When config is loaded, `trait.from_string` will be used.
-    
-    If an error is raised
+
+    If an error is raised in `.from_string`,
+    the original string is returned.
 
     .. versionadded:: 5.0
     """

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -317,12 +317,21 @@ class DeferredConfigString(text_type):
     in the configurable classes.
 
     When config is loaded, `trait.from_string` will be used.
+    
+    If an error is raised
 
     .. versionadded:: 5.0
     """
     def get_value(self, trait):
         """Get the value stored in this string"""
-        return trait.from_string(text_type(self))
+        s = text_type(self)
+        try:
+            return trait.from_string(s)
+        except Exception:
+            # exception casting from string,
+            # let the original string lie.
+            # this will raise a more informative error when config is loaded.
+            return s
 
     def __repr__(self):
         super_repr = super(DeferredConfigString, self).__repr__()
@@ -546,7 +555,12 @@ class CommandLineConfigLoader(ConfigLoader):
                         "Use %r instead of %r" % (rhs, old_rhs),
                         DeprecationWarning)
         if trait:
-            return trait.from_string(rhs)
+            try:
+                return trait.from_string(rhs)
+            except Exception:
+                # failed to eval, let later config loading raise,
+                # which will be more informative
+                return rhs
         else:
             return DeferredConfigString(rhs)
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -5,13 +5,14 @@
 # Distributed under the terms of the Modified BSD License.
 
 import argparse
+from ast import literal_eval
 import copy
 import functools as fnt
 import os
 import re
 import sys
 import json
-from ast import literal_eval
+import warnings
 
 from ipython_genutils.path import filefind
 from ipython_genutils import py3compat
@@ -321,7 +322,7 @@ class DeferredConfigString(text_type):
     """
     def get_value(self, trait):
         """Get the value stored in this string"""
-        return trait.from_string(self)
+        return trait.from_string(text_type(self))
 
     def __repr__(self):
         super_repr = super(DeferredConfigString, self).__repr__()
@@ -533,6 +534,17 @@ class CommandLineConfigLoader(ConfigLoader):
 
     def _parse_config_value(self, rhs, trait=None):
         """Python-evaluates any cmd-line argument values."""
+        rhs = os.path.expanduser(rhs)
+        if len(rhs) > 2:
+            # handle deprecated "1"
+            for c in "'\"":
+                if rhs[0] == rhs[-1] == c:
+                    old_rhs = rhs
+                    rhs = rhs[1:-1]
+                    warnings.warn(
+                        "Supporting extra quotes around strings is deprecated in traitlets 5.0. "
+                        "Use %r instead of %r" % (rhs, old_rhs),
+                        DeprecationWarning)
         if trait:
             return trait.from_string(rhs)
         else:
@@ -542,11 +554,9 @@ class CommandLineConfigLoader(ConfigLoader):
         """execute self.config.<lhs> = <rhs>
 
         * expands ~ with expanduser
-        * tries to assign with literal_eval, otherwise assigns with just the string,
-          allowing `--C.a=foobar` and `--C.a="foobar"` to be equivalent.  *Not*
-          equivalent are `--C.a=4` and `--C.a='4'`.
+        * interprets value with trait if available
         """
-        if isinstance(trait, Dict):
+        if isinstance(trait, Dict) and not isinstance(rhs, string_types):
             if len(rhs) == 1 and isinstance(rhs[0], string_types):
                 # check for deprecated --Class.trait="{'a': 'b'}"
                 self.log.warning(
@@ -554,10 +564,19 @@ class CommandLineConfigLoader(ConfigLoader):
                     "You can pass --{0} <key=value> ... multiple times to add items to a dict.".format(
                         lhs, rhs[0])
                 )
-                value = self._parse_config_value(rhs[0], trait)
+                value = literal_eval(rhs[0])
             else:
                 # FIXME: get trait for values
-                value = {k: self._parse_config_value(v) for k,v in rhs}
+                value = {}
+                for k, v in rhs:
+                    value_trait = (trait._per_key_traits or {}).get(k, trait._value_trait)
+                    if value_trait:
+                        value[k] = self._parse_config_value(v, value_trait)
+                    else:
+                        # no trait, use str
+                        # non-str values can only be passed this way
+                        # if the dict trait defines value traits
+                        value[k] = v
 
         elif isinstance(rhs, (list, tuple)):
             value = None
@@ -576,7 +595,15 @@ class CommandLineConfigLoader(ConfigLoader):
                     value = self._parse_config_value(r, trait)
 
             if value is None:
-                value = [self._parse_config_value(r, trait) for r in rhs]
+                if trait:
+                    value_trait = getattr(trait, "_trait")
+                else:
+                    value_trait = None
+                if value_trait:
+                    value = [self._parse_config_value(r, value_trait) for r in rhs]
+                else:
+                    # no trait, use strings
+                    value = [r for r in rhs]
         else:
             value = self._parse_config_value(rhs, trait)
 
@@ -757,6 +784,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
                 try:
                     self._exec_config_str(lhs, rhs, trait)
                 except Exception:
+                    raise
                     raise ArgumentError("Invalid argument: '%s'" % raw)
 
             elif flag_pattern.match(raw):

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -305,6 +305,29 @@ class Config(dict):
             raise AttributeError(e)
 
 
+class DeferredConfigString(text_type):
+    """Config value for loading config from a string
+
+    Interpretation is deferred until it is loaded into the trait.
+
+    Subclass of unicode for backward compatibility.
+
+    This class is only used for values that are not listed
+    in the configurable classes.
+
+    When config is loaded, `trait.from_string` will be used.
+
+    .. versionadded:: 5.0
+    """
+    def get_value(self, trait):
+        """Get the value stored in this string"""
+        return trait.from_string(self)
+
+    def __repr__(self):
+        super_repr = super(DeferredConfigString, self).__repr__()
+        return '%s(%s)' % (self.__class__.__name__, super_repr)
+
+
 #-----------------------------------------------------------------------------
 # Config loading classes
 #-----------------------------------------------------------------------------
@@ -508,18 +531,12 @@ class CommandLineConfigLoader(ConfigLoader):
     here.
     """
 
-    def _parse_config_value(self, rhs):
+    def _parse_config_value(self, rhs, trait=None):
         """Python-evaluates any cmd-line argument values."""
-        rhs = os.path.expanduser(rhs)
-        try:
-            # Try to see if regular Python syntax will work. This
-            # won't handle strings as the quote marks are removed
-            # by the system shell.
-            value = literal_eval(rhs)
-        except (NameError, SyntaxError, ValueError):
-            # This case happens if the rhs is a string.
-            value = rhs
-        return value
+        if trait:
+            return trait.from_string(rhs)
+        else:
+            return DeferredConfigString(rhs)
 
     def _exec_config_str(self, lhs, rhs, trait=None):
         """execute self.config.<lhs> = <rhs>
@@ -537,8 +554,9 @@ class CommandLineConfigLoader(ConfigLoader):
                     "You can pass --{0} <key=value> ... multiple times to add items to a dict.".format(
                         lhs, rhs[0])
                 )
-                value = self._parse_config_value(rhs[0])
+                value = self._parse_config_value(rhs[0], trait)
             else:
+                # FIXME: get trait for values
                 value = {k: self._parse_config_value(v) for k,v in rhs}
 
         elif isinstance(rhs, (list, tuple)):
@@ -555,12 +573,12 @@ class CommandLineConfigLoader(ConfigLoader):
                         "You can pass --{0} item ... multiple times to add items to a list.".format(
                             lhs, rhs)
                     )
-                    value = self._parse_config_value(r)
+                    value = self._parse_config_value(r, trait)
 
             if value is None:
-                value = [self._parse_config_value(r) for r in rhs]
+                value = [self._parse_config_value(r, trait) for r in rhs]
         else:
-            value = self._parse_config_value(rhs)
+            value = self._parse_config_value(rhs, trait)
 
         exec(u'self.config.%s = value' % lhs, None, locals())
 
@@ -600,7 +618,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         ipython --profile="foo" --InteractiveShell.autocall=False
     """
 
-    def __init__(self, argv=None, aliases=None, flags=None, **kw):
+    def __init__(self, argv=None, aliases=None, flags=None, classes=None, **kw):
         """Create a key value pair config loader.
 
         Parameters
@@ -614,9 +632,12 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
             Keys are the short aliases, Values are the resolved trait.
             Of the form: `{'alias' : 'Configurable.trait'}`
         flags : dict
-            A dict of flags, keyed by str name. Vaues can be Config objects,
+            A dict of flags, keyed by str name. Values can be Config objects,
             dicts, or "key=value" strings.  If Config or dict, when the flag
             is triggered, The flag is loaded as `self.config.update(m)`.
+        classes : sequence
+            A list/tuple of classes that are to be configured.
+            Classes included in this list
 
         Returns
         -------
@@ -638,6 +659,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         self.argv = argv
         self.aliases = aliases or {}
         self.flags = flags or {}
+        self.classes = classes or ()
 
 
     def clear(self):
@@ -657,6 +679,19 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
             uargv.append(arg)
         return uargv
 
+    def _find_trait(self, lhs):
+        """Find the trait for a Class.trait string"""
+        
+        from .configurable import Configurable
+        class_name, trait_name = lhs.split('.')[-2:]
+        for cls in self.classes:
+            for parent in cls.mro():
+                if (
+                    issubclass(parent, Configurable) and
+                    parent.__name__ == class_name
+                ):
+                    return parent.class_traits().get(trait_name)
+        return None
 
     def load_config(self, argv=None, aliases=None, flags=None):
         """Parse the configuration and generate the Config object.
@@ -715,9 +750,12 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
                     lhs = aliases[lhs]
                 if '.' not in lhs:
                     # probably a mistyped alias, but not technically illegal
-                    self.log.warning("Unrecognized alias: '%s', it will probably have no effect.", raw)
+                    self.log.warning("Unrecognized alias: '%s', it will have no effect.", raw)
+                    trait = None
+                else:
+                    trait = self._find_trait(lhs)
                 try:
-                    self._exec_config_str(lhs, rhs)
+                    self._exec_config_str(lhs, rhs, trait)
                 except Exception:
                     raise ArgumentError("Invalid argument: '%s'" % raw)
 
@@ -813,11 +851,6 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
     def _create_parser(self, aliases=None, flags=None, classes=None):
         self.parser = ArgumentParser(*self.parser_args, **self.parser_kw)
         self._add_arguments(aliases, flags, classes)
-
-    def _parse_config_traits(self):
-        for cls in self.classes:
-            for trait, traitname in cls.class_traits(config=True).items():
-                yield ()
 
     def _add_arguments(self, aliases=None, flags=None, classes=None):
         raise NotImplementedError("subclasses must implement _add_arguments")
@@ -950,7 +983,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
             self._load_flag(subc)
 
         if self.extra_args:
-            sub_parser = KeyValueConfigLoader(log=self.log)
+            sub_parser = KeyValueConfigLoader(log=self.log, classes=self.classes)
             sub_parser.load_config(self.extra_args)
             self.config.merge(sub_parser.config)
             self.extra_args = sub_parser.extra_args

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -35,8 +35,9 @@ from traitlets.config.application import (
 from ipython_genutils.tempdir import TemporaryDirectory
 from traitlets import (
     HasTraits,
-    Bool, Unicode, Integer, List, Tuple, Set, Dict
+    Bool, Bytes, Unicode, Integer, List, Tuple, Set, Dict
 )
+
 
 class Foo(Configurable):
 
@@ -48,7 +49,9 @@ class Foo(Configurable):
     j = Integer(1, help="The integer j.").tag(config=True)
     name = Unicode(u'Brian', help="First name.").tag(config=True)
     la = List([]).tag(config=True)
+    li = List(Integer()).tag(config=True)
     fdict = Dict().tag(config=True, multiplicity='+')
+
 
 class Bar(Configurable):
 
@@ -57,6 +60,8 @@ class Bar(Configurable):
     tb = Tuple(()).tag(config=True, multiplicity='*')
     aset = Set().tag(config=True, multiplicity='+')
     bdict = Dict().tag(config=True)
+    idict = Dict(value_trait=Integer()).tag(config=True)
+    key_dict = Dict(per_key_traits={'i': Integer(), 'b': Bytes()}).tag(config=True)
 
 
 class MyApp(Application):
@@ -76,6 +81,7 @@ class MyApp(Application):
                     ('j', 'fooj') : ('Foo.j', "`j` terse help msg"),
                     'name' : 'Foo.name',
                     'la': 'Foo.la',
+                    'li': 'Foo.li',
                     'tb': 'Bar.tb',
                     'D': 'Bar.bdict',
                     'enabled' : 'Bar.enabled',
@@ -166,31 +172,37 @@ class TestApplication(TestCase):
 
     def test_config_seq_args(self):
         app = MyApp()
-        app.parse_command_line("--la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
+        app.parse_command_line("--li 1 --li 3 --la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
         config = app.config
-        self.assertEqual(config.Foo.la, [1, 'ab'])
-        self.assertEqual(config.Bar.tb, ['AB', 2])
+        assert config.Foo.li == [1, 3]
+        assert config.Foo.la == ['1', 'ab']
+        assert config.Bar.tb == ['AB', '2']
         self.assertEqual(config.Bar.aset, 'S1 S2 S1'.split())
         app.init_foo()
-        self.assertEqual(app.foo.la, [1, 'ab'])
+        assert app.foo.li == [1, 3]
+        assert app.foo.la == ['1', 'ab']
         app.init_bar()
         self.assertEqual(app.bar.aset, {'S1', 'S2'})
-        self.assertEqual(app.bar.tb, ('AB', 2))
+        assert app.bar.tb == ('AB', '2')
 
     def test_config_dict_args(self):
         app = MyApp()
         app.parse_command_line(
             "--Foo.fdict a=1 b=b c=3 "
             "--Bar.bdict k=1 -D=a=b -D 22=33 "
+            "--Bar.idict k=1 --Bar.idict b=2 --Bar.idict c=3 "
             .split())
-        fdict = {'a': 1, 'b': 'b', 'c': 3}
-        bdict = {'k': 1, 'a': 'b', '22': 33}
+        fdict = {'a': '1', 'b': 'b', 'c': '3'}
+        bdict = {'k': '1', 'a': 'b', '22': '33'}
+        idict = {'k': 1, 'b': 2, 'c': 3}
         config = app.config
+        assert config.Bar.idict == idict
         self.assertDictEqual(config.Foo.fdict, fdict)
         self.assertDictEqual(config.Bar.bdict, bdict)
         app.init_foo()
         self.assertEqual(app.foo.fdict, fdict)
         app.init_bar()
+        assert app.bar.idict == idict
         self.assertEqual(app.bar.bdict, bdict)
 
     def test_config_propagation(self):

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -125,6 +125,12 @@ class TestApplication(TestCase):
         app.log.info("hello")
         assert "hello" in stream.getvalue()
 
+    def test_no_eval_cli_text(self):
+        app = MyApp()
+        app.initialize(['--Foo.name=1'])
+        app.init_foo()
+        assert app.foo.name == '1'
+
     def test_basic(self):
         app = MyApp()
         self.assertEqual(app.name, u'myapp')

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -23,7 +23,10 @@ from traitlets.config.loader import (
     KVArgParseConfigLoader,
     ConfigError,
 )
-from traitlets import (HasTraits, Union, List, Tuple, Dict, Int, Unicode)
+from traitlets import (
+    HasTraits, Union, List, Tuple, Dict, Int, Unicode,
+    Integer,
+)
 from traitlets.config import Configurable
 
 
@@ -236,25 +239,29 @@ class TestArgParseCL(TestCase):
         self.assertEqual(config.list1, [1, 'B'])
         self.assertEqual(config.list2, [1, 2, 3])
 
+class C(Configurable):
+    str_trait = Unicode(config=True)
+    int_trait = Integer(config=True)
+    list_trait = List(config=True)
 
 class TestKeyValueCL(TestCase):
     klass = KeyValueConfigLoader
 
     def test_eval(self):
         cl = self.klass(log=log)
-        config = cl.load_config('--Class.str_trait=all --Class.int_trait=5 --Class.list_trait=["hello",5]'.split())
-        self.assertEqual(config.Class.str_trait, 'all')
-        self.assertEqual(config.Class.int_trait, 5)
-        self.assertEqual(config.Class.list_trait, ["hello", 5])
+        config = cl.load_config('--C.str_trait=all --C.int_trait=5 --C.list_trait=["hello",5]'.split())
+        c = C(config=config)
+        assert c.str_trait == 'all'
+        assert c.int_trait == 5
+        assert c.list_trait == ["hello", 5]
 
     def test_basic(self):
         cl = self.klass(log=log)
         argv = [ '--' + s[2:] for s in pyfile.split('\n') if s.startswith('c.') ]
-        print(argv)
         config = cl.load_config(argv)
-        self.assertEqual(config.a, 10)
-        self.assertEqual(config.b, 20)
-        self.assertEqual(config.Foo.Bar.value, 10)
+        assert config.a == '10'
+        assert config.b == '20'
+        assert config.Foo.Bar.value == '10'
         # non-literal expressions are not evaluated
         self.assertEqual(config.Foo.Bam.value, 'list(range(10))')
         self.assertEqual(config.D.C.value, 'hi there')
@@ -272,8 +279,8 @@ class TestKeyValueCL(TestCase):
         cl = self.klass(log=log)
         config = cl.load_config(['--a=5', 'b', '--c=10', 'd'])
         self.assertEqual(cl.extra_args, ['b', 'd'])
-        self.assertEqual(config.a, 5)
-        self.assertEqual(config.c, 10)
+        assert config.a == '5'
+        assert config.c == '10'
         config = cl.load_config(['--', '--a=5', '--c=10'])
         self.assertEqual(cl.extra_args, ['--a=5', '--c=10'])
 
@@ -307,7 +314,7 @@ class TestKeyValueCL(TestCase):
 
 class CBase(HasTraits):
     a = List().tag(config=True)
-    b = List().tag(config=True, multiplicity='*')
+    b = List(Integer()).tag(config=True, multiplicity='*')
     c = List().tag(config=True, multiplicity='append')
     adict = Dict().tag(config=True)
 
@@ -338,12 +345,12 @@ class TestArgParseKVCL(TestKeyValueCL):
         argv = ("--CBase.a A --CBase.a 2 --CBase.b 1 2 3 --a3 AA --CBase.c BB "
                 "--CSub.d 1 --CSub.d BBB --CSub.e 1 a bcd").split()
         config = cl.load_config(argv, aliases=aliases)
-        self.assertEqual(config.CBase.a, ['A', 2])
-        self.assertEqual(config.CBase.b, [1, 2, 3])
+        assert config.CBase.a == ['A', '2']
+        assert config.CBase.b == [1, 2, 3]
         self.assertEqual(config.CBase.c, ['AA', 'BB'])
 
-        self.assertEqual(config.CSub.d, [1, 'BBB'])
-        self.assertEqual(config.CSub.e, [1, 'a', 'bcd'])
+        assert config.CSub.d == ['1', 'BBB']
+        assert config.CSub.e == ['1', 'a', 'bcd']
 
     def test_seq_traits_single_empty_string(self):
         cl = self.klass(log=log, classes=(CBase, ))
@@ -357,10 +364,10 @@ class TestArgParseKVCL(TestKeyValueCL):
         aliases = {'D': 'CBase.adict', 'E': 'CSub.bdict'}
         argv = ["--CBase.adict", "k1=v1", "-D=k2=2", "-D", "k3=v 3", "-E", "k=v", "22=222"]
         config = cl.load_config(argv, aliases=aliases)
-        self.assertDictEqual(config.CBase.adict,
-                {'k1': 'v1', 'k2': 2, 'k3': 'v 3'})
-        self.assertEqual(config.CSub.bdict,
-                {'k': 'v', '22': 222})
+        assert config.CBase.adict == \
+                {'k1': 'v1', 'k2': '2', 'k3': 'v 3'}
+        assert config.CSub.bdict == \
+                {'k': 'v', '22': '222'}
 
 
 class TestConfig(TestCase):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2625,3 +2625,114 @@ def test_override_default_instance():
     c._a_default = lambda self: 'overridden'
     assert c.a == 'overridden'
 
+
+def _from_string_test(traittype, s, expected):
+    """Run a test of trait.from_string"""
+    trait = traittype()
+    if type(expected) is type and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            value = trait.from_string(s)
+            trait.validate(None, value)
+    else:
+        value = trait.from_string(s)
+        assert value == expected
+
+@pytest.mark.parametrize('s, expected', [
+    ('xyz', 'xyz'),
+    ('1', '1'),
+    ('"xx"', '"xx"'),
+    ("'abc'", "'abc'"),
+])
+def test_unicode_from_string(s, expected):
+    _from_string_test(Unicode, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', ValueError),
+    ('1', 1),
+    ('123', 123),
+    ('2.0', ValueError),
+])
+def test_int_from_string(s, expected):
+    _from_string_test(Integer, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', ValueError),
+    ('1', 1.0),
+    ('123.5', 123.5),
+    ('2.5', 2.5),
+])
+def test_float_from_string(s, expected):
+    _from_string_test(Float, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', ValueError),
+    ('1', 1.0),
+    ('123.5', 123.5),
+    ('2.5', 2.5),
+    ('1+2j', 1+2j),
+])
+def test_complex_from_string(s, expected):
+    _from_string_test(Complex, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('true', True),
+    ('TRUE', True),
+    ('1', True),
+    ('0', False),
+    ('False', False),
+    ('false', False),
+    ('1.0', ValueError),
+])
+def test_bool_from_string(s, expected):
+    _from_string_test(Bool, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('{}', {}),
+    ('[]', TraitError),
+    ('1', TraitError),
+    ('1/0', TraitError),
+    ('{1: 2}', {1: 2}),
+    ('{"key": "value"}', {"key": "value"}),
+    ('x', TraitError),
+])
+def test_dict_from_string(s, expected):
+    _from_string_test(Dict, s, expected)
+
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('[]', []),
+    ('[1, 2, "x"]', [1, 2, 'x']),
+    ('{}', TraitError),
+    ('1', TraitError),
+    ('1/0', TraitError),
+    ('x', TraitError),
+])
+def test_list_from_string(s, expected):
+    _from_string_test(List, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', 'x'),
+    ('mod.submod', 'mod.submod'),
+    ('not an identifier', TraitError),
+    ('1', '1'),
+])
+def test_object_from_string(s, expected):
+    _from_string_test(DottedObjectName, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('127.0.0.1:8000', ('127.0.0.1', 8000)),
+    ('host.tld:80', ('host.tld', 80)),
+    ('host:notaport', ValueError),
+    ('127.0.0.1', ValueError),
+])
+def test_tcp_from_string(s, expected):
+    _from_string_test(TCPAddress, s, expected)
+

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1867,7 +1867,7 @@ class Instance(ClassBasedTraitType):
         return repr(self.make_dynamic_default())
 
     def from_string(self, s):
-        return literal_eval(s)
+        return _safe_literal_eval(s)
 
 
 class ForwardDeclaredMixin(object):
@@ -2311,7 +2311,7 @@ class Bool(TraitType):
         elif s in {'false', '0'}:
             return False
         else:
-            self.error(obj, s)
+            raise ValueError("%r is not 1, 0, true, or false")
 
 
 class CBool(Bool):
@@ -2912,7 +2912,7 @@ class TCPAddress(TraitType):
 
     def from_string(self, s):
         if ':' not in s:
-            self.error(obj, s)
+            raise ValueError('Require `ip:port`, got %r' % s)
         ip, port = s.split(':', 1)
         port = int(port)
         return (ip, port)


### PR DESCRIPTION
This is related to the new argparse CLI parsing and envvar config in #439 / #217

Adds `trait.from_string` for loading values from a strings-only source (e.g. CLI, env).

Config coming from CLI (or env vars) always come as strings. We have been using `ast.literal_eval` on these, principally because in the early traitlets config design, parsing had to happen before the target traits were known. This has been the source of many problems.

This assumption has changed, as aliases and config parsing *are* given the classes to be configured, so that traits can be relied upon to parse values.

For the fallback `--Class.trait` case, we can also solve this problem by deferring parsing until config loading. This means that config passed that isn't in the official supported class list will always be str (a str subclass for backward-compatibility), and call `trait.from_string(s)` at config load time for the given class. Any config values that in fact never get loaded will be left as un-eval'd strings.

It also eliminates the `eval` in most cases, so bugs related to that should be fixed. Most importantly, it eliminates the eval on Unicode traits, where it was always the wrong thing to do.

Backward-compatibility issues (why I would like to get this in 5.0, along with the other edge-case-breaking CLI changes in the new argparse handling):

- Due to the use of eval, some cases  put quotes *inside* string arguments, so that
  `eval("1")` would get `"1"` instead of `1`. Eliminating the eval would result in these traits
  getting `'"1"'` (failing to strip quotes). Alternately, stripping quotes would make it impossible for traits to get values *with* quotes from the CLI. This is already the case now due to the use of `eval`.
- Unparsed config from the CLI will be strings in the config object.
  This means anything reaching into the config object that relied on `eval`
  would no longer get the eval'd object (typically an integer),
  but instead the DelayedEvalString.
  For any cases accepting a text object, this should be fine,
  but cases where it is something else (e.g. an int), this is a breaking change.

TODO:

- [x] Handle container traits. The new argparse syntax has made this a little more complicated 
      because a trait may come in as a string literal (old way) or a list of values.
      We need to get the right trait to deal with this.
- [x] Deal specially with quotes on strings, which were swallowed by `eval`