### PR TITLE
Update link to enthought trait library

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Traitlets is a pure Python library enabling:
 
 Its implementation relies on the [descriptor](https://docs.python.org/howto/descriptor.html)
 pattern, and it is a lightweight pure-python alternative of the
-[*traits* library](http://code.enthought.com/projects/traits/).
+[*traits* library](http://code.enthought.com/pages/traits.html).
 
 Traitlets powers the configuration system of IPython and Jupyter
 and the declarative API of IPython interactive widgets.


### PR DESCRIPTION
The pages linked here gave me a 404, so I checked Enthought's web pages to find a working version
of the link.