### PR TITLE
Unpin Python 3.5 for docs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - conda
 dependencies:
-  - python==3.5
+  - python=3
   - ipython_genutils
   - sphinx
   - sphinx_rtd_theme


### PR DESCRIPTION
This is now causing failures because 3.5 is no longer available in conda