### PR TITLE
Export Bunch

### DIFF
--- a/traitlets/__init__.py
+++ b/traitlets/__init__.py
@@ -4,6 +4,7 @@ from . import traitlets
 from .traitlets import *
 from .utils.importstring import import_item
 from .utils.decorators import signature_has_traits
+from .utils.bunch import Bunch
 from ._version import version_info, __version__
 
 


### PR DESCRIPTION
Bunch is a very useful utility class that used to be exported, but then we locked down the things exported from traitlets.py.

Bunch is used in our public APIs, and it would be useful to be able to create one to manually call a change handler.