### PR TITLE
[WIP] add absolute name

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -437,15 +437,17 @@ class BaseDescriptor(object):
             yield parent
 
     def __str__(self):
-        lineage = list(self._lineage())
-        absolute_name = lineage[-1].name
-        info = " of ".join(
-            ["the " + type(self).__name__] +
-            [describe("a", t) for t in lineage[1:]]
-        )
-        if self.this_class is not None and absolute_name is not None:
+        if self.this_class is not None:
+            lineage = list(self._lineage())
+            absolute_name = lineage[-1].name
+            info = " of ".join(
+                ["the " + type(self).__name__] +
+                [describe("a", t) for t in lineage[1:]]
+            )
             class_name = describe(None, self.this_class, verbose=True)
             info += " at %s.%s" % (class_name, absolute_name)
+        else:
+            info = super(BaseDescriptor, self).__str__()
         return info
 
 

--- a/traitlets/utils/descriptions.py
+++ b/traitlets/utils/descriptions.py
@@ -44,7 +44,7 @@ def describe(article, value, name=None, verbose=False, capital=False):
     'an object'
     >>> describe("a", type(object))
     'a type'
-    
+
     Definite description:
 
     >>> describe("the", object())
@@ -75,9 +75,9 @@ def describe(article, value, name=None, verbose=False, capital=False):
         if name is not None:
             result = "%s %s" % (typename, name)
             if article is not None:
-                return add_article(result, True, capital)
+                final = add_article(result, True, capital)
             else:
-                return result
+                final = result.strip()
         else:
             tick_wrap = False
             if inspect.isclass(value):
@@ -98,17 +98,19 @@ def describe(article, value, name=None, verbose=False, capital=False):
                 name = _prefix(value) + name
             if tick_wrap:
                 name = name.join("''")
-            return describe(article, value, name=name,
+            final = describe(article, value, name=name,
                 verbose=verbose, capital=capital)
     elif article in ("a", "an") or article is None:
         if article is None:
-            return typename
-        return add_article(typename, False, capital)
+            final = typename
+        else:
+            final = add_article(typename, False, capital)
     else:
         raise ValueError("The 'article' argument should "
             "be 'the', 'a', 'an', or None not %r" % article)
+    return final.strip()
 
-    
+
 def _prefix(value):
     if isinstance(value, types.MethodType):
         name = describe(None, value.__self__, verbose=True) + '.'


### PR DESCRIPTION
# Summary

Allows a nested trait to know that attribute it is assigned to (i.e. it's "absolute name").

This PR is in anticipation of a downstream implementation of Eventful traits.

# Details

We add `BaseDescriptor._parent` which is `None` if it is the root descriptor. Otherwise it holds a weak reference to its parent trait. There is also a new method `BaseDescriptor._lineage()` which will recurse through its parents until it finds a descriptor with `name` that is not `None`.

These additions are leveraged by:

+ The new `BaseDescriptor.absolute_name` property which returns the attribute name the trait exists on.
+ A new `__str__` method for `BaseDescriptor` which will describe its lineage if it exists on a class.
+ and `TraitType.error` to more simply report error messages.