### PR TITLE
Add support for dynamic configuration updates

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -16,6 +16,7 @@ import pprint
 import re
 import sys
 import time
+import weakref
 
 from traitlets.config.configurable import Configurable, SingletonConfigurable
 from traitlets.config.loader import (
@@ -876,7 +877,7 @@ class Application(SingletonConfigurable):
         if not isinstance(configurable, Configurable):
             raise RuntimeError("'{}' is not a subclass of Configurable!".format(configurable))
 
-        self.dynamic_configurables[config_name] = configurable
+        self.dynamic_configurables[config_name] = weakref.proxy(configurable)
 
     @classmethod
     def launch_instance(cls, argv=None, **kwargs):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -316,7 +316,7 @@ class Application(SingletonConfigurable):
             else:
                 self.classes.insert(0, self.__class__)
 
-        self.last_config_update = int(time.time())
+        self.last_config_update = time.time()
         self.dynamic_configurables = {}
 
     @observe('config')
@@ -832,7 +832,7 @@ class Application(SingletonConfigurable):
         """
         updated = False
         for file in self._loaded_config_files:
-            mod_time = int(os.path.getmtime(file))
+            mod_time = os.path.getmtime(file)
             if mod_time > self.last_config_update:
                 self.log.debug("Config file was updated: {}!".format(file))
                 self.last_config_update = mod_time


### PR DESCRIPTION
Long-running, service-oriented, applications should be able to have their configurations updated without requiring restarts.  These changes add methods that support periodic checks of previously loaded configuration files for changes and updates configuration-based traitlets of registered Configurable instances.  Examples where dynamic updates can be useful is in toggling log levels or updated whitelists.

This PR will remain a WIP until the following have been completed (hoping for some feedback prior to moving on):
- [x] Functional code completed, ready for review
- [x] Test code completed
- [x] Documentation added

Applications wishing to utilize this must first register the Configurable instances that are participating in dynamic updates using `Application.add_dynamic_configurable(name, Configurable)`.  The name is for informational purposes but it is suggested to use the traitlets _class prefix_ for its configuration entry.  For example, if `c.MappingKernelManager.cull_idle_timeout = 300` is in the configuration file and the application wishes to monitor traitlets on its multi kernel manager class instance, they would use a name of `MappingKernelManager` and register the Configurable instance using:
```python
    self.add_dynamic_configurable('MappingKernelManager', self.kernel_manager)
```

It is expected that `Application.update_dynamic_configurations()` be called from a periodicCallback, but that's up to the application.

Caveats:
1. Command-line options (or those set via environment variables) will always override file-based options.  As a result, those options will not have their values updated when configuration file changes are detected.  Therefore, applications wishing to utilize this feature should encourage the use of configuration files.
2. Some configurable traitlets, although updated, will not have their updated values reflected in the application if those values are used to initialize other entities or the traitlet's value is copied and used via another variable.  For example, `c.MappingKernelManager.cull_interval` is used to configure a periodic callback of that interval.  Updates to `cull_interval` will not be reflected unless the periodic callback is stopped and re-created.  As a result, applications must be aware and implement the `@observe` callback to reset or reinitialize such entities in order to make those options dynamic.

Example usage:
Here's an example usage from Jupyter Enterprise Gateway.  This method registers the configurables of interest and initializes a periodic callback for `update_dynamic_configurables()`.  It also logs the set of CLI-based options that will not be privy to dynamic updates.
```python
    def init_dynamic_updates(self):
        """
        Initialize the set of configurables that should participate in dynamic updates.  We should
        also log that we're performing dynamic configration updates, along with the list of CLI
        options - that are not privy to dynamic updates.
        :return:
        """
        if self.dynamic_config_interval > 0:
            self.add_dynamic_configurable('EnterpriseGatewayApp', self)
            self.add_dynamic_configurable('MappingKernelManager', self.kernel_manager)
            self.add_dynamic_configurable('KernelSpecManager', self.kernel_spec_manager)
            self.add_dynamic_configurable('KernelSessionManager', self.kernel_session_manager)

            self.log.info("Dynamic updates have been configured.  Checking every {} seconds.".
                          format(self.dynamic_config_interval))

            self.log.info("The following configuration options will not be subject to dynamic updates:")
            for config, options in self.cli_config.items():
                for option, value in options.items():
                    self.log.info("    '{}.{}': '{}'".format(config, option, value))

            if self.dynamic_config_poller is None:
                self.dynamic_config_poller = ioloop.PeriodicCallback(self.update_dynamic_configurables,
                                                                     self.dynamic_config_interval * 1000)
            self.dynamic_config_poller.start()
```
Output at application startup:
```
[I 2019-05-02 06:45:46.835 EnterpriseGatewayApp] Dynamic updates have been configured.  Checking every 60 seconds.
[I 2019-05-02 06:45:46.836 EnterpriseGatewayApp] The following configuration options will not be subject to dynamic updates:
[I 2019-05-02 06:45:46.837 EnterpriseGatewayApp]     'EnterpriseGatewayApp.ip': '0.0.0.0'
[I 2019-05-02 06:45:46.838 EnterpriseGatewayApp]     'EnterpriseGatewayApp.port': '8889'
[I 2019-05-02 06:45:46.839 EnterpriseGatewayApp]     'EnterpriseGatewayApp.port_retries': '0'
[I 2019-05-02 06:45:46.839 EnterpriseGatewayApp]     'EnterpriseGatewayApp.yarn_endpoint': 'http://node-1:8088/ws/v1/cluster'
[I 2019-05-02 06:45:46.841 EnterpriseGatewayApp]     'EnterpriseGatewayApp.remote_hosts': '['node-1','node-2','node-3']'
[I 2019-05-02 06:45:46.843 EnterpriseGatewayApp]     'KernelSessionManager.enable_persistence': 'True'
```
Because user's may want to adjust the polling interval for dynamic config updates, here's an example of an `@observe` callback that adjusts the period (again from Enterprise Gateway).
```python
    @observe('dynamic_config_interval')
    def dynamic_config_interval_changed(self, event):
        prev_val = event['old']
        self.dynamic_config_interval = event['new']
        if self.dynamic_config_interval != prev_val:
            # Values are different.  Stop the current poller.  If new value is > 0, start a poller.
            if self.dynamic_config_poller:
                self.dynamic_config_poller.stop()
                self.dynamic_config_poller = None

            if self.dynamic_config_interval <= 0:
                self.log.warning("Dynamic configuration updates have been disabled and cannot be re-enabled "
                                 "without restarting Enterprise Gateway!")
            elif prev_val > 0:  # The interval has been changed, but still positive
                self.init_dynamic_configurables()  # Restart the poller
```