### PR TITLE
Add trait.from_string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 .#*
 .coverage
 .cache
+htmlcov

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -661,6 +661,7 @@ class Application(SingletonConfigurable):
     @catch_config_error
     def parse_command_line(self, argv=None):
         """Parse the command line arguments."""
+        assert not isinstance(argv, str)
         argv = sys.argv[1:] if argv is None else argv
         self.argv = [cast_unicode(arg) for arg in argv ]
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -694,10 +694,15 @@ class Application(SingletonConfigurable):
             self.exit(0)
 
         # flatten flags&aliases, so cl-args get appropriate priority:
-        flags,aliases = self.flatten_flags()
+        flags, aliases = self.flatten_flags()
         classes = tuple(self._classes_with_config_traits())
         loader = self._create_loader(argv, aliases, flags, classes=classes)
-        self.cli_config = deepcopy(loader.load_config())
+        try:
+            self.cli_config = deepcopy(loader.load_config())
+        except SystemExit:
+            # print help output on error
+            self.print_help()
+            raise
         self.update_config(self.cli_config)
         # store unparsed args in extra_args
         self.extra_args = loader.extra_args

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -7,7 +7,7 @@
 from copy import deepcopy
 import warnings
 
-from .loader import Config, LazyConfigValue, _is_section_key
+from .loader import Config, LazyConfigValue, DeferredConfigString, _is_section_key
 from traitlets.traitlets import (
     HasTraits,
     Instance,
@@ -163,6 +163,9 @@ class Configurable(HasTraits):
                         # without having to copy the initial value
                         initial = getattr(self, name)
                         config_value = config_value.get_value(initial)
+                    elif isinstance(config_value, DeferredConfigString):
+                        # DeferredEval tends to come from CLI/environment variables
+                        config_value = config_value.get_value(self.traits()[name])
                     # We have to do a deepcopy here if we don't deepcopy the entire
                     # config object. If we don't, a mutable config_value will be
                     # shared by all instances, effectively making it a class attribute.

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -305,9 +305,9 @@ class Configurable(HasTraits):
 
         Parameters
         ----------
-        trait: Trait
+        trait : Trait
             The trait to look for
-        classes: list
+        classes : list
             The list of other classes to consider for redundancy.
             Will return `cls` even if it is not defined on `cls`
             if the defining class is not in `classes`.
@@ -326,7 +326,7 @@ class Configurable(HasTraits):
 
         Parameters
         ----------
-        classes: list, optional
+        classes : list, optional
             The list of other classes in the config file.
             Used to reduce redundant information.
         """

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -7,7 +7,7 @@
 from copy import deepcopy
 import warnings
 
-from .loader import Config, LazyConfigValue, DeferredConfigString, _is_section_key
+from .loader import Config, LazyConfigValue, DeferredConfig, _is_section_key
 from traitlets.traitlets import (
     HasTraits,
     Instance,
@@ -163,9 +163,9 @@ class Configurable(HasTraits):
                         # without having to copy the initial value
                         initial = getattr(self, name)
                         config_value = config_value.get_value(initial)
-                    elif isinstance(config_value, DeferredConfigString):
-                        # DeferredEval tends to come from CLI/environment variables
-                        config_value = config_value.get_value(self.traits()[name])
+                    elif isinstance(config_value, DeferredConfig):
+                        # DeferredConfig tends to come from CLI/environment variables
+                        config_value = config_value.get_value(traits[name])
                     # We have to do a deepcopy here if we don't deepcopy the entire
                     # config object. If we don't, a mutable config_value will be
                     # shared by all instances, effectively making it a class attribute.

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -358,8 +358,9 @@ class DeferredConfigString(text_type):
     in the configurable classes.
 
     When config is loaded, `trait.from_string` will be used.
-    
-    If an error is raised
+
+    If an error is raised in `.from_string`,
+    the original string is returned.
 
     .. versionadded:: 5.0
     """

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -346,6 +346,29 @@ class Config(dict):
             raise AttributeError(e)
 
 
+class DeferredConfigString(text_type):
+    """Config value for loading config from a string
+
+    Interpretation is deferred until it is loaded into the trait.
+
+    Subclass of unicode for backward compatibility.
+
+    This class is only used for values that are not listed
+    in the configurable classes.
+
+    When config is loaded, `trait.from_string` will be used.
+
+    .. versionadded:: 5.0
+    """
+    def get_value(self, trait):
+        """Get the value stored in this string"""
+        return trait.from_string(self)
+
+    def __repr__(self):
+        super_repr = super(DeferredConfigString, self).__repr__()
+        return '%s(%s)' % (self.__class__.__name__, super_repr)
+
+
 #-----------------------------------------------------------------------------
 # Config loading classes
 #-----------------------------------------------------------------------------
@@ -544,18 +567,12 @@ class CommandLineConfigLoader(ConfigLoader):
     here.
     """
 
-    def _parse_config_value(self, rhs):
+    def _parse_config_value(self, rhs, trait=None):
         """Python-evaluates any cmd-line argument values."""
-        rhs = os.path.expanduser(rhs)
-        try:
-            # Try to see if regular Python syntax will work. This
-            # won't handle strings as the quote marks are removed
-            # by the system shell.
-            value = literal_eval(rhs)
-        except (NameError, SyntaxError, ValueError):
-            # This case happens if the rhs is a string.
-            value = rhs
-        return value
+        if trait:
+            return trait.from_string(rhs)
+        else:
+            return DeferredConfigString(rhs)
 
     def _exec_config_str(self, lhs, rhs, trait=None):
         """execute self.config.<lhs> = <rhs>
@@ -573,8 +590,9 @@ class CommandLineConfigLoader(ConfigLoader):
                     "You can pass --{0} <key=value> ... multiple times to add items to a dict.".format(
                         lhs, rhs[0])
                 )
-                value = self._parse_config_value(rhs[0])
+                value = self._parse_config_value(rhs[0], trait)
             else:
+                # FIXME: get trait for values
                 value = {k: self._parse_config_value(v) for k,v in rhs}
 
         elif isinstance(rhs, (list, tuple)):
@@ -591,12 +609,12 @@ class CommandLineConfigLoader(ConfigLoader):
                         "You can pass --{0} item ... multiple times to add items to a list.".format(
                             lhs, rhs)
                     )
-                    value = self._parse_config_value(r)
+                    value = self._parse_config_value(r, trait)
 
             if value is None:
-                value = [self._parse_config_value(r) for r in rhs]
+                value = [self._parse_config_value(r, trait) for r in rhs]
         else:
-            value = self._parse_config_value(rhs)
+            value = self._parse_config_value(rhs, trait)
 
         exec(u'self.config.%s = value' % lhs, None, locals())
 
@@ -636,7 +654,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         ipython --profile="foo" --InteractiveShell.autocall=False
     """
 
-    def __init__(self, argv=None, aliases=None, flags=None, **kw):
+    def __init__(self, argv=None, aliases=None, flags=None, classes=None, **kw):
         """Create a key value pair config loader.
 
         Parameters
@@ -650,9 +668,12 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
             Keys are the short aliases, Values are the resolved trait.
             Of the form: `{'alias' : 'Configurable.trait'}`
         flags : dict
-            A dict of flags, keyed by str name. Vaues can be Config objects,
+            A dict of flags, keyed by str name. Values can be Config objects,
             dicts, or "key=value" strings.  If Config or dict, when the flag
             is triggered, The flag is loaded as `self.config.update(m)`.
+        classes : sequence
+            A list/tuple of classes that are to be configured.
+            Classes included in this list
 
         Returns
         -------
@@ -673,6 +694,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         self.argv = argv
         self.aliases = aliases or {}
         self.flags = flags or {}
+        self.classes = classes or ()
 
 
     def clear(self):
@@ -692,6 +714,19 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
             uargv.append(arg)
         return uargv
 
+    def _find_trait(self, lhs):
+        """Find the trait for a Class.trait string"""
+        
+        from .configurable import Configurable
+        class_name, trait_name = lhs.split('.')[-2:]
+        for cls in self.classes:
+            for parent in cls.mro():
+                if (
+                    issubclass(parent, Configurable) and
+                    parent.__name__ == class_name
+                ):
+                    return parent.class_traits().get(trait_name)
+        return None
 
     def load_config(self, argv=None, aliases=None, flags=None):
         """Parse the configuration and generate the Config object.
@@ -750,9 +785,12 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
                     lhs = aliases[lhs]
                 if '.' not in lhs:
                     # probably a mistyped alias, but not technically illegal
-                    self.log.warning("Unrecognized alias: '%s', it will probably have no effect.", raw)
+                    self.log.warning("Unrecognized alias: '%s', it will have no effect.", raw)
+                    trait = None
+                else:
+                    trait = self._find_trait(lhs)
                 try:
-                    self._exec_config_str(lhs, rhs)
+                    self._exec_config_str(lhs, rhs, trait)
                 except Exception:
                     raise ArgumentError("Invalid argument: '%s'" % raw)
 
@@ -843,11 +881,6 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
     def _create_parser(self, aliases=None, flags=None, classes=None):
         self.parser = ArgumentParser(*self.parser_args, **self.parser_kw)
         self._add_arguments(aliases, flags, classes)
-
-    def _parse_config_traits(self):
-        for cls in self.classes:
-            for trait, traitname in cls.class_traits(config=True).items():
-                yield ()
 
     def _add_arguments(self, aliases=None, flags=None, classes=None):
         raise NotImplementedError("subclasses must implement _add_arguments")
@@ -992,7 +1025,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
             self._load_flag(subc)
 
         if self.extra_args:
-            sub_parser = KeyValueConfigLoader(log=self.log)
+            sub_parser = KeyValueConfigLoader(log=self.log, classes=self.classes)
             sub_parser.load_config(self.extra_args)
             self.config.merge(sub_parser.config)
             self.extra_args = sub_parser.extra_args

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -358,12 +358,21 @@ class DeferredConfigString(text_type):
     in the configurable classes.
 
     When config is loaded, `trait.from_string` will be used.
+    
+    If an error is raised
 
     .. versionadded:: 5.0
     """
     def get_value(self, trait):
         """Get the value stored in this string"""
-        return trait.from_string(text_type(self))
+        s = text_type(self)
+        try:
+            return trait.from_string(s)
+        except Exception:
+            # exception casting from string,
+            # let the original string lie.
+            # this will raise a more informative error when config is loaded.
+            return s
 
     def __repr__(self):
         super_repr = super(DeferredConfigString, self).__repr__()
@@ -582,7 +591,12 @@ class CommandLineConfigLoader(ConfigLoader):
                         "Use %r instead of %r" % (rhs, old_rhs),
                         DeprecationWarning)
         if trait:
-            return trait.from_string(rhs)
+            try:
+                return trait.from_string(rhs)
+            except Exception:
+                # failed to eval, let later config loading raise,
+                # which will be more informative
+                return rhs
         else:
             return DeferredConfigString(rhs)
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -347,7 +347,7 @@ class Config(dict):
             raise AttributeError(e)
 
 
-class DeferredConfigString(text_type):
+class DeferredConfigString(str):
     """Config value for loading config from a string
 
     Interpretation is deferred until it is loaded into the trait.
@@ -366,7 +366,7 @@ class DeferredConfigString(text_type):
     """
     def get_value(self, trait):
         """Get the value stored in this string"""
-        s = text_type(self)
+        s = str(self)
         try:
             return trait.from_string(s)
         except Exception:

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -188,9 +188,9 @@ class TestApplication(TestCase):
         app.parse_command_line("--li 1 --li 3 --la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
         config = app.config
         assert config.Foo.li == [1, 3]
-        assert config.Foo.la == ['1', 'ab']
-        assert config.Bar.tb == ['AB', '2']
-        self.assertEqual(config.Bar.aset, 'S1 S2 S1'.split())
+        assert config.Foo.la == ["1", "ab"]
+        assert config.Bar.tb == ("AB", "2")
+        self.assertEqual(config.Bar.aset, {"S1", "S2"})
         app.init_foo()
         assert app.foo.li == [1, 3]
         assert app.foo.la == ['1', 'ab']
@@ -420,8 +420,10 @@ class TestApplication(TestCase):
         self.assertEqual(app.extra_args, ['extra', '--disable', 'args'])
 
         app = MyApp()
-        app.parse_command_line(['-', '--disable', '--Bar.b=1', '-', 'extra'])
-        self.assertEqual(app.extra_args, ['-', '-', 'extra'])
+        app.parse_command_line(
+            ["--disable", "--la", "-", "-", "--Bar.b=1", "--", "-", "extra"]
+        )
+        self.assertEqual(app.extra_args, ["-", "extra"])
 
     def test_unicode_argv(self):
         app = MyApp()
@@ -580,7 +582,7 @@ class TestApplication(TestCase):
 
             app.load_config_file(name, path=[td1])
             self.assertEqual(len(app.loaded_config_files), 1)
-            self.assertEquals(app.loaded_config_files[0], config_file)
+            self.assertEqual(app.loaded_config_files[0], config_file)
 
             app.start()
             self.assertEqual(app.running, True)

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -14,7 +14,7 @@ import os
 import sys
 from io import StringIO
 from tempfile import TemporaryDirectory
-from unittest import TestCase, skip
+from unittest import TestCase
 
 from pytest import mark
 
@@ -22,8 +22,11 @@ from traitlets import Bool, Dict, HasTraits, Integer, List, Set, Tuple, Unicode
 from traitlets.config.application import Application
 from traitlets.config.configurable import Configurable
 from traitlets.config.loader import Config
-from traitlets.tests.utils import (check_help_all_output, check_help_output,
-                                   get_output_error_code)
+from traitlets.tests.utils import (
+    check_help_all_output,
+    check_help_output,
+    get_output_error_code,
+)
 
 try:
     from unittest import mock
@@ -31,9 +34,6 @@ except ImportError:
     import mock
 
 pjoin = os.path.join
-
-
-
 
 
 class Foo(Configurable):
@@ -46,7 +46,9 @@ class Foo(Configurable):
     j = Integer(1, help="The integer j.").tag(config=True)
     name = Unicode(u'Brian', help="First name.").tag(config=True)
     la = List([]).tag(config=True)
+    li = List(Integer()).tag(config=True)
     fdict = Dict().tag(config=True, multiplicity='+')
+
 
 class Bar(Configurable):
 
@@ -55,6 +57,8 @@ class Bar(Configurable):
     tb = Tuple(()).tag(config=True, multiplicity='*')
     aset = Set().tag(config=True, multiplicity='+')
     bdict = Dict().tag(config=True)
+    idict = Dict(value_trait=Integer()).tag(config=True)
+    key_dict = Dict(per_key_traits={'i': Integer(), 'b': Bytes()}).tag(config=True)
 
 
 class MyApp(Application):
@@ -74,6 +78,7 @@ class MyApp(Application):
                     ('j', 'fooj') : ('Foo.j', "`j` terse help msg"),
                     'name' : 'Foo.name',
                     'la': 'Foo.la',
+                    'li': 'Foo.li',
                     'tb': 'Bar.tb',
                     'D': 'Bar.bdict',
                     'enabled' : 'Bar.enabled',
@@ -106,7 +111,6 @@ def class_to_names(classes):
 
 
 class TestApplication(TestCase):
-
     def test_log(self):
         stream = StringIO()
         app = MyApp(log_level=logging.INFO)
@@ -165,31 +169,37 @@ class TestApplication(TestCase):
 
     def test_config_seq_args(self):
         app = MyApp()
-        app.parse_command_line("--la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
+        app.parse_command_line("--li 1 --li 3 --la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
         config = app.config
-        self.assertEqual(config.Foo.la, [1, 'ab'])
-        self.assertEqual(config.Bar.tb, ['AB', 2])
+        assert config.Foo.li == [1, 3]
+        assert config.Foo.la == ['1', 'ab']
+        assert config.Bar.tb == ['AB', '2']
         self.assertEqual(config.Bar.aset, 'S1 S2 S1'.split())
         app.init_foo()
-        self.assertEqual(app.foo.la, [1, 'ab'])
+        assert app.foo.li == [1, 3]
+        assert app.foo.la == ['1', 'ab']
         app.init_bar()
         self.assertEqual(app.bar.aset, {'S1', 'S2'})
-        self.assertEqual(app.bar.tb, ('AB', 2))
+        assert app.bar.tb == ('AB', '2')
 
     def test_config_dict_args(self):
         app = MyApp()
         app.parse_command_line(
             "--Foo.fdict a=1 b=b c=3 "
             "--Bar.bdict k=1 -D=a=b -D 22=33 "
+            "--Bar.idict k=1 --Bar.idict b=2 --Bar.idict c=3 "
             .split())
-        fdict = {'a': 1, 'b': 'b', 'c': 3}
-        bdict = {'k': 1, 'a': 'b', '22': 33}
+        fdict = {'a': '1', 'b': 'b', 'c': '3'}
+        bdict = {'k': '1', 'a': 'b', '22': '33'}
+        idict = {'k': 1, 'b': 2, 'c': 3}
         config = app.config
+        assert config.Bar.idict == idict
         self.assertDictEqual(config.Foo.fdict, fdict)
         self.assertDictEqual(config.Bar.bdict, bdict)
         app.init_foo()
         self.assertEqual(app.foo.fdict, fdict)
         app.init_bar()
+        assert app.bar.idict == idict
         self.assertEqual(app.bar.bdict, bdict)
 
     def test_config_propagation(self):

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -18,7 +18,17 @@ from unittest import TestCase
 
 from pytest import mark
 
-from traitlets import Bool, Dict, HasTraits, Integer, List, Set, Tuple, Unicode
+from traitlets import (
+    Bool,
+    Bytes,
+    Dict,
+    HasTraits,
+    Integer,
+    List,
+    Set,
+    Tuple,
+    Unicode,
+)
 from traitlets.config.application import Application
 from traitlets.config.configurable import Configurable
 from traitlets.config.loader import Config

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -176,32 +176,39 @@ class TestApplication(TestCase):
 
     def test_config(self):
         app = MyApp()
-        app.parse_command_line(["--i=10","--Foo.j=10","--enable=False","--log-level=50"])
+        app.parse_command_line([
+            "--i=10",
+            "--Foo.j=10",
+            "--enable=False",
+            "--log-level=50",
+        ])
         config = app.config
+        print(config)
         self.assertEqual(config.Foo.i, 10)
         self.assertEqual(config.Foo.j, 10)
         self.assertEqual(config.Bar.enabled, False)
-        self.assertEqual(config.MyApp.log_level,50)
+        self.assertEqual(config.MyApp.log_level, 50)
 
     def test_config_seq_args(self):
         app = MyApp()
-        app.parse_command_line("--li 1 --li 3 --la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
+        app.parse_command_line("--li 1 --li 3 --la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 --Bar.aset S2 --Bar.aset S1".split())
+        assert app.extra_args == ["2"]
         config = app.config
         assert config.Foo.li == [1, 3]
         assert config.Foo.la == ["1", "ab"]
-        assert config.Bar.tb == ("AB", "2")
+        assert config.Bar.tb == ("AB",)
         self.assertEqual(config.Bar.aset, {"S1", "S2"})
         app.init_foo()
         assert app.foo.li == [1, 3]
         assert app.foo.la == ['1', 'ab']
         app.init_bar()
         self.assertEqual(app.bar.aset, {'S1', 'S2'})
-        assert app.bar.tb == ('AB', '2')
+        assert app.bar.tb == ('AB',)
 
     def test_config_dict_args(self):
         app = MyApp()
         app.parse_command_line(
-            "--Foo.fdict a=1 b=b c=3 "
+            "--Foo.fdict a=1 --Foo.fdict b=b --Foo.fdict c=3 "
             "--Bar.bdict k=1 -D=a=b -D 22=33 "
             "--Bar.idict k=1 --Bar.idict b=2 --Bar.idict c=3 "
             .split())
@@ -406,7 +413,7 @@ class TestApplication(TestCase):
     def test_extra_args(self):
 
         app = MyApp()
-        app.parse_command_line(["--Bar.b=5", 'extra', "--disable", 'args'])
+        app.parse_command_line(["--Bar.b=5", 'extra', 'args', "--disable"])
         app.init_bar()
         self.assertEqual(app.bar.enabled, False)
         self.assertEqual(app.bar.b, 5)
@@ -423,7 +430,7 @@ class TestApplication(TestCase):
         app.parse_command_line(
             ["--disable", "--la", "-", "-", "--Bar.b=1", "--", "-", "extra"]
         )
-        self.assertEqual(app.extra_args, ["-", "extra"])
+        self.assertEqual(app.extra_args, ["-", "-", "extra"])
 
     def test_unicode_argv(self):
         app = MyApp()

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -122,6 +122,12 @@ class TestApplication(TestCase):
         app.log.info("hello")
         assert "hello" in stream.getvalue()
 
+    def test_no_eval_cli_text(self):
+        app = MyApp()
+        app.initialize(['--Foo.name=1'])
+        app.init_foo()
+        assert app.foo.name == '1'
+
     def test_basic(self):
         app = MyApp()
         self.assertEqual(app.name, u'myapp')

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -4,8 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import logging
-import sys
-import warnings
 from unittest import TestCase
 
 from pytest import mark
@@ -31,7 +29,7 @@ class MyConfigurable(Configurable):
     c = Unicode('no config')
 
 
-mc_help=u"""MyConfigurable(Configurable) options
+mc_help = u"""MyConfigurable(Configurable) options
 ------------------------------------
 --MyConfigurable.a=<Integer>
     The integer a.
@@ -426,26 +424,24 @@ class TestParentConfigurable(TestCase):
 
     def test_multi_parent_priority(self):
         cfg = Config({
-            'MyConfigurable' : {
-                'b' : 2.0,
+            'MyConfigurable': {
+                'b': 2.0,
             },
-            'MyParent' : {
-                'MyConfigurable' : {
-                    'b' : 3.0,
-                }
+            'MyParent': {
+                'MyConfigurable': {
+                    'b': 3.0,
+                },
             },
-            'MyParent2' : {
-                'MyConfigurable' : {
-                    'b' : 4.0,
-                }
+            'MyParent2': {
+                'MyConfigurable': {
+                    'b': 4.0,
+                },
+                'MyParent': {
+                    'MyConfigurable': {
+                        'b': 5.0,
+                    },
+                },
             },
-            'MyParent2' : {
-                'MyParent' : {
-                    'MyConfigurable' : {
-                        'b' : 5.0,
-                    }
-                }
-            }
         })
         parent2 = MyParent2(config=cfg)
         parent = MyParent2(parent=parent2)

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -21,15 +21,12 @@ from traitlets.config.loader import (
     KeyValueConfigLoader,
     ArgParseConfigLoader,
     KVArgParseConfigLoader,
-    ConfigError,
 )
 from traitlets import (
     HasTraits,
-    Union,
     List,
     Tuple,
     Dict,
-    Int,
     Unicode,
     Integer,
 )

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -316,17 +316,6 @@ class TestKeyValueCL(TestCase):
         print(config)
         self.assertEqual(config.a, u'épsîlön')
 
-    def test_unicode_bytes_args(self):
-        uarg = u'--a=é'
-        try:
-            barg = uarg.encode(sys.stdin.encoding)
-        except (TypeError, UnicodeEncodeError):
-            raise skip("sys.stdin.encoding can't handle 'é'")
-
-        cl = self.klass(log=log)
-        config = cl.load_config([barg])
-        self.assertEqual(config.a, u'é')
-
     def test_list_append(self):
         cl = self.klass(log=log)
         argv = ["--C.list_trait", "x", "--C.list_trait", "y"]

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -355,6 +355,20 @@ class CSub(CBase):
 class TestArgParseKVCL(TestKeyValueCL):
     klass = KVArgParseConfigLoader
 
+    def test_no_cast_literals(self):
+        cl = self.klass(log=log)
+        # test ipython -c 1 doesn't cast to int
+        argv = ["-c", "1"]
+        config = cl.load_config(argv, aliases=dict(c="IPython.command_to_run"))
+        assert config.IPython.command_to_run == "1"
+
+    def test_int_literals(self):
+        cl = self.klass(log=log)
+        # test ipython -c 1 doesn't cast to int
+        argv = ["-c", "1"]
+        config = cl.load_config(argv, aliases=dict(c="IPython.command_to_run"))
+        assert config.IPython.command_to_run == "1"
+
     def test_unicode_alias(self):
         cl = self.klass(log=log)
         argv = [u'--a=épsîlön']

--- a/traitlets/tests/_warnings.py
+++ b/traitlets/tests/_warnings.py
@@ -95,7 +95,7 @@ def expected_warnings(matching):
         # enter context
         yield w
         # exited user context, check the recorded warnings
-        remaining = [m for m in matching if not '\A\Z' in m.split('|')]
+        remaining = [m for m in matching if not r'\A\Z' in m.split('|')]
         for warn in w:
             found = False
             for match in matching:

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -17,12 +17,49 @@ import pytest
 from pytest import mark
 
 from traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, CInt, Long, CLong, Integer, Float, CFloat, Complex, Bytes, Unicode,
-    TraitError, Union, Callable, All, Undefined, Type, This, Instance, TCPAddress,
-    List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
-    ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
-    observe_compat, BaseDescriptor, HasDescriptors,
+    HasTraits,
+    MetaHasTraits,
+    TraitType,
+    Any,
+    Bool,
+    CBytes,
+    Dict,
+    Enum,
+    Int,
+    CInt,
+    Long,
+    CLong,
+    Integer,
+    Float,
+    CFloat,
+    Complex,
+    Bytes,
+    Unicode,
+    TraitError,
+    Union,
+    Callable,
+    All,
+    Undefined,
+    Type,
+    This,
+    Instance,
+    TCPAddress,
+    List,
+    Tuple,
+    ObjectName,
+    DottedObjectName,
+    CRegExp,
+    link,
+    directional_link,
+    ForwardDeclaredType,
+    ForwardDeclaredInstance,
+    validate,
+    observe,
+    default,
+    observe_compat,
+    BaseDescriptor,
+    HasDescriptors,
+    CUnicode,
 )
 
 def change_dict(*ordered_values):
@@ -102,7 +139,7 @@ class TestTraitType(TestCase):
 
     def test_error(self):
         class A(HasTraits):
-            tt = TraitType
+            tt = TraitType()
         a = A()
         self.assertRaises(TraitError, A.tt.error, a, 10)
 
@@ -2624,14 +2661,18 @@ def _from_string_test(traittype, s, expected):
         assert value == expected
 
 
-@pytest.mark.parametrize('s, expected', [
-    ('xyz', 'xyz'),
-    ('1', '1'),
-    ('"xx"', '"xx"'),
-    ("'abc'", "'abc'"),
-])
+@pytest.mark.parametrize(
+    "s, expected", [("xyz", "xyz"), ("1", "1"), ('"xx"', "xx"), ("'abc'", "abc"),]
+)
 def test_unicode_from_string(s, expected):
     _from_string_test(Unicode, s, expected)
+
+
+@pytest.mark.parametrize(
+    "s, expected", [("xyz", "xyz"), ("1", "1"), ('"xx"', "xx"), ("'abc'", "abc"),]
+)
+def test_cunicode_from_string(s, expected):
+    _from_string_test(CUnicode, s, expected)
 
 
 @pytest.mark.parametrize('s, expected', [

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2596,6 +2596,7 @@ def test_override_default_instance():
     c._a_default = lambda self: 'overridden'
     assert c.a == 'overridden'
 
+
 def test_copy_HasTraits():
     from copy import copy
 
@@ -2609,3 +2610,115 @@ def test_copy_HasTraits():
     cc.a = 2
     assert cc.a == 2
     assert c.a == 1
+
+
+def _from_string_test(traittype, s, expected):
+    """Run a test of trait.from_string"""
+    trait = traittype()
+    if type(expected) is type and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            value = trait.from_string(s)
+            trait.validate(None, value)
+    else:
+        value = trait.from_string(s)
+        assert value == expected
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('xyz', 'xyz'),
+    ('1', '1'),
+    ('"xx"', '"xx"'),
+    ("'abc'", "'abc'"),
+])
+def test_unicode_from_string(s, expected):
+    _from_string_test(Unicode, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', ValueError),
+    ('1', 1),
+    ('123', 123),
+    ('2.0', ValueError),
+])
+def test_int_from_string(s, expected):
+    _from_string_test(Integer, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', ValueError),
+    ('1', 1.0),
+    ('123.5', 123.5),
+    ('2.5', 2.5),
+])
+def test_float_from_string(s, expected):
+    _from_string_test(Float, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', ValueError),
+    ('1', 1.0),
+    ('123.5', 123.5),
+    ('2.5', 2.5),
+    ('1+2j', 1+2j),
+])
+def test_complex_from_string(s, expected):
+    _from_string_test(Complex, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('true', True),
+    ('TRUE', True),
+    ('1', True),
+    ('0', False),
+    ('False', False),
+    ('false', False),
+    ('1.0', ValueError),
+])
+def test_bool_from_string(s, expected):
+    _from_string_test(Bool, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('{}', {}),
+    ('[]', TraitError),
+    ('1', TraitError),
+    ('1/0', TraitError),
+    ('{1: 2}', {1: 2}),
+    ('{"key": "value"}', {"key": "value"}),
+    ('x', TraitError),
+])
+def test_dict_from_string(s, expected):
+    _from_string_test(Dict, s, expected)
+
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('[]', []),
+    ('[1, 2, "x"]', [1, 2, 'x']),
+    ('{}', TraitError),
+    ('1', TraitError),
+    ('1/0', TraitError),
+    ('x', TraitError),
+])
+def test_list_from_string(s, expected):
+    _from_string_test(List, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('x', 'x'),
+    ('mod.submod', 'mod.submod'),
+    ('not an identifier', TraitError),
+    ('1', '1'),
+])
+def test_object_from_string(s, expected):
+    _from_string_test(DottedObjectName, s, expected)
+
+
+@pytest.mark.parametrize('s, expected', [
+    ('127.0.0.1:8000', ('127.0.0.1', 8000)),
+    ('host.tld:80', ('host.tld', 80)),
+    ('host:notaport', ValueError),
+    ('127.0.0.1', ValueError),
+])
+def test_tcp_from_string(s, expected):
+    _from_string_test(TCPAddress, s, expected)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1865,7 +1865,7 @@ class Instance(ClassBasedTraitType):
         return repr(self.make_dynamic_default())
 
     def from_string(self, s):
-        return literal_eval(s)
+        return _safe_literal_eval(s)
 
 
 class ForwardDeclaredMixin(object):
@@ -2221,7 +2221,7 @@ class Bool(TraitType):
         elif s in {'false', '0'}:
             return False
         else:
-            self.error(obj, s)
+            raise ValueError("%r is not 1, 0, true, or false")
 
 
 class CBool(Bool):
@@ -2834,7 +2834,7 @@ class TCPAddress(TraitType):
 
     def from_string(self, s):
         if ':' not in s:
-            self.error(obj, s)
+            raise ValueError('Require `ip:port`, got %r' % s)
         ip, port = s.split(':', 1)
         port = int(port)
         return (ip, port)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2889,7 +2889,11 @@ class Dict(Instance):
 
         This is where we parse CLI configuration
         """
-        if len(s_list) == 1 and s_list[0].startswith("{") and s_list[0].startswith("}"):
+        if (
+            len(s_list) == 1
+            and s_list[0].startswith("{")
+            and s_list[0].endswith("}")
+        ):
             warn(
                 "--{0}={1} for dict-traits is deprecated in traitlets 5.0. "
                 "You can pass --{0} <key=value> ... multiple times to add items to a dict.".format(

--- a/traitlets/utils/descriptions.py
+++ b/traitlets/utils/descriptions.py
@@ -8,7 +8,7 @@ def describe(article, value, name=None, verbose=False, capital=False):
 
     Parameters
     ----------
-    article: str or None
+    article : str or None
         A definite or indefinite article. If the article is
         indefinite (i.e. "a" or "an") the appropriate one
         will be infered. Thus, the arguments of ``describe``
@@ -17,18 +17,18 @@ def describe(article, value, name=None, verbose=False, capital=False):
         will be prepended to the result. For non-articled
         description, values that are instances are treated
         definitely, while classes are handled indefinitely.
-    value: any
+    value : any
         The value which will be named.
-    name: str or None (default: None)
+    name : str or None (default: None)
         Only applies when ``article`` is "the" - this
         ``name`` is a definite reference to the value.
         By default one will be infered from the value's
         type and repr methods.
-    verbose: bool (default: False)
+    verbose : bool (default: False)
         Whether the name should be concise or verbose. When
         possible, verbose names include the module, and/or
         class name where an object was defined.
-    capital: bool (default: False)
+    capital : bool (default: False)
         Whether the first letter of the article should
         be capitalized or not. By default it is not.
 
@@ -137,11 +137,11 @@ def add_article(name, definite=False, capital=False):
 
     Parameters
     ----------
-    definite: bool (default: False)
+    definite : bool (default: False)
         Whether the article is definite or not.
         Indefinite articles being 'a' and 'an',
         while 'the' is definite.
-    capital: bool (default: False)
+    capital : bool (default: False)
         Whether the added article should have
         its first letter capitalized or not.
     """

--- a/traitlets/utils/tests/test_importstring.py
+++ b/traitlets/utils/tests/test_importstring.py
@@ -25,5 +25,5 @@ class TestImportItem(TestCase):
             "import_item accepts strings, "
             "not '%s'." % NotAString
         )
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             import_item(NotAString())


### PR DESCRIPTION
Re-issue of long-idle #441

The key to this PR is deferring the parsing of strings from the CLI to trait objects themselves, to avoid inconsistency when

This is attempting to resolve an inconsistency in the improved argparse handling for container traits, where a list trait can be specified in the argparse list way of giving the flag multiple times:

```
command -l x -l y
# or
command --Class.list_trait x --Class.list_trait y
```

which results in `Class.list_trait = ['x', 'y']`

The main issue with master is summarized [here](https://github.com/ipython/traitlets/pull/441#issuecomment-323811638):

>  There are three cases: `--short` aliases, `--Class.trait` in the classes list, and `--Class.trait` not in the classes list.

The new handling works for `--short` and when `Class` is in the classes list, but *not* when `Class` is not in the explicit Application.classes list (e.g. an IPython extension). This PR so far improves handling of scalars (solving the longstanding `ipython -c 1` bug), but container traits have been the sticky part.

TODO:

- [x] add TraitType.from_string
- [x] define from_string for simple scalars
- [x] use trait.from_string to evaluate CLI strings at config-loading time instead of CLI-parsing time
- [x] define from_string for container traits (`item_from_string`?)
- [x] make `--Class.trait x --Class.trait y` produce the same config regardless of `Application.classes`
- [x] test confirming above
- [ ] test some sensible Union cases