### PR TITLE
feat(config): support MERGE-PRIORITIES for `Config` items

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -64,6 +64,9 @@ subcommand 'cmd', do: `{app} cmd -h`.
 # Application class
 #-----------------------------------------------------------------------------
 
+CFG_RANK = 0
+ENV_RANK = 10
+CLI_RANK = 20
 
 
 _envvar = os.environ.get('TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR','')
@@ -275,6 +278,8 @@ class Application(SingletonConfigurable):
 
     cli_config = Instance(Config, (), {},
         help="""The subset of our configuration that came from the command-line
+
+        <DEPRECATED and unused but updated - use `Config` merge-priorities instead.>
 
         We re-load this configuration after loading config files,
         to ensure that it maintains highest priority.
@@ -700,6 +705,7 @@ class Application(SingletonConfigurable):
         classes = tuple(self._classes_with_config_traits())
         loader = self._create_loader(argv, aliases, flags, classes=classes)
         self.cli_config = deepcopy(loader.load_config())
+        self.cli_config.set_default_rank(CLI_RANK)
         self.update_config(self.cli_config)
         # store unparsed args in extra_args
         self.extra_args = loader.extra_args
@@ -762,8 +768,6 @@ class Application(SingletonConfigurable):
         ):
             new_config.merge(config)
             self._loaded_config_files.append(filename)
-        # add self.cli_config to preserve CLI config priority
-        new_config.merge(self.cli_config)
         self.update_config(new_config)
 
     def _classes_with_config_traits(self, classes=None):

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -204,18 +204,20 @@ class Configurable(HasTraits):
         self._load_config(change.new, traits=traits, section_names=section_names)
 
     def update_config(self, config):
-        """Update config and load the new values"""
+        """Update traits and merge prioritized any `config` values into :attr:`config`"""
+        diffs = self.config.substract(config)
+        self._load_config(diffs)
+
         # traitlets prior to 4.2 created a copy of self.config in order to trigger change events.
         # Some projects (IPython < 5) relied upon one side effect of this,
         # that self.config prior to update_config was not modified in-place.
         # For backward-compatibility, we must ensure that self.config
         # is a new object and not modified in-place,
         # but config consumers should not rely on this behavior.
-        self.config = deepcopy(self.config)
         # load config
-        self._load_config(config)
         # merge it into self.config
-        self.config.merge(config)
+        self.config = deepcopy(self.config)
+        self.config.merge(diffs)
         # TODO: trigger change event if/when dict-update change events take place
         # DO NOT trigger full trait-change
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -164,7 +164,12 @@ def _is_section_key(key):
 
 
 class Config(dict):
-    """An attribute based dict that can do smart merges."""
+    """An attribute based dict that can do smart merges respecting their priority-ranks."""
+
+    #: Either the "priority rank" as integer, or a dict mapping, at least,
+    #: the `None` key to the default priority-rank
+    #: (ie for all non-explicit direct children).
+    _merge_priorities = 0
 
     def __init__(self, *args, **kwds):
         dict.__init__(self, *args, **kwds)
@@ -183,6 +188,39 @@ class Config(dict):
                     and not isinstance(obj, Config):
                 setattr(self, key, Config(obj))
 
+    def rank_of(self, key=None):
+        """return the rank(an int) of the value for the given `key` or default one"""
+        my_pr = self._merge_priorities
+        try:
+            rank = my_pr.get(key)
+        except AttributeError:
+            return my_pr
+        return my_pr[None] if rank is None else rank
+
+    def _set_rank_of(self, key, rank):
+        """private, so as to push clients to work with default-rank on sub-configs"""
+        my_pr = self._merge_priorities
+        if my_pr != rank:
+            try:
+                def_rank = my_pr[None]
+            except TypeError:
+                self._merge_priorities = {None: my_pr, key: rank}
+            else:
+                if def_rank != rank:
+                    my_pr[key] = rank
+
+    def set_default_rank(self, rank):
+        """set priority-rank(an int) for all values without explicit rank, recursively"""
+        my_pr = self._merge_priorities
+        try:
+            my_pr[None] = rank
+        except TypeError:
+            self._merge_priorities = rank
+
+        for v in self.values():
+            if isinstance(v, Config):
+                v.set_default_rank(rank)
+
     def _merge(self, other):
         """deprecated alias, use Config.merge()"""
         self.merge(other)
@@ -191,15 +229,28 @@ class Config(dict):
         """merge another config object into this one"""
         to_update = {}
         for k, v in other.items():
+            try:
+                other_rank = other.rank_of(k)
+            except AttributeError:
+                my_rank = other_rank = None
+            else:
+                my_rank = self.rank_of(k)
+
             if k not in self:
+                # New keys adopted regardless of rank.
                 to_update[k] = v
             else: # I have this key
                 if isinstance(v, Config) and isinstance(self[k], Config):
-                    # Recursively merge common sub Configs
+                    # Recursively merge common sub Configs.
                     self[k].merge(v)
-                else:
-                    # Plain updates for non-Configs
+                else: # For non-Configs, update anything >= my-rank.
+                    if my_rank is not None and other_rank < my_rank:
+                        continue
+
                     to_update[k] = v
+
+            if my_rank != other_rank:
+                self._set_rank_of(k, other_rank)
 
         self.update(to_update)
 
@@ -240,7 +291,9 @@ class Config(dict):
         return _is_section_key(key) and key in self
 
     def copy(self):
-        return type(self)(dict.copy(self))
+        clone = type(self)(dict.copy(self))
+        clone._merge_priorities = copy.copy(self._merge_priorities)
+        return clone
 
     def __copy__(self):
         return self.copy()
@@ -255,6 +308,7 @@ class Config(dict):
                 # shallow copy plain container traits
                 value = copy.copy(value)
             new_config[key] = value
+        new_config._merge_priorities = copy.deepcopy(self._merge_priorities)
         return new_config
 
     def __getitem__(self, key):
@@ -289,7 +343,7 @@ class Config(dict):
             raise AttributeError(e)
 
     def __setattr__(self, key, value):
-        if key.startswith('__'):
+        if key.startswith('__') or key == '_merge_priorities':
             return dict.__setattr__(self, key, value)
         try:
             self.__setitem__(key, value)

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -254,6 +254,38 @@ class Config(dict):
 
         self.update(to_update)
 
+    def substract(self, other):
+        """return a new config with all overriding-differences of the `other`"""
+        diffs = type(self)()
+        ## Diffs jusfged against my priorities.
+        diffs._merge_priorities = self.rank_of()
+
+        for k, v in other.items():
+            try:
+                other_rank = other.rank_of(k)
+            except AttributeError:
+                my_rank = other_rank = None
+            else:
+                my_rank = self.rank_of(k)
+
+            if k not in self:
+                # New keys adopted regardless of rank.
+                diffs[k] = v
+            else: # I have this key
+                if isinstance(v, Config) and isinstance(self[k], Config):
+                    # Recursively substract common Configs.
+                    diffs[k] = self[k].substract(v)
+                else: # For non-Configs, diff is anything >= my-rank.
+                    if my_rank is not None and other_rank < my_rank:
+                        continue
+
+                    diffs[k] = v
+
+            if my_rank != other_rank:
+                diffs._set_rank_of(k, other_rank)
+
+        return diffs
+
     def collisions(self, other):
         """Check for collisions between two config objects.
 

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -526,3 +526,55 @@ class TestConfig(TestCase):
         self.assertEqual(c.Foo.trait, [1])
         self.assertEqual(c2.Foo.trait, [1])
 
+def test_config_priorities():
+    c0 = Config()
+    c0.A.a = 0
+    c0.A.B.c = 0
+    c0.A.B.d = 0
+
+    c1 = Config()
+    c1.A.a = 1
+    c1.A.b = 11
+    c1.A.B.c = 111
+    c1.set_default_rank(10)
+    assert c1.rank_of() == 10
+    assert c1.A.rank_of() == 10
+    assert c1.A.rank_of('a') == 10
+    assert c1.A.rank_of('b') == 10
+    assert c1.A.B.rank_of() == 10
+    assert c1.A.B.rank_of('c') == 10
+
+    c2 = Config()
+    c2.A.a = 2
+    c2.A.b = 22
+    c2.A.B.c = 222
+    c2.set_default_rank(-10)
+
+    c = copy.deepcopy(c0)
+    c.merge(c1)
+    assert c.A.a == 1
+    assert c.A.b == 11
+    assert c.A.B.c == 111
+    assert c.A.B.d == 0
+    assert c.rank_of() == 0
+    assert c.A.rank_of() == 0
+    assert c.A.rank_of('a') == 10
+    assert c.A.rank_of('b') == 10
+    assert c.A.B.rank_of() == 0
+    assert c.A.B.rank_of('c') == 10
+    assert c.A.B.rank_of('d') == 0
+
+    c = copy.deepcopy(c0)
+    c.merge(c2)
+    assert c.A.a == 0
+    assert c.A.b == 22
+    assert c.A.B.c == 0
+    assert c.A.B.d == 0
+    assert c.rank_of() == 0
+    assert c.A.rank_of() == 0
+    assert c.A.rank_of('a') == 0
+    assert c.A.rank_of('b') == -10
+    assert c.A.B.rank_of() == 0
+    assert c.A.B.rank_of('c') == 0
+    assert c.A.B.rank_of('d') == 0
+


### PR DESCRIPTION
(I hope you don't get too mad at me for trying...)

Retrofitted `loader.Config` class to support merging-priorities for specific values based on ranks (e.g. integers).  Now `update_config()` always respects priorities.  The purpose it to use it to fully support also #99 environment-variable priorities.

For this PR, the new features are used also to deprecate the need to re-update `Application.cli_config`  on top of file-configs.  

## Implementation
- A lot of effort was put to have code and the memory-footprint as small as possible.  
  - `Config` instances by default don't waste extra memory - default priority `resolved from _merge_priority` class attribute.
  - Possible to set a single rank(number) that propagates to all config-object values; these apply to 1st level only.  But it can be set recursively to inner config-objects (wasting an in per config-object).
  - To support different ranks in the same config-object, the `_merge_priority` is upgraded to dict.
  - The original idea in #439 of storing *tags* (a new dict) into config ibjects would be an overkill.
  - Have to study performance-tax on the merges.
- A new `Config.substract()` method is used to limit value-changes, taking into account priority-ranks.
  This is useful to preserve traits that have been directly modified between loading of configs from different sources.
- The *ranks* must be comparable. besides that, the code does not enforce any other limitation on their type APART from setting the default `Config._merge_priority = 0` which in effect "force" the use of integers. 
