### PR TITLE
adding tests for default values for traitlets types and new traits (i…

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2625,3 +2625,82 @@ def test_override_default_instance():
     c._a_default = lambda self: 'overridden'
     assert c.a == 'overridden'
 
+
+# adding additional tests to test default values for original types and new ones
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+        ([],  {},                      0),
+        ([],  {"default_value": 1},    1),
+        ([1], {},                      1)
+        ])
+def test_int_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = Int(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+    assert type(ht.foo) is int
+
+
+class NewInt(Int):
+    info_text = "an int with default_value = None"
+    allow_none = True
+    default_value = None
+    
+    def __init__(self, default_value=None, allow_none=False,
+                 read_only=None, help=None, config=None, **kwargs):
+        super(NewInt, self).__init__(default_value=default_value, allow_none=allow_none,
+                                     read_only=read_only, help=help, config=config)
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+        ([],  {},                      None),
+        ([],  {"default_value": None}, None),
+        ([],  {"default_value": 1},    1),
+        ([1], {},                      1)
+        ])
+def test_newint_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = NewInt(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+     ([],    {},                      []),
+     ([],    {"default_value": [1]},  [1]),
+     ([[1]], {},                      [1])
+     ])
+def test_list_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = List(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+
+class NewList(List):
+    allow_none = True
+    default_value = None
+    info_text = "a list with default_value = None"
+    def __init__(self, trait=None, default_value=None,
+                 minlen=0, maxlen=sys.maxsize, kw=None,
+                 read_only=None, help=None, config=None, **kwargs):
+        super(NewList, self).__init__(trait=trait, default_value=default_value,
+                                      minlen=0, maxlen=maxlen, kw=kw,
+                                      read_only=read_only, help=help, config=config)
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+     ([],    {},                      None),
+     ([],    {"default_value": None}, None),
+     ([],    {"default_value": [1]},  [1]),
+     ([[1]], {},                      [1])
+     ])
+def test_newlist_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = NewList(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2679,6 +2679,43 @@ def test_list_default(arg_lst, arg_dict, foo_val):
     assert ht.foo == foo_val
 
 
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+        ([],     {},                                     False),
+        ([],     {"default_value": True},                True),
+        ([True], {},                                     True)
+        ])
+def test_bool_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = Bool(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+
+class NewBool(Bool):
+    allow_none = True
+    default_value = None
+    info_text = "a boolean with default_value = None"
+    def __init__(self, default_value=None, allow_none=False,
+                 read_only=None, help=None, config=None, **kwargs):
+        super(NewBool, self).__init__(default_value=default_value, allow_none=allow_none,
+                                   read_only=read_only, help=help, config=config)
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+        ([],     {},                      None),
+        ([],     {"default_value": None}, None),
+        ([],     {"default_value": True}, True),
+        ([True], {},                      True)
+        ])
+def test_newbool_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = NewBool(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+
+
 class NewList(List):
     allow_none = True
     default_value = None
@@ -2688,7 +2725,7 @@ class NewList(List):
                  read_only=None, help=None, config=None, **kwargs):
         super(NewList, self).__init__(trait=trait, default_value=default_value,
                                       minlen=0, maxlen=maxlen, kw=kw,
-                                      read_only=read_only, help=help, config=config)
+                                      read_only=read_only, help=help, config=config, **kwargs)
 
 @pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
      ([],    {},                      None),
@@ -2704,3 +2741,77 @@ def test_newlist_default(arg_lst, arg_dict, foo_val):
     assert ht.foo == foo_val
 
 
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+     ([],    {},                       ()),
+     ([],    {"default_value": (1,2)}, (1,2)),
+     ([(1,)], {},                      (1,))
+     ])
+def test_tuple_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = Tuple(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+
+class NewTuple(Tuple):
+    allow_none = True
+    default_value = None
+    info_text = "a tuple with default_value = None"
+    def __init__(self, *traits, default_value=Undefined, kw=None, #default_value can't be None??
+                 read_only=None, help=None, config=None, **kwargs):
+        super(NewTuple, self).__init__(*traits, default_value=default_value,
+                                        kw=kw, read_only=read_only, help=help, 
+                                        config=config, **kwargs)
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+     ([],     {},                       None),
+     ([],     {"default_value": None},  None),
+     ([],     {"default_value": (1,2)}, (1,2)),
+     ([(1,)], {},                       (1,))
+     ])
+def test_newtuple_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = NewTuple(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+     ([],        {},                         {}),
+     ([],        {"default_value": {"a":1}}, {"a":1}),
+     ([{"a":1}], {},                         {"a":1})
+     ])
+def test_dict_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = Dict(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val
+
+
+class NewDict(Dict):
+    allow_none = True
+    default_value = None
+    info_text = "a dictionary with default_value = None"
+
+    def __init__(self, value_trait=None, per_key_traits=None, key_trait=None,
+                 default_value=None, kw=None,
+                 read_only=None, help=None, config=None, **kwargs):
+        super(NewDict, self).__init__(value_trait=value_trait, per_key_traits=per_key_traits,
+                                   key_trait=key_trait, default_value=default_value,
+                                   kw=kw, read_only=read_only,
+                                   help=help, config=config)
+
+@pytest.mark.parametrize("arg_lst, arg_dict, foo_val", [
+     ([],        {},                         None),
+     ([],        {"default_value": None},    None),
+     ([],        {"default_value": {"a":1}}, {"a":1}),
+     ])
+def test_newdict_default(arg_lst, arg_dict, foo_val):
+    class HasTr(HasTraits):
+        foo = NewDict(*arg_lst, **arg_dict)
+
+    ht = HasTr()
+    assert ht.foo == foo_val

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2437,6 +2437,7 @@ class Container(Instance):
             args = ()
         elif isinstance(default_value, self._valid_defaults):
             args = (default_value,)
+            self.default_value = Undefined
         else:
             raise TypeError('default value of %s was %s' %(self.__class__.__name__, default_value))
 


### PR DESCRIPTION
…nt and list only for now)

examples  of  tests for default value of original traits and new defined traits. Use only `Int` and `List` as examples for now, can write more.

Two of those test fail, see #455. Should I mar as `xfail`? 