### PR TITLE
allow default json files in a .d directory

### DIFF
--- a/traitlets/config/manager.py
+++ b/traitlets/config/manager.py
@@ -9,7 +9,7 @@ import os
 
 from six import PY3
 from traitlets.config import LoggingConfigurable
-from traitlets.traitlets import Unicode
+from traitlets.traitlets import Unicode, Bool
 
 
 def recursive_update(target, new):
@@ -36,10 +36,12 @@ def recursive_update(target, new):
 class BaseJSONConfigManager(LoggingConfigurable):
     """General JSON config manager
     
-    Deals with persisting/storing config in a json file
+    Deals with persisting/storing config in a json file with optionally
+    default values in a {section_name}.d directory.
     """
 
     config_dir = Unicode('.')
+    read_directory = Bool(True)
 
     def ensure_config_dir_exists(self):
         try:
@@ -51,6 +53,9 @@ class BaseJSONConfigManager(LoggingConfigurable):
     def file_name(self, section_name):
         return os.path.join(self.config_dir, section_name+'.json')
 
+    def directory(self, section_name):
+        return os.path.join(self.config_dir, section_name+'.d')
+
     def get(self, section_name):
         """Retrieve the config data for the specified section.
 
@@ -58,11 +63,23 @@ class BaseJSONConfigManager(LoggingConfigurable):
         doesn't exist.
         """
         filename = self.file_name(section_name)
+        data = {}
+        if self.read_directory:
+            directory = self.directory(section_name)
+            if os.path.isdir(directory):
+                paths = os.listdir(directory)
+                for path in sorted(paths):
+                    name, ext = os.path.splitext(path)
+                    abspath = os.path.join(directory, path)
+                    if ext == ".json" and name not in data:
+                        with io.open(abspath, encoding='utf-8') as f:
+                            more_defaults = json.load(f)
+                        recursive_update(data, more_defaults)
         if os.path.isfile(filename):
             with io.open(filename, encoding='utf-8') as f:
-                return json.load(f)
-        else:
-            return {}
+                new_data = json.load(f)
+            recursive_update(data, new_data)
+        return data
 
     def set(self, section_name, data):
         """Store the given config data.

--- a/traitlets/config/manager.py
+++ b/traitlets/config/manager.py
@@ -66,6 +66,11 @@ class BaseJSONConfigManager(LoggingConfigurable):
         paths = [self.file_name(section_name)]
         if self.read_directory:
             pattern = os.path.join(self.directory(section_name), '*.json')
+            # These json files should be processed first so that the
+            # {section_name}.json take precedence.
+            # The idea behind this is that installing a Python package may
+            # put a json file somewhere in the a .d directory, while the 
+            # .json file is probably a user configuration.
             paths = sorted(glob.glob(pattern)) + paths
         data = {}
         for path in paths:

--- a/traitlets/config/tests/test_manager.py
+++ b/traitlets/config/tests/test_manager.py
@@ -1,0 +1,34 @@
+import json
+import os
+
+from traitlets.config.manager import BaseJSONConfigManager
+
+
+def test_json(tmpdir):
+    tmpdir = str(tmpdir)  # we're ok with a regular string path
+    with open(os.path.join(tmpdir, 'foo.json'), 'w') as f:
+        json.dump(dict(a=1), f)
+    # also make a foo.d/ directory with multiple json files
+    os.makedirs(os.path.join(tmpdir, 'foo.d'))
+    with open(os.path.join(tmpdir, 'foo.d', 'a.json'), 'w') as f:
+        json.dump(dict(a=2, b=1), f)
+    with open(os.path.join(tmpdir, 'foo.d', 'b.json'), 'w') as f:
+        json.dump(dict(a=3, b=2, c=3), f)
+    manager = BaseJSONConfigManager(config_dir=tmpdir, read_directory=False)
+    data = manager.get('foo')
+    assert 'a' in data
+    assert 'b' not in data
+    assert 'c' not in data
+    assert data['a'] == 1
+
+    manager = BaseJSONConfigManager(config_dir=tmpdir, read_directory=True)
+    data = manager.get('foo')
+    assert 'a' in data
+    assert 'b' in data
+    assert 'c' in data
+    # files should be read in order foo.d/a.json foo.d/b.json foo.json
+    assert data['a'] == 1
+    assert data['b'] == 2
+    assert data['c'] == 3
+
+


### PR DESCRIPTION
This allows to have in addition to a single `foobar.json` file a `foobar.d` directory, where all '*.json' files will be read, and used as default values.
Would make implementing https://github.com/jupyter/notebook/issues/2824 trivial.