### PR TITLE
Minor addition to docs 

### DIFF
--- a/docs/source/using_traitlets.rst
+++ b/docs/source/using_traitlets.rst
@@ -120,6 +120,13 @@ Basic Example: Validating the Parity of a Trait
         parity_check.value = 1
         parity_check.parity = 1
 
+Notice how all of the examples above return
+``proposal['value']``. This is necessary for validation to work
+properly, since the new value of the trait will be the
+return value of the function decorated by ``@validate``. If this
+function does not have any ``return`` statement, then the returned
+value will be ``None``, instead of what we wanted (which is ``proposal['value']``).
+
 However, we recommend that custom cross-validators don't modify the state of
 the HasTraits instance.
 


### PR DESCRIPTION
Suggested minor addition to the docs to prevent other people from making the same mistake I made.

I know this is fairly obvious in hindsight, but better explicit than implicit I guess. I genuinely did spend around 30-60 minutes puzzled about how to fix this (since I had assumed incorrectly that the default behavior was that the value of `proposal.value` was accepted automatically as long as no errors were raised by the decorating function, but really functions with `@validate` decorators seem to be setters as much as anything else).

Again, my fault for not reading the original docs closely enough. I thought it might be helpful to explain the examples a little bit, is all.