### PR TITLE
Fix tests for ipywidgets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - python: 3.6
       env:
         - TEST_DEPS=ipywidgets[test]
-        - TEST="nosetests ipywidgets"
+        - TEST="pytest --pyargs ipywidgets"
     - python: 3.6
       env:
         - TEST_DEPS=traittypes[test]


### PR DESCRIPTION
Hello @rmorshea,

`ipywidgets` switched from `nose` to `pytest`, so we have to use `pytest` as well.

Related PR:
https://github.com/jupyter-widgets/ipywidgets/pull/2219

Best regards!