### PR TITLE
DOC: Add Callable to docs.

### DIFF
--- a/docs/source/trait_types.rst
+++ b/docs/source/trait_types.rst
@@ -110,5 +110,7 @@ Miscellaneous
 .. autoclass:: Union
    :members: __init__
 
+.. autoclass:: Callable
+
 .. autoclass:: Any
 


### PR DESCRIPTION
Missed in #333, as noted in https://github.com/ipython/traitlets/issues/321#issuecomment-386471262.

Thanks!