### PR TITLE
Backport PR 522 to 4.3.x - Expose loaded config files, make load idempotent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 \#*#
 .#*
 .coverage
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
     - 3.5
     - 3.4
     - 2.7
-    - 3.3
     - 3.6-dev
 sudo: false
 install:

--- a/traitlets/_version.py
+++ b/traitlets/_version.py
@@ -1,2 +1,2 @@
-version_info = (4, 3, 2)
+version_info = (4, 3, 3, 'dev')
 __version__ = '.'.join(map(str, version_info))

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -267,6 +267,7 @@ class Application(SingletonConfigurable):
         """
     )
 
+    _loaded_config_files = List()
 
     def __init__(self, **kwargs):
         SingletonConfigurable.__init__(self, **kwargs)
@@ -554,10 +555,10 @@ class Application(SingletonConfigurable):
             if log:
                 log.debug("Looking for %s in %s", basefilename, path or os.getcwd())
             jsonloader = cls.json_config_loader_class(basefilename+'.json', path=path, log=log)
-            config = None
             loaded = []
             filenames = []
             for loader in [pyloader, jsonloader]:
+                config = None
                 try:
                     config = loader.load_config()
                 except ConfigFileNotFound:
@@ -583,21 +584,20 @@ class Application(SingletonConfigurable):
                                 " {1} has higher priority: {2}".format(
                                 filename, loader.full_filename, json.dumps(collisions, indent=2),
                             ))
-                    yield config
+                    yield (config, loader.full_filename)
                     loaded.append(config)
                     filenames.append(loader.full_filename)
-            
-
 
     @catch_config_error
     def load_config_file(self, filename, path=None):
         """Load config files by filename and path."""
         filename, ext = os.path.splitext(filename)
         new_config = Config()
-        for config in self._load_config_files(filename, path=path, log=self.log,
+        for (config, filename) in self._load_config_files(filename, path=path, log=self.log,
             raise_config_file_errors=self.raise_config_file_errors,
         ):
             new_config.merge(config)
+            self._loaded_config_files.append(filename)
         # add self.cli_config to preserve CLI config priority
         new_config.merge(self.cli_config)
         self.update_config(new_config)

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -588,6 +588,11 @@ class Application(SingletonConfigurable):
                     loaded.append(config)
                     filenames.append(loader.full_filename)
 
+    @property
+    def loaded_config_files(self):
+        """Currently loaded configuration files"""
+        return self._loaded_config_files[:]
+
     @catch_config_error
     def load_config_file(self, filename, path=None):
         """Load config files by filename and path."""
@@ -597,7 +602,8 @@ class Application(SingletonConfigurable):
             raise_config_file_errors=self.raise_config_file_errors,
         ):
             new_config.merge(config)
-            self._loaded_config_files.append(filename)
+            if filename not in self._loaded_config_files:  # only add to list of loaded files if not previously loaded
+                self._loaded_config_files.append(filename)
         # add self.cli_config to preserve CLI config priority
         new_config.merge(self.cli_config)
         self.update_config(new_config)


### PR DESCRIPTION
This PR consists of 4 commits which should probably not be squashed when merged.

1. Set the version to 4.3.3.dev until 4.3.3 or 4.4.0? is built.
2. Since PR #522 depended on a very small portion of PR #341, yet #341 introduced (and depended on) API-level changes destined for 5.0.0, only the required (and very small) portion of one of the commits from 341 was backported.
3. A complete backport of #522.
4. Removed python 3.3 from travis configuration since it no longer exists.
