### PR TITLE
feat(app): support ENV-VAR with priority against CLI-configs

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -64,6 +64,9 @@ subcommand 'cmd', do: `{app} cmd -h`.
 # Application class
 #-----------------------------------------------------------------------------
 
+CFG_RANK = 0
+ENV_RANK = 10
+CLI_RANK = 20
 
 
 _envvar = os.environ.get('TRAITLETS_APPLICATION_RAISE_CONFIG_FILE_ERROR','')
@@ -275,6 +278,8 @@ class Application(SingletonConfigurable):
 
     cli_config = Instance(Config, (), {},
         help="""The subset of our configuration that came from the command-line
+
+        <DEPRECATED and unused but updated - use `Config` merge-priorities instead.>
 
         We re-load this configuration after loading config files,
         to ensure that it maintains highest priority.
@@ -700,6 +705,7 @@ class Application(SingletonConfigurable):
         classes = tuple(self._classes_with_config_traits())
         loader = self._create_loader(argv, aliases, flags, classes=classes)
         self.cli_config = deepcopy(loader.load_config())
+        self.cli_config.set_default_rank(CLI_RANK)
         self.update_config(self.cli_config)
         # store unparsed args in extra_args
         self.extra_args = loader.extra_args
@@ -762,8 +768,6 @@ class Application(SingletonConfigurable):
         ):
             new_config.merge(config)
             self._loaded_config_files.append(filename)
-        # add self.cli_config to preserve CLI config priority
-        new_config.merge(self.cli_config)
         self.update_config(new_config)
 
     def _classes_with_config_traits(self, classes=None):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -65,7 +65,7 @@ subcommand 'cmd', do: `{app} cmd -h`.
 #-----------------------------------------------------------------------------
 
 CFG_RANK = 0
-ENV_RANK = 10
+ENV_RANK = 10  # Informative; used literal in :meth:`Configurable.update_config()`.
 CLI_RANK = 20
 
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -204,18 +204,20 @@ class Configurable(HasTraits):
         self._load_config(change.new, traits=traits, section_names=section_names)
 
     def update_config(self, config):
-        """Update config and load the new values"""
+        """Update traits and merge prioritized any `config` values into :attr:`config`"""
+        diffs = self.config.substract(config)
+        self._load_config(diffs)
+
         # traitlets prior to 4.2 created a copy of self.config in order to trigger change events.
         # Some projects (IPython < 5) relied upon one side effect of this,
         # that self.config prior to update_config was not modified in-place.
         # For backward-compatibility, we must ensure that self.config
         # is a new object and not modified in-place,
         # but config consumers should not rely on this behavior.
-        self.config = deepcopy(self.config)
         # load config
-        self._load_config(config)
         # merge it into self.config
-        self.config.merge(config)
+        self.config = deepcopy(self.config)
+        self.config.merge(diffs)
         # TODO: trigger change event if/when dict-update change events take place
         # DO NOT trigger full trait-change
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -274,6 +274,11 @@ class Configurable(HasTraits):
             # include Enum choices
             lines.append(indent('Choices: %s' % trait.info()))
 
+        env_var = trait.metadata.get('envvar')
+        if env_var:
+            env_info = 'Environment variable: %s' % env_var
+            lines.append(indent(env_info, 4))
+
         if inst is not None:
             lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))
         else:
@@ -366,6 +371,11 @@ class Configurable(HasTraits):
                 # cls owns the trait, show full help
                 if trait.help:
                     lines.append(c(trait.help))
+
+                env_var = trait.metadata.get('envvar')
+                if env_var:
+                    lines.append('#  Environment variable: %s' % env_var)
+                
                 if 'Enum' in type(trait).__name__:
                     # include Enum choices
                     lines.append('#  Choices: %s' % trait.info())
@@ -401,6 +411,10 @@ class Configurable(HasTraits):
             else:
                 termline += ' : ' + ttype
             lines.append(termline)
+
+            env_var = trait.metadata.get('envvar')
+            if env_var:
+                lines.append(indent('Environment variable: ``%s``' % env_var, 4))
 
             # Default value
             try:
@@ -523,6 +537,4 @@ class SingletonConfigurable(LoggingConfigurable):
     def initialized(cls):
         """Has an instance been created?"""
         return hasattr(cls, "_instance") and cls._instance is not None
-
-
 

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -646,3 +646,26 @@ class TestLogger(TestCase):
         self.assertIn('Config option `totally_wrong` not recognized by `A`.', output)
         self.assertNotIn('Did you mean', output)
 
+
+@mark.fixture
+def check_meth():
+    pass
+
+
+@mark.parametrize('check_meth', [
+    ('class_get_help', r'^    Environment variable: MY_ENVVAR'),
+    ('class_config_section', r'^#  Environment variable: MY_ENVVAR'),
+    ('class_config_rst_doc', r'^    Environment variable: ``MY_ENVVAR``'),
+])
+def test_environment_variable_comment_list(check_meth):
+    import re
+
+    class A(Configurable):
+        a = Integer().tag(config=True, envvar='MY_ENVVAR')
+        b = Integer().tag(config=True, envvar='NO_ENVVAR')
+
+    meth, regex = check_meth
+    txt = getattr(A, meth)()
+    assert re.search(regex, txt,
+        re.MULTILINE)
+    #assert not re.search('Environment variable: NO_ENVVAR', txt)

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -526,3 +526,55 @@ class TestConfig(TestCase):
         self.assertEqual(c.Foo.trait, [1])
         self.assertEqual(c2.Foo.trait, [1])
 
+def test_config_priorities():
+    c0 = Config()
+    c0.A.a = 0
+    c0.A.B.c = 0
+    c0.A.B.d = 0
+
+    c1 = Config()
+    c1.A.a = 1
+    c1.A.b = 11
+    c1.A.B.c = 111
+    c1.set_default_rank(10)
+    assert c1.rank_of() == 10
+    assert c1.A.rank_of() == 10
+    assert c1.A.rank_of('a') == 10
+    assert c1.A.rank_of('b') == 10
+    assert c1.A.B.rank_of() == 10
+    assert c1.A.B.rank_of('c') == 10
+
+    c2 = Config()
+    c2.A.a = 2
+    c2.A.b = 22
+    c2.A.B.c = 222
+    c2.set_default_rank(-10)
+
+    c = copy.deepcopy(c0)
+    c.merge(c1)
+    assert c.A.a == 1
+    assert c.A.b == 11
+    assert c.A.B.c == 111
+    assert c.A.B.d == 0
+    assert c.rank_of() == 0
+    assert c.A.rank_of() == 0
+    assert c.A.rank_of('a') == 10
+    assert c.A.rank_of('b') == 10
+    assert c.A.B.rank_of() == 0
+    assert c.A.B.rank_of('c') == 10
+    assert c.A.B.rank_of('d') == 0
+
+    c = copy.deepcopy(c0)
+    c.merge(c2)
+    assert c.A.a == 0
+    assert c.A.b == 22
+    assert c.A.B.c == 0
+    assert c.A.B.d == 0
+    assert c.rank_of() == 0
+    assert c.A.rank_of() == 0
+    assert c.A.rank_of('a') == 0
+    assert c.A.rank_of('b') == -10
+    assert c.A.B.rank_of() == 0
+    assert c.A.B.rank_of('c') == 0
+    assert c.A.B.rank_of('d') == 0
+

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2598,7 +2598,7 @@ def test_override_default():
         a = Unicode('hard default')
         def _a_default(self):
             return 'default method'
-    
+
     C._a_default = lambda self: 'overridden'
     c = C()
     assert c.a == 'overridden'
@@ -2609,7 +2609,7 @@ def test_override_default_decorator():
         @default('a')
         def _a_default(self):
             return 'default method'
-    
+
     C._a_default = lambda self: 'overridden'
     c = C()
     assert c.a == 'overridden'
@@ -2620,8 +2620,26 @@ def test_override_default_instance():
         @default('a')
         def _a_default(self):
             return 'default method'
-    
+
     c = C()
     c._a_default = lambda self: 'overridden'
     assert c.a == 'overridden'
 
+def test_envvar_override_default(monkeypatch):
+    class A(HasTraits):
+        b = CInt(allow_none=True).tag(config=True, envvar='MY_ENVVAR')
+
+    a = A()
+    assert a.b == 0
+
+    monkeypatch.setenv('MY_ENVVAR', '1')
+
+    a = A()
+    assert a.b == 1
+    a = A(a=2)
+    assert a.b == 1
+
+    a.b = 3
+    assert a.b == 3  # Direct assignments override env-var.
+    a.b = None
+    assert a.b == None

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -514,18 +514,33 @@ class TraitType(BaseDescriptor):
         obj._trait_values[self.name] = value
         return value
 
+    def get_env_value(self):
+        """
+        Gets the value of any environment-variable named as `env` metadata.
+
+        :return:
+            the textual value of the environment variable, or None, meaning
+            that no `envvar` metadata is defined.
+        """
+        env_var = self.metadata.get('envvar')
+        return env_var and os.environ.get(env_var)
+
     def get(self, obj, cls=None):
+        ## Value origin precendance: assigned-by-code, env-var, defaults.
         try:
             value = obj._trait_values[self.name]
-        except KeyError:
-            # Check for a dynamic initializer.
-            default = obj.trait_defaults(self.name)
-            if default is Undefined:
-                raise TraitError("No default value found for "
-                    "the '%s' trait named '%s' of %r" % (
-                    type(self).__name__, self.name, obj))
+        except KeyError as ex:
+            value = self.get_env_value()
+            if value is None:
+                # Check for a dynamic initializer.
+                value = obj.trait_defaults(self.name)
+                if value is Undefined:
+                    raise TraitError("No default value found for "
+                                     "the '%s' trait named '%s' of %r" % (
+                                         type(self).__name__, self.name, obj))
+
             with obj.cross_validation_lock:
-                value = self._validate(obj, default)
+                value = self._validate(obj, value)
             obj._trait_values[self.name] = value
             obj._notify_observers(Bunch(
                 name=self.name,


### PR DESCRIPTION
(I really hope you don't get too mad at me for trying :-))

After #439 study, this the 2nd attempt to implement environment-variables with proper priorities for configuration sources (as described in #99) following 
- the insight of @minrk (to construct a proper config-instance that will propagate wherever the correct values) and 
- building on the idea for config's MERGE-PRIORITIES.

## Implementation
- It is based(has merged) on Config-Priorities(#) and Traits-Env-Vars(#447).
- The `Configurable.update_config(#448)` is now modified to ignore any config-values below priority-20 (FIXED atm) for which there are variables defined in the environment.
- There is no need to define a new keword `skip_env` since config- priorities lifted this burden.

