### PR TITLE
adds string parsing ability to CBool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ __pycache__
 .#*
 .coverage
 .cache
+.idea
+.pytest_cache

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -10,22 +10,23 @@
 import pickle
 import re
 import sys
-from ._warnings import expected_warnings
-
+from distutils.util import strtobool
 from unittest import TestCase
+
 import pytest
+import six
 from pytest import mark
 
 from traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
+    HasTraits, MetaHasTraits, TraitType, Any, Bool, CBool, CBytes, Dict, Enum,
     Int, CInt, Long, CLong, Integer, Float, CFloat, Complex, Bytes, Unicode,
     TraitError, Union, All, Undefined, Type, This, Instance, TCPAddress,
     List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
     ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
     observe_compat, BaseDescriptor, HasDescriptors,
 )
+from ._warnings import expected_warnings
 
-import six
 
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')
@@ -1456,6 +1457,17 @@ class TestUnicode(TraitTestBase):
                       [10], ['ten'], [u'ten'], {'ten': 10},(10,), None]
     if not six.PY3:
         _bad_values.extend([long(10), long(-10)])
+
+class CBoolTrait(HasTraits):
+    value = CBool(True)
+
+class TestCBool(TraitTestBase):
+    obj = CBoolTrait()
+    _good_values = [True, False, 1, 0, "true", "false", "yes", "no"]
+    def coerce(self, n):
+        if isinstance(n, str):
+            return strtobool(n)
+        return bool(n)
 
 
 class ObjectNameTrait(HasTraits):

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1463,9 +1463,11 @@ class CBoolTrait(HasTraits):
 
 class TestCBool(TraitTestBase):
     obj = CBoolTrait()
-    _good_values = [True, False, 1, 0, "true", "false", "yes", "no"]
+    _good_values = [True, False, 1, 0, "true", "false", "yes", "no", b'yes', b'no']
+    _bad_values = ["I am not a crook!"]
+
     def coerce(self, n):
-        if isinstance(n, str):
+        if isinstance(n, six.string_types):
             return strtobool(n)
         return bool(n)
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2264,7 +2264,7 @@ class CBool(Bool):
 
     def validate(self, obj, value):
         try:
-            if isinstance(value, str):
+            if isinstance(value, six.string_types):
                 return strtobool(value)
             return bool(value)
         except:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -41,12 +41,13 @@ Inheritance diagram:
 # also under the terms of the Modified BSD License.
 
 import contextlib
+import enum
 import inspect
 import os
 import re
 import sys
 import types
-import enum
+
 try:
     from types import ClassType, InstanceType
     ClassTypes = (ClassType, type)
@@ -61,6 +62,7 @@ from .utils.importstring import import_item
 from .utils.sentinel import Sentinel
 from .utils.bunch import Bunch
 from .utils.descriptions import describe, class_of, add_article, repr_type
+from distutils.util import strtobool
 
 SequenceTypes = (list, tuple, set, frozenset)
 
@@ -2262,6 +2264,8 @@ class CBool(Bool):
 
     def validate(self, obj, value):
         try:
+            if isinstance(value, str):
+                return strtobool(value)
             return bool(value)
         except:
             self.error(obj, value)


### PR DESCRIPTION
This allows strings to be parsed in CBool. This mitigates unexpected scenarios in user code, for instance when using CBool with the value of 'False' which will return True. 

This is particularly useful when using env variables for traitlets since they will always come in as strings, as was the case in this project: https://github.com/jupyter/kernel_gateway/pull/299
