### PR TITLE
Prepare for an beta1 release.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 license_file = COPYING.md
 

--- a/traitlets/_version.py
+++ b/traitlets/_version.py
@@ -1,2 +1,14 @@
-version_info = (5, 0, 0, 'dev')
-__version__ = '.'.join(map(str, version_info))
+version_info = (5, 0, 0, "b1")
+
+# unlike `.dev`, alpha, beta and rc _must not_ have dots,
+# or the wheel and tgz won't look to pip like the same version.
+
+__version__ = (
+    ".".join(map(str, version_info))
+    .replace(".b", "b")
+    .replace(".a", "a")
+    .replace(".rc", "rc")
+)
+assert ".b" not in __version__
+assert ".a" not in __version__
+assert ".rc" not in __version__


### PR DESCRIPTION
Remove universal wheel (we are Python 3 only anyway)
Bump version with beta1, be careful about the format (with or without
dots)