### PR TITLE
Remove extra backtics from class link

### DIFF
--- a/docs/source/using_traitlets.rst
+++ b/docs/source/using_traitlets.rst
@@ -15,7 +15,7 @@ Default values, and checking type and value
 -------------------------------------------
 
 At its most basic, traitlets provides type checking, and dynamic default
-value generation of attributes on :class:``traitlets.HasTraits``
+value generation of attributes on :class:`traitlets.HasTraits`
 subclasses:
 
 .. code:: python


### PR DESCRIPTION
The `:class:` link in the "Using Traitlets" docs was using 
double backtics instead of single so the link was broken.