### PR TITLE
Facilitate adding new config-file loaders

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -722,7 +722,7 @@ class Application(SingletonConfigurable):
             for ext, loader in cls.supported_cfg_loaders.items():
                 if name.endswith(ext):
                     return loader(name, path, log=log)
-            raise AssertionError("Unknown file-extension in config-file %r!" % name)
+            raise ValueError("Unknown file-extension in config-file %r!" % name)
 
         if not isinstance(path, list):
             path = [path]

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -600,7 +600,7 @@ class Application(SingletonConfigurable):
             # or ask factory to create it...
             self.subapp = subapp(self)
         else:
-            raise AssertionError("Invalid mappings for subcommand '%s'!" % subc)
+            raise ValueError("Invalid mappings for subcommand '%s'!" % subc)
 
         # ... and finally initialize subapp.
         self.subapp.initialize(argv)

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -138,8 +138,9 @@ class Configurable(HasTraits):
         if self.parent:
             cfgs.append(self.parent._find_my_config(cfg))
         my_config = Config()
+        section_names = self.section_names()
         for c in cfgs:
-            for sname in self.section_names():
+            for sname in section_names:
                 # Don't do a blind getattr as that would cause the config to
                 # dynamically create the section with name Class.__name__.
                 if c._has_section(sname):

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -264,6 +264,20 @@ class TestApplication(TestCase):
             assert app.config.TestApp.value == 'cli'
             assert app.value == 'cli'
 
+    def test_modify_config_loaders(self):
+        class TestApp(Application):
+            supported_cfg_loaders = {'.myext': Application.json_config_loader_class}
+            config_file_loaded = Bool().tag(config=True)
+
+        name = 'config.myext'
+        app = TestApp()
+        with TemporaryDirectory() as td:
+            config_file = pjoin(td, name)
+            with open(config_file, 'w') as f:
+                f.write('{"TestApp": {"config_file_loaded": true}}')
+            app.load_config_file(name, path=[td])
+            assert app.config_file_loaded
+
     def test_flags(self):
         app = MyApp()
         app.parse_command_line(["--disable"])
@@ -418,7 +432,7 @@ class TestApplication(TestCase):
     def test_generate_config_file_classes_to_include(self):
         class NotInConfig(HasTraits):
             from_hidden = Unicode('x', help="""From hidden class
-            
+
             Details about from_hidden.
             """).tag(config=True)
 
@@ -611,7 +625,7 @@ def test_show_config(capsys):
     cfg.MyApp.i = 5
     # don't show empty
     cfg.OtherApp
-    
+
     app = MyApp(config=cfg, show_config=True)
     app.start()
     out, err = capsys.readouterr()
@@ -624,7 +638,7 @@ def test_show_config_json(capsys):
     cfg = Config()
     cfg.MyApp.i = 5
     cfg.OtherApp
-    
+
     app = MyApp(config=cfg, show_config_json=True)
     app.start()
     out, err = capsys.readouterr()


### PR DESCRIPTION
## Rational:
If someone needs to introduce a new config-loader, 
(e.g. YAML), currently  has must re-implent the full `Application._load_config_files()`,
and change just a single line.

Similar to #360 for cmd-line argument loaders, 
this PR facilitates introducing new config-loaders without estensive changes in the code.

NOTE: this PR conceptually contans 2 "tips", 
one before the merge with @minrk 's #242 and one with it (in case this is merged as well)

## Before merge with #242 
To introduce a newconfig-loader, simply overridde `Application._make_loaders()` to return an orderd list of loaders.

## After merge with #242
- To extend with a new config-file, simply add its loader class in the
`supported_cfg_loaders: {.ext: loader-class}` ordered mapping.
- Deprecated `Application` class-attributes:
  - `python_config_loader_class`
  - `json_config_loader_class`
  replaced by the `supported_cfg_loaders` mapping:

## Bonus
A minor speedup is introduced when accesing only once the `HasTrairs.section_names()` outside of `_find_my_config()` loop.