### PR TITLE
feat(traits): Implement ENV-VARS in traits-level

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -9,7 +9,7 @@ from __future__ import print_function, absolute_import
 from copy import deepcopy
 import warnings
 
-from .loader import Config, LazyConfigValue, _is_section_key
+from .loader import Config, LazyConfigValue, DeferredConfigString, _is_section_key
 from traitlets.traitlets import (
     HasTraits,
     Instance,
@@ -165,6 +165,9 @@ class Configurable(HasTraits):
                         # without having to copy the initial value
                         initial = getattr(self, name)
                         config_value = config_value.get_value(initial)
+                    elif isinstance(config_value, DeferredConfigString):
+                        # DeferredEval tends to come from CLI/environment variables
+                        config_value = config_value.get_value(self.traits()[name])
                     # We have to do a deepcopy here if we don't deepcopy the entire
                     # config object. If we don't, a mutable config_value will be
                     # shared by all instances, effectively making it a class attribute.

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -274,6 +274,11 @@ class Configurable(HasTraits):
             # include Enum choices
             lines.append(indent('Choices: %s' % trait.info()))
 
+        env_var = trait.metadata.get('envvar')
+        if env_var:
+            env_info = 'Environment variable: %s' % env_var
+            lines.append(indent(env_info, 4))
+
         if inst is not None:
             lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))
         else:
@@ -366,6 +371,11 @@ class Configurable(HasTraits):
                 # cls owns the trait, show full help
                 if trait.help:
                     lines.append(c(trait.help))
+
+                env_var = trait.metadata.get('envvar')
+                if env_var:
+                    lines.append('#  Environment variable: %s' % env_var)
+                
                 if 'Enum' in type(trait).__name__:
                     # include Enum choices
                     lines.append('#  Choices: %s' % trait.info())
@@ -401,6 +411,10 @@ class Configurable(HasTraits):
             else:
                 termline += ' : ' + ttype
             lines.append(termline)
+
+            env_var = trait.metadata.get('envvar')
+            if env_var:
+                lines.append(indent('Environment variable: ``%s``' % env_var, 4))
 
             # Default value
             try:
@@ -523,6 +537,4 @@ class SingletonConfigurable(LoggingConfigurable):
     def initialized(cls):
         """Has an instance been created?"""
         return hasattr(cls, "_instance") and cls._instance is not None
-
-
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -5,13 +5,14 @@
 # Distributed under the terms of the Modified BSD License.
 
 import argparse
+from ast import literal_eval
 import copy
 import functools as fnt
 import os
 import re
 import sys
 import json
-from ast import literal_eval
+import warnings
 
 from ipython_genutils.path import filefind
 from ipython_genutils import py3compat
@@ -305,6 +306,29 @@ class Config(dict):
             raise AttributeError(e)
 
 
+class DeferredConfigString(text_type):
+    """Config value for loading config from a string
+
+    Interpretation is deferred until it is loaded into the trait.
+
+    Subclass of unicode for backward compatibility.
+
+    This class is only used for values that are not listed
+    in the configurable classes.
+
+    When config is loaded, `trait.from_string` will be used.
+
+    .. versionadded:: 5.0
+    """
+    def get_value(self, trait):
+        """Get the value stored in this string"""
+        return trait.from_string(text_type(self))
+
+    def __repr__(self):
+        super_repr = super(DeferredConfigString, self).__repr__()
+        return '%s(%s)' % (self.__class__.__name__, super_repr)
+
+
 #-----------------------------------------------------------------------------
 # Config loading classes
 #-----------------------------------------------------------------------------
@@ -508,28 +532,31 @@ class CommandLineConfigLoader(ConfigLoader):
     here.
     """
 
-    def _parse_config_value(self, rhs):
+    def _parse_config_value(self, rhs, trait=None):
         """Python-evaluates any cmd-line argument values."""
         rhs = os.path.expanduser(rhs)
-        try:
-            # Try to see if regular Python syntax will work. This
-            # won't handle strings as the quote marks are removed
-            # by the system shell.
-            value = literal_eval(rhs)
-        except (NameError, SyntaxError, ValueError):
-            # This case happens if the rhs is a string.
-            value = rhs
-        return value
+        if len(rhs) > 2:
+            # handle deprecated "1"
+            for c in "'\"":
+                if rhs[0] == rhs[-1] == c:
+                    old_rhs = rhs
+                    rhs = rhs[1:-1]
+                    warnings.warn(
+                        "Supporting extra quotes around strings is deprecated in traitlets 5.0. "
+                        "Use %r instead of %r" % (rhs, old_rhs),
+                        DeprecationWarning)
+        if trait:
+            return trait.from_string(rhs)
+        else:
+            return DeferredConfigString(rhs)
 
     def _exec_config_str(self, lhs, rhs, trait=None):
         """execute self.config.<lhs> = <rhs>
 
         * expands ~ with expanduser
-        * tries to assign with literal_eval, otherwise assigns with just the string,
-          allowing `--C.a=foobar` and `--C.a="foobar"` to be equivalent.  *Not*
-          equivalent are `--C.a=4` and `--C.a='4'`.
+        * interprets value with trait if available
         """
-        if isinstance(trait, Dict):
+        if isinstance(trait, Dict) and not isinstance(rhs, string_types):
             if len(rhs) == 1 and isinstance(rhs[0], string_types):
                 # check for deprecated --Class.trait="{'a': 'b'}"
                 self.log.warning(
@@ -537,9 +564,19 @@ class CommandLineConfigLoader(ConfigLoader):
                     "You can pass --{0} <key=value> ... multiple times to add items to a dict.".format(
                         lhs, rhs[0])
                 )
-                value = self._parse_config_value(rhs[0])
+                value = literal_eval(rhs[0])
             else:
-                value = {k: self._parse_config_value(v) for k,v in rhs}
+                # FIXME: get trait for values
+                value = {}
+                for k, v in rhs:
+                    value_trait = (trait._per_key_traits or {}).get(k, trait._value_trait)
+                    if value_trait:
+                        value[k] = self._parse_config_value(v, value_trait)
+                    else:
+                        # no trait, use str
+                        # non-str values can only be passed this way
+                        # if the dict trait defines value traits
+                        value[k] = v
 
         elif isinstance(rhs, (list, tuple)):
             value = None
@@ -555,12 +592,20 @@ class CommandLineConfigLoader(ConfigLoader):
                         "You can pass --{0} item ... multiple times to add items to a list.".format(
                             lhs, rhs)
                     )
-                    value = self._parse_config_value(r)
+                    value = self._parse_config_value(r, trait)
 
             if value is None:
-                value = [self._parse_config_value(r) for r in rhs]
+                if trait:
+                    value_trait = getattr(trait, "_trait")
+                else:
+                    value_trait = None
+                if value_trait:
+                    value = [self._parse_config_value(r, value_trait) for r in rhs]
+                else:
+                    # no trait, use strings
+                    value = [r for r in rhs]
         else:
-            value = self._parse_config_value(rhs)
+            value = self._parse_config_value(rhs, trait)
 
         exec(u'self.config.%s = value' % lhs, None, locals())
 
@@ -600,7 +645,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         ipython --profile="foo" --InteractiveShell.autocall=False
     """
 
-    def __init__(self, argv=None, aliases=None, flags=None, **kw):
+    def __init__(self, argv=None, aliases=None, flags=None, classes=None, **kw):
         """Create a key value pair config loader.
 
         Parameters
@@ -614,9 +659,12 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
             Keys are the short aliases, Values are the resolved trait.
             Of the form: `{'alias' : 'Configurable.trait'}`
         flags : dict
-            A dict of flags, keyed by str name. Vaues can be Config objects,
+            A dict of flags, keyed by str name. Values can be Config objects,
             dicts, or "key=value" strings.  If Config or dict, when the flag
             is triggered, The flag is loaded as `self.config.update(m)`.
+        classes : sequence
+            A list/tuple of classes that are to be configured.
+            Classes included in this list
 
         Returns
         -------
@@ -638,6 +686,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         self.argv = argv
         self.aliases = aliases or {}
         self.flags = flags or {}
+        self.classes = classes or ()
 
 
     def clear(self):
@@ -657,6 +706,19 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
             uargv.append(arg)
         return uargv
 
+    def _find_trait(self, lhs):
+        """Find the trait for a Class.trait string"""
+        
+        from .configurable import Configurable
+        class_name, trait_name = lhs.split('.')[-2:]
+        for cls in self.classes:
+            for parent in cls.mro():
+                if (
+                    issubclass(parent, Configurable) and
+                    parent.__name__ == class_name
+                ):
+                    return parent.class_traits().get(trait_name)
+        return None
 
     def load_config(self, argv=None, aliases=None, flags=None):
         """Parse the configuration and generate the Config object.
@@ -715,10 +777,14 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
                     lhs = aliases[lhs]
                 if '.' not in lhs:
                     # probably a mistyped alias, but not technically illegal
-                    self.log.warning("Unrecognized alias: '%s', it will probably have no effect.", raw)
+                    self.log.warning("Unrecognized alias: '%s', it will have no effect.", raw)
+                    trait = None
+                else:
+                    trait = self._find_trait(lhs)
                 try:
-                    self._exec_config_str(lhs, rhs)
+                    self._exec_config_str(lhs, rhs, trait)
                 except Exception:
+                    raise
                     raise ArgumentError("Invalid argument: '%s'" % raw)
 
             elif flag_pattern.match(raw):
@@ -813,11 +879,6 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
     def _create_parser(self, aliases=None, flags=None, classes=None):
         self.parser = ArgumentParser(*self.parser_args, **self.parser_kw)
         self._add_arguments(aliases, flags, classes)
-
-    def _parse_config_traits(self):
-        for cls in self.classes:
-            for trait, traitname in cls.class_traits(config=True).items():
-                yield ()
 
     def _add_arguments(self, aliases=None, flags=None, classes=None):
         raise NotImplementedError("subclasses must implement _add_arguments")
@@ -962,7 +1023,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
             self._load_flag(subc)
 
         if self.extra_args:
-            sub_parser = KeyValueConfigLoader(log=self.log)
+            sub_parser = KeyValueConfigLoader(log=self.log, classes=self.classes)
             sub_parser.load_config(self.extra_args)
             self.config.merge(sub_parser.config)
             self.extra_args = sub_parser.extra_args

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -35,8 +35,9 @@ from traitlets.config.application import (
 from ipython_genutils.tempdir import TemporaryDirectory
 from traitlets import (
     HasTraits,
-    Bool, Unicode, Integer, List, Tuple, Set, Dict
+    Bool, Bytes, Unicode, Integer, List, Tuple, Set, Dict
 )
+
 
 class Foo(Configurable):
 
@@ -48,7 +49,9 @@ class Foo(Configurable):
     j = Integer(1, help="The integer j.").tag(config=True)
     name = Unicode(u'Brian', help="First name.").tag(config=True)
     la = List([]).tag(config=True)
+    li = List(Integer()).tag(config=True)
     fdict = Dict().tag(config=True, multiplicity='+')
+
 
 class Bar(Configurable):
 
@@ -57,6 +60,8 @@ class Bar(Configurable):
     tb = Tuple(()).tag(config=True, multiplicity='*')
     aset = Set().tag(config=True, multiplicity='+')
     bdict = Dict().tag(config=True)
+    idict = Dict(value_trait=Integer()).tag(config=True)
+    key_dict = Dict(per_key_traits={'i': Integer(), 'b': Bytes()}).tag(config=True)
 
 
 class MyApp(Application):
@@ -76,6 +81,7 @@ class MyApp(Application):
                     ('j', 'fooj') : ('Foo.j', "`j` terse help msg"),
                     'name' : 'Foo.name',
                     'la': 'Foo.la',
+                    'li': 'Foo.li',
                     'tb': 'Bar.tb',
                     'D': 'Bar.bdict',
                     'enabled' : 'Bar.enabled',
@@ -167,31 +173,37 @@ class TestApplication(TestCase):
 
     def test_config_seq_args(self):
         app = MyApp()
-        app.parse_command_line("--la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
+        app.parse_command_line("--li 1 --li 3 --la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
         config = app.config
-        self.assertEqual(config.Foo.la, [1, 'ab'])
-        self.assertEqual(config.Bar.tb, ['AB', 2])
+        assert config.Foo.li == [1, 3]
+        assert config.Foo.la == ['1', 'ab']
+        assert config.Bar.tb == ['AB', '2']
         self.assertEqual(config.Bar.aset, 'S1 S2 S1'.split())
         app.init_foo()
-        self.assertEqual(app.foo.la, [1, 'ab'])
+        assert app.foo.li == [1, 3]
+        assert app.foo.la == ['1', 'ab']
         app.init_bar()
         self.assertEqual(app.bar.aset, {'S1', 'S2'})
-        self.assertEqual(app.bar.tb, ('AB', 2))
+        assert app.bar.tb == ('AB', '2')
 
     def test_config_dict_args(self):
         app = MyApp()
         app.parse_command_line(
             "--Foo.fdict a=1 b=b c=3 "
             "--Bar.bdict k=1 -D=a=b -D 22=33 "
+            "--Bar.idict k=1 --Bar.idict b=2 --Bar.idict c=3 "
             .split())
-        fdict = {'a': 1, 'b': 'b', 'c': 3}
-        bdict = {'k': 1, 'a': 'b', '22': 33}
+        fdict = {'a': '1', 'b': 'b', 'c': '3'}
+        bdict = {'k': '1', 'a': 'b', '22': '33'}
+        idict = {'k': 1, 'b': 2, 'c': 3}
         config = app.config
+        assert config.Bar.idict == idict
         self.assertDictEqual(config.Foo.fdict, fdict)
         self.assertDictEqual(config.Bar.bdict, bdict)
         app.init_foo()
         self.assertEqual(app.foo.fdict, fdict)
         app.init_bar()
+        assert app.bar.idict == idict
         self.assertEqual(app.bar.bdict, bdict)
 
     def test_config_propagation(self):

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -653,19 +653,20 @@ def check_meth():
 
 
 @mark.parametrize('check_meth', [
-    ('class_get_help', r'^    Environment variable: MY_ENVVAR'),
-    ('class_config_section', r'^#  Environment variable: MY_ENVVAR'),
-    ('class_config_rst_doc', r'^    Environment variable: ``MY_ENVVAR``'),
+    ('class_get_help', r'^    Environment variable(\(only\))?: MY_ENVVAR', 2),
+    ('class_config_section', r'^#  Environment variable(\(only\))?: MY_ENVVAR', 1),
+    ('class_config_rst_doc', r'^    Environment variable(\(only\))?: ``MY_ENVVAR``', 2),
 ])
 def test_environment_variable_comment_list(check_meth):
     import re
 
     class A(Configurable):
         a = Integer().tag(config=True, envvar='MY_ENVVAR')
-        b = Integer().tag(config=True, envvar='NO_ENVVAR')
+        b = Integer().tag(envvar='MY_ENVVAR')
 
-    meth, regex = check_meth
+    meth, regex, expected_nmatches = check_meth
     txt = getattr(A, meth)()
-    assert re.search(regex, txt,
-        re.MULTILINE)
-    #assert not re.search('Environment variable: NO_ENVVAR', txt)
+    matches = list(re.finditer(regex, txt, re.MULTILINE))
+    assert len(matches) == expected_nmatches
+    if expected_nmatches > 1:
+        assert matches[1].group(1) == '(only)'

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -646,3 +646,26 @@ class TestLogger(TestCase):
         self.assertIn('Config option `totally_wrong` not recognized by `A`.', output)
         self.assertNotIn('Did you mean', output)
 
+
+@mark.fixture
+def check_meth():
+    pass
+
+
+@mark.parametrize('check_meth', [
+    ('class_get_help', r'^    Environment variable: MY_ENVVAR'),
+    ('class_config_section', r'^#  Environment variable: MY_ENVVAR'),
+    ('class_config_rst_doc', r'^    Environment variable: ``MY_ENVVAR``'),
+])
+def test_environment_variable_comment_list(check_meth):
+    import re
+
+    class A(Configurable):
+        a = Integer().tag(config=True, envvar='MY_ENVVAR')
+        b = Integer().tag(config=True, envvar='NO_ENVVAR')
+
+    meth, regex = check_meth
+    txt = getattr(A, meth)()
+    assert re.search(regex, txt,
+        re.MULTILINE)
+    #assert not re.search('Environment variable: NO_ENVVAR', txt)

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -23,7 +23,10 @@ from traitlets.config.loader import (
     KVArgParseConfigLoader,
     ConfigError,
 )
-from traitlets import (HasTraits, Union, List, Tuple, Dict, Int, Unicode)
+from traitlets import (
+    HasTraits, Union, List, Tuple, Dict, Int, Unicode,
+    Integer,
+)
 from traitlets.config import Configurable
 
 
@@ -236,25 +239,29 @@ class TestArgParseCL(TestCase):
         self.assertEqual(config.list1, [1, 'B'])
         self.assertEqual(config.list2, [1, 2, 3])
 
+class C(Configurable):
+    str_trait = Unicode(config=True)
+    int_trait = Integer(config=True)
+    list_trait = List(config=True)
 
 class TestKeyValueCL(TestCase):
     klass = KeyValueConfigLoader
 
     def test_eval(self):
         cl = self.klass(log=log)
-        config = cl.load_config('--Class.str_trait=all --Class.int_trait=5 --Class.list_trait=["hello",5]'.split())
-        self.assertEqual(config.Class.str_trait, 'all')
-        self.assertEqual(config.Class.int_trait, 5)
-        self.assertEqual(config.Class.list_trait, ["hello", 5])
+        config = cl.load_config('--C.str_trait=all --C.int_trait=5 --C.list_trait=["hello",5]'.split())
+        c = C(config=config)
+        assert c.str_trait == 'all'
+        assert c.int_trait == 5
+        assert c.list_trait == ["hello", 5]
 
     def test_basic(self):
         cl = self.klass(log=log)
         argv = [ '--' + s[2:] for s in pyfile.split('\n') if s.startswith('c.') ]
-        print(argv)
         config = cl.load_config(argv)
-        self.assertEqual(config.a, 10)
-        self.assertEqual(config.b, 20)
-        self.assertEqual(config.Foo.Bar.value, 10)
+        assert config.a == '10'
+        assert config.b == '20'
+        assert config.Foo.Bar.value == '10'
         # non-literal expressions are not evaluated
         self.assertEqual(config.Foo.Bam.value, 'list(range(10))')
         self.assertEqual(config.D.C.value, 'hi there')
@@ -272,8 +279,8 @@ class TestKeyValueCL(TestCase):
         cl = self.klass(log=log)
         config = cl.load_config(['--a=5', 'b', '--c=10', 'd'])
         self.assertEqual(cl.extra_args, ['b', 'd'])
-        self.assertEqual(config.a, 5)
-        self.assertEqual(config.c, 10)
+        assert config.a == '5'
+        assert config.c == '10'
         config = cl.load_config(['--', '--a=5', '--c=10'])
         self.assertEqual(cl.extra_args, ['--a=5', '--c=10'])
 
@@ -307,7 +314,7 @@ class TestKeyValueCL(TestCase):
 
 class CBase(HasTraits):
     a = List().tag(config=True)
-    b = List().tag(config=True, multiplicity='*')
+    b = List(Integer()).tag(config=True, multiplicity='*')
     c = List().tag(config=True, multiplicity='append')
     adict = Dict().tag(config=True)
 
@@ -338,12 +345,12 @@ class TestArgParseKVCL(TestKeyValueCL):
         argv = ("--CBase.a A --CBase.a 2 --CBase.b 1 2 3 --a3 AA --CBase.c BB "
                 "--CSub.d 1 --CSub.d BBB --CSub.e 1 a bcd").split()
         config = cl.load_config(argv, aliases=aliases)
-        self.assertEqual(config.CBase.a, ['A', 2])
-        self.assertEqual(config.CBase.b, [1, 2, 3])
+        assert config.CBase.a == ['A', '2']
+        assert config.CBase.b == [1, 2, 3]
         self.assertEqual(config.CBase.c, ['AA', 'BB'])
 
-        self.assertEqual(config.CSub.d, [1, 'BBB'])
-        self.assertEqual(config.CSub.e, [1, 'a', 'bcd'])
+        assert config.CSub.d == ['1', 'BBB']
+        assert config.CSub.e == ['1', 'a', 'bcd']
 
     def test_seq_traits_single_empty_string(self):
         cl = self.klass(log=log, classes=(CBase, ))
@@ -357,10 +364,10 @@ class TestArgParseKVCL(TestKeyValueCL):
         aliases = {'D': 'CBase.adict', 'E': 'CSub.bdict'}
         argv = ["--CBase.adict", "k1=v1", "-D=k2=2", "-D", "k3=v 3", "-E", "k=v", "22=222"]
         config = cl.load_config(argv, aliases=aliases)
-        self.assertDictEqual(config.CBase.adict,
-                {'k1': 'v1', 'k2': 2, 'k3': 'v 3'})
-        self.assertEqual(config.CSub.bdict,
-                {'k': 'v', '22': 222})
+        assert config.CBase.adict == \
+                {'k1': 'v1', 'k2': '2', 'k3': 'v 3'}
+        assert config.CSub.bdict == \
+                {'k': 'v', '22': '222'}
 
 
 class TestConfig(TestCase):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2598,7 +2598,7 @@ def test_override_default():
         a = Unicode('hard default')
         def _a_default(self):
             return 'default method'
-    
+
     C._a_default = lambda self: 'overridden'
     c = C()
     assert c.a == 'overridden'
@@ -2609,7 +2609,7 @@ def test_override_default_decorator():
         @default('a')
         def _a_default(self):
             return 'default method'
-    
+
     C._a_default = lambda self: 'overridden'
     c = C()
     assert c.a == 'overridden'
@@ -2620,8 +2620,26 @@ def test_override_default_instance():
         @default('a')
         def _a_default(self):
             return 'default method'
-    
+
     c = C()
     c._a_default = lambda self: 'overridden'
     assert c.a == 'overridden'
 
+def test_envvar_override_default(monkeypatch):
+    class A(HasTraits):
+        b = CInt(allow_none=True).tag(config=True, envvar='MY_ENVVAR')
+
+    a = A()
+    assert a.b == 0
+
+    monkeypatch.setenv('MY_ENVVAR', '1')
+
+    a = A()
+    assert a.b == 1
+    a = A(a=2)
+    assert a.b == 1
+
+    a.b = 3
+    assert a.b == 3  # Direct assignments override env-var.
+    a.b = None
+    assert a.b == None

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -175,7 +175,7 @@ def _safe_literal_eval(s):
     """Safely evaluate an expression
 
     Returns original string if eval fails.
-    
+
     Use only where types are ambiguous.
     """
     try:
@@ -547,7 +547,11 @@ class TraitType(BaseDescriptor):
             that no `envvar` metadata is defined.
         """
         env_var = self.metadata.get('envvar')
-        return env_var and os.environ.get(env_var)
+        if env_var:
+            env_value = os.environ.get(env_var)
+            if env_value is not None:
+                ## `trait.from_string()` cannot handle nones.
+                return self.from_string(env_value)
 
     def get(self, obj, cls=None):
         ## Value origin precendance: assigned-by-code, env-var, defaults.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -514,18 +514,33 @@ class TraitType(BaseDescriptor):
         obj._trait_values[self.name] = value
         return value
 
+    def get_env_value(self):
+        """
+        Gets the value of any environment-variable named as `env` metadata.
+
+        :return:
+            the textual value of the environment variable, or None, meaning
+            that no `envvar` metadata is defined.
+        """
+        env_var = self.metadata.get('envvar')
+        return env_var and os.environ.get(env_var)
+
     def get(self, obj, cls=None):
+        ## Value origin precendance: assigned-by-code, env-var, defaults.
         try:
             value = obj._trait_values[self.name]
-        except KeyError:
-            # Check for a dynamic initializer.
-            default = obj.trait_defaults(self.name)
-            if default is Undefined:
-                raise TraitError("No default value found for "
-                    "the '%s' trait named '%s' of %r" % (
-                    type(self).__name__, self.name, obj))
+        except KeyError as ex:
+            value = self.get_env_value()
+            if value is None:
+                # Check for a dynamic initializer.
+                value = obj.trait_defaults(self.name)
+                if value is Undefined:
+                    raise TraitError("No default value found for "
+                                     "the '%s' trait named '%s' of %r" % (
+                                         type(self).__name__, self.name, obj))
+
             with obj.cross_validation_lock:
-                value = self._validate(obj, default)
+                value = self._validate(obj, value)
             obj._trait_values[self.name] = value
             obj._notify_observers(Bunch(
                 name=self.name,


### PR DESCRIPTION
As discussed in #439, i extracted here the code related to traits-level only.
Specifically:
- added `evvar='MY_VAR'` tag with higher priority over defaults;
- modified the respective printout routines in `Configurable` just to append a new `'# 
 Environment variable: MY_VAR'` line in help/rst/config-file messages.

~Two~ These open issues remain from #439:
- [ ] Documentation: Where to describe the new capability? 
  - [ ] collect all metadata usages in some place? YES
  - [ ] Explain that `config-files < env-var < CLI` order is not obeyed.
- [x] Should we print the envvar-value in the help description, if var exists? NO 
- [x] Include non-config tagged taits in print-outs for class-help, config-file headers & RsT docs.
- [x] Parse env-vars using #441 machinery.