### PR TITLE
nicer falsy behavior for LazyConfigValue

### DIFF
--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -361,6 +361,9 @@ class Config(dict):
         except KeyError as e:
             raise AttributeError(e)
 
+    def __repr__(self):
+        return 'Config('+super().__repr__()+')'
+
 
 #-----------------------------------------------------------------------------
 # Config loading classes

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -485,7 +485,10 @@ class TestConfig(TestCase):
         self.assertNotIn('foo', cfg)
         foo = cfg.foo
         assert isinstance(foo, LazyConfigValue)
-        self.assertIn('foo', cfg)
+        # empty lazy value indicates no config is actually there
+        assert 'foo' not in cfg
+        foo.append('x')
+        assert 'foo' in cfg
 
     def test_lazy_truthiness(self):
         cfg = Config()
@@ -537,7 +540,10 @@ class TestConfig(TestCase):
         self.assertNotIn('foo', cfg)
         foo = cfg['foo']
         assert isinstance(foo, LazyConfigValue)
-        self.assertIn('foo', cfg)
+        # empty lazy value indicates no config is actually there
+        assert 'foo' not in cfg
+        foo.append('x')
+        assert 'foo' in cfg
 
     def test_merge_no_copies(self):
         c = Config()

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -487,6 +487,30 @@ class TestConfig(TestCase):
         assert isinstance(foo, LazyConfigValue)
         self.assertIn('foo', cfg)
 
+    def test_lazy_truthiness(self):
+        cfg = Config()
+        lazy = cfg.empty_trait
+        assert not lazy
+        assert not cfg.empty_trait
+
+        cfg.append_trait.append('x')
+        assert cfg.append_trait
+
+        cfg.prepend_trait.prepend('x')
+        assert cfg.prepend_trait
+
+        cfg.extend_trait.extend(['x'])
+        assert cfg.extend_trait
+
+        cfg.Class.insert_trait.insert(0, 'x')
+        assert cfg.Class.insert_trait
+
+        cfg.Class.update_trait.update({'key': 'value'})
+        assert cfg.Class.update_trait
+
+        cfg.Class.add_trait.add('item')
+        assert cfg.Class.add_trait
+
     def test_getattr_private_missing(self):
         cfg = Config()
         self.assertNotIn('_repr_html_', cfg)
@@ -507,7 +531,6 @@ class TestConfig(TestCase):
         repr2 = repr(cfg)
         assert repr([0,1]) in repr2
         assert 'value=' in repr2
-
 
     def test_getitem_not_section(self):
         cfg = Config()
@@ -655,3 +678,18 @@ class TestConfig(TestCase):
         c.merge(c2)
 
         self.assertEqual(c.Foo.trait._update, {"a": 1, "z": 26, "b": 1})
+
+    def test_empty_lazy_not_in(self):
+        c = Config()
+        lazy1 = c.Foo.trait
+        # 'in' check looks for *actual* config
+        # so creation of a lazy config handle
+        # doesn't mean we have config there
+        assert 'trait' not in c.Foo
+        # make sure that subsequent lazy access
+        # doesn't create a new LazyConfigValue, though
+        c.Foo.trait.append("x")
+        assert 'trait' in c.Foo
+        assert c.Foo.trait
+        assert lazy1 is c.Foo.trait
+        assert lazy1


### PR DESCRIPTION
- empty lazy config is falsy, non-empty is truthy
- checking `in` for empty lazy config returns False, indicating there's no config there