### PR TITLE
Drop dependency on decorator package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'ipython_genutils',
     'six',
-    'decorator',
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
Over the weekend, all Jupyter applications were briefly broken by decorator 4.2.0, before being promptly fixed by version 4.2.1.

* https://github.com/jupyter/notebook/issues/3209
* https://github.com/ipython/ipython/issues/10981

While this case has already been resolved, I don't think that the convenience of saving a few lines of code is worth the added risk of an external dependency right at the base of our stack. It only seems to be used in one place in traitlets. I'm proposing that we drop the dependency for traitlets and implement `@catch_config_error` using standard Python tools.