### PR TITLE
Fix SyntaxWarning: "is" with a literal.

### DIFF
--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -918,7 +918,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
                 if key in self.aliases:
                     alias_flags[self.aliases[key]] = value
                     continue
-                keys = ('-'+key, '--'+key) if len(key) is 1 else ('--'+key, )
+                keys = ('-'+key, '--'+key) if len(key) == 1 else ('--'+key, )
                 paa(*keys, action=_FlagAction, flag=value)
 
         for keys, traitname in aliases.items():
@@ -943,7 +943,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
                     argparse_kwds['action'] = _FlagAction
                     argparse_kwds['flag'] = alias_flags[traitname]
                     argparse_kwds['alias'] = traitname
-                keys = ('-'+key, '--'+key) if len(key) is 1 else ('--'+key, )
+                keys = ('-'+key, '--'+key) if len(key) == 1 else ('--'+key, )
                 paa(*keys, **argparse_kwds)
 
     def _convert_to_config(self):


### PR DESCRIPTION
When using ipython with Python 3.8.0a4 I discovered this problem in traitlets library.

Reproducer:
```
Python 3.8.0a4 (default, May 17 2019, 21:21:00) 
[GCC 9.1.1 20190503 (Red Hat 9.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import traitlets.config.loader
/home/lbalhar/Software/traitlets/traitlets/config/loader.py:921: SyntaxWarning: "is" with a literal. Did you mean "=="?
  keys = ('-'+key, '--'+key) if len(key) is 1 else ('--'+key, )
/home/lbalhar/Software/traitlets/traitlets/config/loader.py:946: SyntaxWarning: "is" with a literal. Did you mean "=="?
  keys = ('-'+key, '--'+key) if len(key) is 1 else ('--'+key, )
>>>
```