### PR TITLE
Implement --show-config using mixin class for Application

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -408,6 +408,15 @@ application, simply pass ``-h`` or ``--help``. And to see the full list of
 configurable options (*very* long), pass ``--help-all``.
 
 
+Mixins
+======
+- :class:`~traitlets.config.DumpConfig`: a :class:`~traitlets.config.Application`
+  mixin that dumps configurations and continue with launching the app as normal.
+- :class:`~traitlets.config.DumpConfig`: a :class:`~traitlets.config.Application`
+  mixin that dumps configurations, but stops app after dumping them
+  (just return from :meth:`~traitlets.config.Application.start()`).
+
+
 Design requirements
 ===================
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -893,6 +893,16 @@ class DumpConfigAndStop(_DumpConfigBase):
             return super(DumpConfigAndStop, self).start()
 
 
+class DumpConfig(_DumpConfigBase):
+    """
+    Application mixin that dumpsconfigs when `--show-config(-json)` given.
+    """
+    def start(self):
+        if self.show_config or self.show_config_json:
+            self._dump_config()
+        return super(DumpConfig, self).start()
+
+
 
 if __name__ == '__main__':
     Application.launch_instance()

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -29,7 +29,7 @@ from traitlets.config.loader import Config
 from traitlets.tests.utils import get_output_error_code, check_help_output, check_help_all_output
 
 from traitlets.config.application import (
-    Application, DumpConfigAndStop
+    Application, DumpConfigAndStop, DumpConfig
 )
 
 from ipython_genutils.tempdir import TemporaryDirectory
@@ -636,12 +636,13 @@ def test_DumpConfigAndStop_show_config_json(capsys):
     assert not err
 
 
+def _my_launch(app, *argv):
+    app.initialize(argv)
+    app.start()
+
+
 @mark.parametrize('flag', ['--show-config', '--show-config-json'])
 def test_DumpConfigAndStop_application_start_called(flag):
-    def my_launch(app, *argv):
-        app.initialize(argv)
-        app.start()
-
     class MyApp(DumpConfigAndStop, Application):
         pass
 
@@ -650,7 +651,7 @@ def test_DumpConfigAndStop_application_start_called(flag):
     m = mock.Mock()  # @UndefinedVariable
     with mock.patch.object(Application, 'start', m):  # @UndefinedVariable
         app = MyApp()
-        my_launch(app)
+        _my_launch(app)
     assert m.call_count == 1
 
 
@@ -659,8 +660,30 @@ def test_DumpConfigAndStop_application_start_called(flag):
     m = mock.Mock()                                     # @UndefinedVariable
     with mock.patch.object(Application, 'start', m):    # @UndefinedVariable
         app = MyApp()
-        my_launch(app, flag)
+        _my_launch(app, flag)
     assert not m.called
+
+
+@mark.parametrize('flag', ['--show-config', '--show-config-json'])
+def test_DumpConfig_application_start_called(flag):
+    class MyApp(DumpConfig, Application):
+        pass
+
+    ## Check `start()` called without flag.
+    #
+    m = mock.Mock()  # @UndefinedVariable
+    with mock.patch.object(Application, 'start', m):  # @UndefinedVariable
+        app = MyApp()
+        _my_launch(app)
+    assert m.call_count == 1
+
+    ## Check `start()` CALLED aso WITH flag.
+    #
+    m = mock.Mock()                                     # @UndefinedVariable
+    with mock.patch.object(Application, 'start', m):    # @UndefinedVariable
+        app = MyApp()
+        _my_launch(app, flag)
+    assert m.call_count == 1
 
 
 


### PR DESCRIPTION
Replaces #479 and simplifies dumping of configurations (a new feature not released yet in 5.0.x). 
Instead of monkeypatching `application.start()`, it uses plain inheritance and *mixins* classes.

- 2 mixin classes implemented in this PR:
  - `DumpConfig`: dump config and continue wth launchng application as normal.
  - `DumpConfigAndStop`: dump config and return from `start()`.
- Users can choose to opt-in any of the 2 functionalities by inheriting their app-classes from these mixins.
- Users may easily customize a new mixin classes to i.e. dump configs in a fie, instead of to `stdut`, simply by inheriting from them.
- Added a new section in docs to explain the 2 new mixin classes.

Open issue:
-------------
`Application.flags` may need a better way to enusre new flags are added if users want to modify them.

General note about Mixins on traitlets
=========================
It is not always possible to have all desired functionality built-in to classes.
Sometimes the requirements are contradictory;  other times, testing all functionality combinations is difficult.  

Mixins can be used for extra features that users can enable/disable in their sources, 
while testing becomes simpler because mixn-classes may specify in their documentation "incompatibilities" against other mixins, and avoid testing alltogether.

In my opinion, they should be used more often.