### PR TITLE
In hold_trait_notifications, don't assume `change` is a Bunch

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1164,6 +1164,9 @@ class HasTraits(six.with_metaclass(MetaHasTraits, HasDescriptors)):
                     return past_changes
 
             def hold(change):
+                if not isinstance(change, Bunch):
+                # cast to bunch if given a dict
+                    change = Bunch(change)
                 name = change.name
                 cache[name] = compress(cache.get(name), change)
 


### PR DESCRIPTION
If a change is submitted directly with `HasTraits.notify_change`, `_notify_observers` (which handles turning a `dict` to a `Bunch`) has been replaced with `hold`, which needs to be prepared for plain `dicts`.