### PR TITLE
Ensure default Set values are sorted for a reproducible build

### DIFF
--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -62,7 +62,9 @@ class Bar(Foo):
     b = Unicode('gotit', help="The string b.").tag(config=False)
     c = Float(help="The string c.").tag(config=True)
     bset = Set([]).tag(config=True, multiplicity='+')
+    bset_values = Set([2,1,5]).tag(config=True, multiplicity='+')
     bdict = Dict().tag(config=True, multiplicity='+')
+    bdict_values = Dict({1:'a','0':'b',5:'c'}).tag(config=True, multiplicity='+')
 
 foo_help=u"""Foo(Configurable) options
 -------------------------
@@ -83,8 +85,12 @@ bar_help=u"""Bar(Foo) options
     Default: 0
 --Bar.bdict <key-1>=<value-1>...
     Default: {}
+--Bar.bdict_values <key-1>=<value-1>...
+    Default: {1: 'a', '0': 'b', 5: 'c'}
 --Bar.bset <set-item-1>...
     Default: set()
+--Bar.bset_values <set-item-1>...
+    Default: {1, 2, 5}
 --Bar.c=<Float>
     The string c.
     Default: 0.0

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2596,6 +2596,10 @@ class Set(List):
         """
         super(Set, self).__init__(trait, default_value, minlen, maxlen, **kwargs)
 
+    def default_value_repr(self):
+        # Ensure default value is sorted for a reproducible build
+        return repr(sorted(self.make_dynamic_default()))
+
 
 class Tuple(Container):
     """An instance of a Python tuple."""

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2598,7 +2598,10 @@ class Set(List):
 
     def default_value_repr(self):
         # Ensure default value is sorted for a reproducible build
-        return repr(sorted(self.make_dynamic_default()))
+        list_repr = repr(sorted(self.make_dynamic_default()))
+        if list_repr == '[]':
+            return 'set()'
+        return '{'+list_repr[1:-1]+'}'
 
 
 class Tuple(Container):


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that traitlets generates non-reproducible output which is affecting the reproducibility of other packages. For example, in nbconvert:

```
  -<dd><p class="first">Default: {'image/jpeg',</span> <span class="pre">'image/svg+xml',</span> [..]
  +<dd><p class="first">Default: {'image/svg+xml',</span> <span class="pre">'application/pdf',</span> [..]
```

(From https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/nbconvert.html as of time-of writing.)

This is due to it not iterating over a `Set` traitlet type in a deterministic ordering when generating the `Default: [..]` human-readable strings. This patch ensures that we display the `Set` traits defaults in a sorted, and thus reproducible, manner.