### PR TITLE
--show-config dumps configurations and then launches start() normally

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test': ['pytest'],
+    'test': ['pytest', 'pytest-mock'],
     'test:python_version=="2.7"': ["mock"],
     # -- SUPPORT UNIFORM-WHEELS: Extra packages for Python 2.7
     # SEE: https://bitbucket.org/pypa/wheel/ , CHANGES.txt (v0.24.0)

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -286,22 +286,18 @@ class Application(SingletonConfigurable):
     _loaded_config_files = List()
 
     show_config = Bool(
-        help="Instead of starting the Application, dump configuration to stdout"
+        help="Dump configuration to stdout while starting application"
     ).tag(config=True)
 
     show_config_json = Bool(
-        help="Instead of starting the Application, dump configuration to stdout (as JSON)"
+        help="Dump configuration to stdout while starting application (as JSON)"
     ).tag(config=True)
 
-    @observe('show_config_json')
-    def _show_config_json_changed(self, change):
-        self.show_config = change.new
-
-    @observe('show_config')
+    @observe('show_config', 'show_config_json')
     def _show_config_changed(self, change):
-        if change.new:
-            self._save_start = self.start
-            self.start = self.start_show_config
+        if change.new and not hasattr(self, '_original_start'):
+            self._original_start = self.start
+            self.start = self._dump_config_and_start
 
     def __init__(self, **kwargs):
         SingletonConfigurable.__init__(self, **kwargs)
@@ -338,7 +334,7 @@ class Application(SingletonConfigurable):
         if self.subapp is not None:
             return self.subapp.start()
 
-    def start_show_config(self):
+    def _dump_config_and_start(self):
         """start function used when show_config is True"""
         config = self.config.copy()
         # exclude show_config flags from displayed config
@@ -353,29 +349,31 @@ class Application(SingletonConfigurable):
                       indent=1, sort_keys=True, default=repr)
             # add trailing newline
             sys.stdout.write('\n')
-            return
 
-        if self._loaded_config_files:
-            print("Loaded config files:")
-            for f in self._loaded_config_files:
-                print('  ' + f)
-            print()
+        else:
+            if self._loaded_config_files:
+                print("Loaded config files:")
+                for f in self._loaded_config_files:
+                    print('  ' + f)
+                print()
+    
+            for classname in sorted(config):
+                class_config = config[classname]
+                if not class_config:
+                    continue
+                print(classname)
+                pformat_kwargs = dict(indent=4)
+                if sys.version_info >= (3,4):
+                    # use compact pretty-print on Pythons that support it
+                    pformat_kwargs['compact'] = True
+                for traitname in sorted(class_config):
+                    value = class_config[traitname]
+                    print('  .{} = {}'.format(
+                        traitname,
+                        pprint.pformat(value, **pformat_kwargs),
+                    ))
 
-        for classname in sorted(config):
-            class_config = config[classname]
-            if not class_config:
-                continue
-            print(classname)
-            pformat_kwargs = dict(indent=4)
-            if sys.version_info >= (3,4):
-                # use compact pretty-print on Pythons that support it
-                pformat_kwargs['compact'] = True
-            for traitname in sorted(class_config):
-                value = class_config[traitname]
-                print('  .{} = {}'.format(
-                    traitname,
-                    pprint.pformat(value, **pformat_kwargs),
-                ))
+        return self._original_start()
 
     def print_alias_help(self):
         """Print the alias parts of the help."""

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -611,8 +611,9 @@ def test_show_config(capsys):
     cfg.MyApp.i = 5
     # don't show empty
     cfg.OtherApp
-    
+
     app = MyApp(config=cfg, show_config=True)
+    app.initialize([])
     app.start()
     out, err = capsys.readouterr()
     assert 'MyApp' in out
@@ -624,8 +625,9 @@ def test_show_config_json(capsys):
     cfg = Config()
     cfg.MyApp.i = 5
     cfg.OtherApp
-    
+
     app = MyApp(config=cfg, show_config_json=True)
+    app.initialize([])
     app.start()
     out, err = capsys.readouterr()
     displayed = json.loads(out)

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -418,7 +418,7 @@ class TestApplication(TestCase):
     def test_generate_config_file_classes_to_include(self):
         class NotInConfig(HasTraits):
             from_hidden = Unicode('x', help="""From hidden class
-            
+
             Details about from_hidden.
             """).tag(config=True)
 
@@ -630,6 +630,25 @@ def test_show_config_json(capsys):
     out, err = capsys.readouterr()
     displayed = json.loads(out)
     assert Config(displayed) == cfg
+
+
+@mark.parametrize('flag', ['--show-config', '--show-config-json'])
+def test_show_config_calls_start(flag, mocker):
+    def my_launch(app, *argv):
+        app.initialize(argv)
+        app.start()
+
+    ## Sanity check.
+    #
+    app = Application()
+    start_stub = mocker.patch.object(app, 'start')
+    my_launch(app)
+    start_stub.assert_called_once_with()
+
+    app = Application()
+    start_stub = mocker.patch.object(app, 'start')
+    my_launch(app, flag)
+    start_stub.assert_called_once_with()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem
[edit: misstook a my local modifications as traitlets's codebase!]

I want to combine the  `--debug` flag when it's true, to also dump configurations 
(set `show_config` app.parameter to true).
Unfortunately, as currently implemented, the app halts!
And that is quite untypical for a `--debug` flag.

The reason is that `show_config[_json]` params (#341) is replacing the `Application.start()` method with a new one, that halts after dumping.
It is quite possible to dump the configuration AND continue normally with the application.

## Solution
This PR is simply calls `start()` after dumping configurations.

But in principle, config-dumping can be simplified even more by avoiding the replacement of `start()` in the first place.
We may just inspect the `show_config[_json]` params in `initialize()` function, like that:
[edit originally code had neglected sub-commands]
```python
    def initialize(self, argv=None):
        self.parse_command_line(argv)
        if self.subapp is None and (  # Only final sub-command dumps.
                self.show_config or self.show_config_json):
            self._dump_config()
```

But the `test_show_config[_json]()` test-cases in #341 have been written to bypass `initialize()` and call immediately `start()` after app construction.  

I would prefer such a simple configuration, unless there is a concrete reason behind that decision, agree?