### PR TITLE
Travis CI: Test the current versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
   - "nightly"
+  - 3.8
+  - 3.7
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
-sudo: false
 install:
   - pip install --upgrade pip
   - pip install .
@@ -21,23 +21,23 @@ matrix:
   allow_failures:
     - python: "nightly"
   include:
-    - python: 3.6
+    - python: 3.8
       env:
         - TEST_DEPS=ipython[test]
         - TEST=iptest
-    - python: 3.6
+    - python: 3.8
       env:
         - TEST_DEPS=git+https://github.com/jupyter/nbconvert.git#egg=nbconvert[test]
         - TEST="py.test --pyargs nbconvert"
-    - python: 3.6
+    - python: 3.8
       env:
         - TEST_DEPS=notebook[test]
         - TEST="nosetests --exclude selenium notebook"
-    - python: 3.6
+    - python: 3.8
       env:
         - TEST_DEPS=ipywidgets[test]
         - TEST="pytest --pyargs ipywidgets"
-    - python: 3.6
+    - python: 3.8
       env:
         - TEST_DEPS=traittypes[test]
         - TEST="nosetests traittypes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env:
         - TEST_DEPS=ipython[test]
         - TEST=iptest
-    - python: 3.8
+    - python: 3.6
       env:
         - TEST_DEPS=git+https://github.com/jupyter/nbconvert.git#egg=nbconvert[test]
         - TEST="py.test --pyargs nbconvert"
@@ -37,7 +37,7 @@ matrix:
       env:
         - TEST_DEPS=ipywidgets[test]
         - TEST="pytest --pyargs ipywidgets"
-    - python: 3.8
+    - python: 3.6
       env:
         - TEST_DEPS=traittypes[test]
         - TEST="nosetests traittypes"


### PR DESCRIPTION
Travis has deprecated the `sudo:` tag.