### PR TITLE
Convert dict to Config before merging to avoid overwriting extant values

### DIFF
--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -190,7 +190,7 @@ class Config(dict):
     def merge(self, other):
         """merge another config object into this one"""
         to_update = {}
-        for k, v in other.items():
+        for k, v in Config(other).items():
             if k not in self:
                 to_update[k] = v
             else: # I have this key

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -429,7 +429,6 @@ class TestApplication(TestCase):
         app.classes.append(NoTraits)
 
         conf_txt = app.generate_config_file()
-        print(conf_txt)
         self.assertIn('The integer b.', conf_txt)
         self.assertIn('# Foo(Configurable)', conf_txt)
         self.assertNotIn('# Configurable', conf_txt)

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -450,6 +450,15 @@ class TestConfig(TestCase):
         self.assertEqual(c1.Foo.bar, 1)
         self.assertEqual(c1.Foo.baz, 2)
         self.assertNotIn('baz', c2.Foo)
+        
+    def test_dictmerge(self):
+        c1 = Config({'Foo' : {'baz' : 2}})
+        c2 = {'Foo' : {'bar' : 1}}
+        c1.merge(c2)
+        self.assertEqual(c1.Foo.__class__, Config)
+        self.assertEqual(c1.Foo.bar, 1)
+        self.assertEqual(c1.Foo.baz, 2)
+        self.assertNotIn('baz', c2['Foo'])
 
     def test_contains(self):
         c1 = Config({'Foo' : {'baz' : 2}})

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -250,7 +250,6 @@ class TestKeyValueCL(TestCase):
     def test_basic(self):
         cl = self.klass(log=log)
         argv = [ '--' + s[2:] for s in pyfile.split('\n') if s.startswith('c.') ]
-        print(argv)
         config = cl.load_config(argv)
         self.assertEqual(config.a, 10)
         self.assertEqual(config.b, 20)
@@ -534,4 +533,3 @@ class TestConfig(TestCase):
         self.assertIs(c.Foo, c2.Foo)
         self.assertEqual(c.Foo.trait, [1])
         self.assertEqual(c2.Foo.trait, [1])
-


### PR DESCRIPTION
Right now merging a dictionary into a Config object will overwrite the values of the Config object. If the dictionary had first been converted into a Config object, it would not overwrite the values. 

This converts arguments passed to merge to a `Config` object before beginning the merge. It appears to not affect existing `Config` objects that are being merged, but if there are any performance concerns, I can add a check to see if it's a dict before applying the transformation.

This also removes some unrelated, unnecessary prints from the tests that were making it hard to read the test output.