### PR TITLE
Add imports to "Using Traitlets" docs

### DIFF
--- a/docs/source/using_traitlets.rst
+++ b/docs/source/using_traitlets.rst
@@ -19,7 +19,8 @@ value generation of attributes on :class:`traitlets.HasTraits`
 subclasses:
 
 .. code:: python
-
+    
+    from traitlets import HasTraits, Int, Unicode
     import getpass
 
     class Identity(HasTraits):


### PR DESCRIPTION
I'm currently wrapping my head around Traitlets, and tried running the code in the docs. Although `Unicode`, `Int`, etc lie directly inside `traitlets`, it wasn't immediately obvious, so I added them to make life easier for the next user.