### PR TITLE
Remove u string prefixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,9 +71,9 @@ if _release['version_info'][-1] == 'dev':
 master_doc = 'index'
 
 # General information about the project.
-project = u'traitlets'
-copyright = u'2015, The IPython Development Team'
-author = u'The IPython Development Team'
+project = 'traitlets'
+copyright = '2015, The IPython Development Team'
+author = 'The IPython Development Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -252,8 +252,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'traitlets.tex', u'traitlets Documentation',
-   u'The IPython Development Team', 'manual'),
+  (master_doc, 'traitlets.tex', 'traitlets Documentation',
+   'The IPython Development Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -282,7 +282,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'traitlets', u'traitlets Documentation',
+    (master_doc, 'traitlets', 'traitlets Documentation',
      [author], 1)
 ]
 
@@ -296,7 +296,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'traitlets', u'traitlets Documentation',
+  (master_doc, 'traitlets', 'traitlets Documentation',
    author, 'traitlets', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -120,7 +120,7 @@ subclass
     from traitlets import Int, Float, Unicode, Bool
 
     class MyClass(Configurable):
-        name = Unicode(u'defaultname'
+        name = Unicode('defaultname'
             help="the name of the object"
         ).tag(config=True)
         ranking = Integer(0, help="the class's ranking").tag(config=True)
@@ -239,11 +239,11 @@ to be reflected in the configuration system.  Here is a simple example::
     from traitlets import Integer, Float, Unicode, Bool
 
     class Foo(Configurable):
-        name = Unicode(u'fooname', config=True)
+        name = Unicode('fooname', config=True)
         value = Float(100.0, config=True)
 
     class Bar(Foo):
-        name = Unicode(u'barname', config=True)
+        name = Unicode('barname', config=True)
         othervalue = Int(0, config=True)
 
 Now, we can create a configuration file to configure instances of :class:`Foo`
@@ -252,7 +252,7 @@ and :class:`Bar`::
     # config file
     c = get_config()
 
-    c.Foo.name = u'bestname'
+    c.Foo.name = 'bestname'
     c.Bar.othervalue = 10
 
 This class hierarchy and configuration file accomplishes the following:

--- a/examples/myapp.py
+++ b/examples/myapp.py
@@ -44,7 +44,7 @@ class Foo(Configurable):
 
     i = Int(0, help="The integer i.").tag(config=True)
     j = Int(1, help="The integer j.").tag(config=True)
-    name = Unicode(u'Brian', help="First name.").tag(config=True, shortname="B")
+    name = Unicode('Brian', help="First name.").tag(config=True, shortname="B")
 
 
 class Bar(Configurable):
@@ -54,11 +54,11 @@ class Bar(Configurable):
 
 class MyApp(Application):
 
-    name = Unicode(u'myapp')
+    name = Unicode('myapp')
     running = Bool(False, 
                    help="Is the app running?").tag(config=True)
     classes = List([Bar, Foo])
-    config_file = Unicode(u'', 
+    config_file = Unicode('',
                    help="Load this config file").tag(config=True)
     
     aliases = Dict(dict(i='Foo.i',j='Foo.j',name='Foo.name', running='MyApp.running',

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -121,11 +121,11 @@ class Application(SingletonConfigurable):
 
     # The name of the application, will usually match the name of the command
     # line application
-    name = Unicode(u'application')
+    name = Unicode('application')
 
     # The description of the application that is printed at the beginning
     # of the help.
-    description = Unicode(u'This is an application.')
+    description = Unicode('This is an application.')
     # default section descriptions
     option_description = Unicode(option_description)
     keyvalue_description = Unicode(keyvalue_description)
@@ -162,7 +162,7 @@ class Application(SingletonConfigurable):
                     yield parent
 
     # The version string of this application.
-    version = Unicode(u'0.0')
+    version = Unicode('0.0')
 
     # the argv used to initialize the application
     argv = List()

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -177,11 +177,11 @@ class Configurable(HasTraits):
                     else:
                         warn = lambda msg: warnings.warn(msg, stacklevel=9)
                     matches = get_close_matches(name, traits)
-                    msg = u"Config option `{option}` not recognized by `{klass}`.".format(
+                    msg = "Config option `{option}` not recognized by `{klass}`.".format(
                         option=name, klass=self.__class__.__name__)
 
                     if len(matches) == 1:
-                        msg += u"  Did you mean `{matches}`?".format(matches=matches[0])
+                        msg += "  Did you mean `{matches}`?".format(matches=matches[0])
                     elif len(matches) >= 1:
                         msg +="  Did you mean one of: `{matches}`?".format(matches=', '.join(sorted(matches)))
                     warn(msg)
@@ -230,8 +230,8 @@ class Configurable(HasTraits):
         assert inst is None or isinstance(inst, cls)
         final_help = []
         base_classes = ', '.join(p.__name__ for p in cls.__bases__)
-        final_help.append(u'%s(%s) options' % (cls.__name__, base_classes))
-        final_help.append(len(final_help[0])*u'-')
+        final_help.append('%s(%s) options' % (cls.__name__, base_classes))
+        final_help.append(len(final_help[0])*'-')
         for k, v in sorted(cls.class_traits(config=True).items()):
             help = cls.class_get_trait_help(v, inst)
             final_help.append(help)

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -54,7 +54,7 @@ class Foo(Configurable):
     Details about i.
     """).tag(config=True)
     j = Integer(1, help="The integer j.").tag(config=True)
-    name = Unicode(u'Brian', help="First name.").tag(config=True)
+    name = Unicode('Brian', help="First name.").tag(config=True)
     la = List([]).tag(config=True)
     li = List(Integer()).tag(config=True)
     fdict = Dict().tag(config=True, multiplicity='+')
@@ -73,12 +73,12 @@ class Bar(Configurable):
 
 class MyApp(Application):
 
-    name = Unicode(u'myapp')
+    name = Unicode('myapp')
     running = Bool(False, help="Is the app running?").tag(config=True)
     classes = List([Bar, Foo])
-    config_file = Unicode(u'', help="Load this config file").tag(config=True)
+    config_file = Unicode('', help="Load this config file").tag(config=True)
 
-    warn_tpyo = Unicode(u"yes the name is wrong on purpose", config=True,
+    warn_tpyo = Unicode("yes the name is wrong on purpose", config=True,
             help="Should print a warning if `MyApp.warn-typo=...` command is passed")
 
     aliases = {}
@@ -140,10 +140,10 @@ class TestApplication(TestCase):
 
     def test_basic(self):
         app = MyApp()
-        self.assertEqual(app.name, u'myapp')
+        self.assertEqual(app.name, 'myapp')
         self.assertEqual(app.running, False)
         self.assertEqual(app.classes, [MyApp, Bar, Foo])
-        self.assertEqual(app.config_file, u'')
+        self.assertEqual(app.config_file, '')
 
     def test_mro_discovery(self):
         app = MyApp()

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -29,7 +29,7 @@ class MyConfigurable(Configurable):
     c = Unicode('no config')
 
 
-mc_help = u"""MyConfigurable(Configurable) options
+mc_help = """MyConfigurable(Configurable) options
 ------------------------------------
 --MyConfigurable.a=<Integer>
     The integer a.
@@ -38,7 +38,7 @@ mc_help = u"""MyConfigurable(Configurable) options
     The integer b.
     Default: 1.0"""
 
-mc_help_inst=u"""MyConfigurable(Configurable) options
+mc_help_inst="""MyConfigurable(Configurable) options
 ------------------------------------
 --MyConfigurable.a=<Integer>
     The integer a.
@@ -66,7 +66,7 @@ class Bar(Foo):
     bdict = Dict().tag(config=True, multiplicity='+')
     bdict_values = Dict({1:'a','0':'b',5:'c'}).tag(config=True, multiplicity='+')
 
-foo_help=u"""Foo(Configurable) options
+foo_help="""Foo(Configurable) options
 -------------------------
 --Foo.a=<Int>
     The integer a.
@@ -78,7 +78,7 @@ foo_help=u"""Foo(Configurable) options
 --Foo.flist=<list-item-1>...
     Default: []"""
 
-bar_help=u"""Bar(Foo) options
+bar_help="""Bar(Foo) options
 ----------------
 --Bar.a=<Int>
     The integer a.

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -83,7 +83,7 @@ class TestFileCL(TestCase):
         self.assertEqual(config.D.C.value, 'hi there')
 
     def test_python(self):
-        fd, fname = mkstemp('.py', prefix=u'μnïcø∂e')
+        fd, fname = mkstemp('.py', prefix='μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write(pyfile)
         f.close()
@@ -93,7 +93,7 @@ class TestFileCL(TestCase):
         self._check_conf(config)
 
     def test_json(self):
-        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
+        fd, fname = mkstemp('.json', prefix='μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write(json1file)
         f.close()
@@ -104,7 +104,7 @@ class TestFileCL(TestCase):
 
     def test_context_manager(self):
 
-        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
+        fd, fname = mkstemp('.json', prefix='μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write('{}')
         f.close()
@@ -123,7 +123,7 @@ class TestFileCL(TestCase):
         self.assertEqual(cl.config.MyAttr.value, value)
 
     def test_json_context_bad_write(self):
-        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
+        fd, fname = mkstemp('.json', prefix='μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write('{}')
         f.close()
@@ -169,7 +169,7 @@ class TestFileCL(TestCase):
         })
 
     def test_v2raise(self):
-        fd, fname = mkstemp('.json', prefix=u'μnïcø∂e')
+        fd, fname = mkstemp('.json', prefix='μnïcø∂e')
         f = os.fdopen(fd, 'w')
         f.write(json2file)
         f.close()
@@ -314,10 +314,10 @@ class TestKeyValueCL(TestCase):
 
     def test_unicode_args(self):
         cl = self.klass(log=log)
-        argv = [u'--a=épsîlön']
+        argv = ['--a=épsîlön']
         config = cl.load_config(argv)
         print(config, cl.extra_args)
-        self.assertEqual(config.a, u'épsîlön')
+        self.assertEqual(config.a, 'épsîlön')
 
     def test_list_append(self):
         cl = self.klass(log=log)
@@ -374,12 +374,12 @@ class TestArgParseKVCL(TestKeyValueCL):
 
     def test_unicode_alias(self):
         cl = self.klass(log=log)
-        argv = [u'--a=épsîlön']
+        argv = ['--a=épsîlön']
         config = cl.load_config(argv, aliases=dict(a='A.a'))
         print(dict(config))
         print(cl.extra_args)
         print(cl.aliases)
-        self.assertEqual(config.A.a, u'épsîlön')
+        self.assertEqual(config.A.a, 'épsîlön')
 
     def test_expanduser2(self):
         cl = self.klass(log=log)
@@ -398,7 +398,7 @@ class TestArgParseKVCL(TestKeyValueCL):
         cl = self.klass(log=log)
         argv = ['-c', 'a=5']
         config = cl.load_config(argv, aliases=dict(c='A.c'))
-        self.assertEqual(config.A.c, u"a=5")
+        self.assertEqual(config.A.c, "a=5")
 
     def test_seq_traits(self):
         cl = self.klass(log=log, classes=(CBase, CSub))

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1229,7 +1229,7 @@ class AnyTraitTest(TraitTestBase):
     obj = AnyTrait()
 
     _default_value = None
-    _good_values   = [10.0, 'ten', u'ten', [10], {'ten': 10},(10,), None, 1j]
+    _good_values   = [10.0, 'ten', [10], {'ten': 10},(10,), None, 1j]
     _bad_values    = []
 
 class UnionTrait(HasTraits):
@@ -1271,9 +1271,9 @@ class TestInt(TraitTestBase):
     obj = IntTrait()
     _default_value = 99
     _good_values   = [10, -10]
-    _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j,
-                      10.1, -10.1, '10L', '-10L', '10.1', '-10.1', u'10L',
-                      u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', -200]
+    _bad_values    = ['ten', [10], {'ten': 10}, (10,), None, 1j,
+                      10.1, -10.1, '10L', '-10L', '10.1', '-10.1',
+                      '10', '-10', -200]
 
 
 class CIntTrait(HasTraits):
@@ -1283,9 +1283,9 @@ class TestCInt(TraitTestBase):
     obj = CIntTrait()
 
     _default_value = 5
-    _good_values   = ['10', '-10', u'10', u'-10', 10, 10.0, -10.0, 10.1]
-    _bad_values    = ['ten', u'ten', [10], {'ten': 10},(10,),
-                      None, 1j, '10.1', u'10.1']
+    _good_values   = ['10', '-10', 10, 10.0, -10.0, 10.1]
+    _bad_values    = ['ten', [10], {'ten': 10},(10,),
+                      None, 1j, '10.1']
 
     def coerce(self, n):
         return int(n)
@@ -1312,10 +1312,9 @@ class TestLong(TraitTestBase):
 
     _default_value = 99
     _good_values   = [10, -10]
-    _bad_values    = ['ten', u'ten', [10], {'ten': 10},(10,),
+    _bad_values    = ['ten', [10], {'ten': 10},(10,),
                       None, 1j, 10.1, -10.1, '10', '-10', '10L', '-10L', '10.1',
-                      '-10.1', u'10', u'-10', u'10L', u'-10L', u'10.1',
-                      u'-10.1']
+                      '-10.1']
 
 
 class MinBoundLongTrait(HasTraits):
@@ -1347,9 +1346,9 @@ class TestCLong(TraitTestBase):
     obj = CLongTrait()
 
     _default_value = 5
-    _good_values   = ['10', '-10', u'10', u'-10', 10, 10.0, -10.0, 10.1]
-    _bad_values    = ['ten', u'ten', [10], {'ten': 10},(10,),
-                      None, 1j, '10.1', u'10.1']
+    _good_values   = ['10', '-10', 10, 10.0, -10.0, 10.1]
+    _bad_values    = ['ten', [10], {'ten': 10},(10,),
+                      None, 1j, '10.1']
 
     def coerce(self, n):
         return int(n)
@@ -1409,9 +1408,8 @@ class TestFloat(TraitTestBase):
 
     _default_value = 99.0
     _good_values   = [10, -10, 10.1, -10.1]
-    _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None,
-                      1j, '10', '-10', '10L', '-10L', '10.1', '-10.1', u'10',
-                      u'-10', u'10L', u'-10L', u'10.1', u'-10.1', 201.0]
+    _bad_values    = ['ten', [10], {'ten': 10}, (10,), None,
+                      1j, '10', '-10', '10L', '-10L', '10.1', '-10.1', 201.0]
 
 
 class CFloatTrait(HasTraits):
@@ -1423,8 +1421,8 @@ class TestCFloat(TraitTestBase):
     obj = CFloatTrait()
 
     _default_value = 99.0
-    _good_values   = [10, 10.0, 10.5, '10.0', '10', '-10', '10.0', u'10']
-    _bad_values    = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j,
+    _good_values   = [10, 10.0, 10.5, '10.0', '10', '-10']
+    _bad_values    = ['ten', [10], {'ten': 10}, (10,), None, 1j,
                       200.1, '200.1']
 
     def coerce(self, v):
@@ -1442,7 +1440,7 @@ class TestComplex(TraitTestBase):
     _default_value = 99.0-99.0j
     _good_values   = [10, -10, 10.1, -10.1, 10j, 10+10j, 10-10j,
                       10.1j, 10.1+10.1j, 10.1-10.1j]
-    _bad_values    = [u'10L', u'-10L', 'ten', [10], {'ten': 10},(10,), None]
+    _bad_values    = ['10L', '-10L', 'ten', [10], {'ten': 10},(10,), None]
 
 
 class BytesTrait(HasTraits):
@@ -1457,22 +1455,22 @@ class TestBytes(TraitTestBase):
     _good_values   = [b'10', b'-10', b'10L',
                       b'-10L', b'10.1', b'-10.1', b'string']
     _bad_values    = [10, -10, 10.1, -10.1, 1j, [10],
-                      ['ten'],{'ten': 10},(10,), None,  u'string']
+                      ['ten'],{'ten': 10},(10,), None,  'string']
 
 
 class UnicodeTrait(HasTraits):
 
-    value = Unicode(u'unicode')
+    value = Unicode('unicode')
 
 class TestUnicode(TraitTestBase):
 
     obj = UnicodeTrait()
 
-    _default_value = u'unicode'
+    _default_value = 'unicode'
     _good_values   = ['10', '-10', '10L', '-10L', '10.1',
-                      '-10.1', '', u'', 'string', u'string', u"€"]
+                      '-10.1', '', 'string', "€"]
     _bad_values    = [10, -10, 10.1, -10.1, 1j,
-                      [10], ['ten'], [u'ten'], {'ten': 10},(10,), None]
+                      [10], ['ten'], {'ten': 10},(10,), None]
 
 
 class ObjectNameTrait(HasTraits):
@@ -1482,10 +1480,10 @@ class TestObjectName(TraitTestBase):
     obj = ObjectNameTrait()
 
     _default_value = "abc"
-    _good_values = ["a", "gh", "g9", "g_", "_G", u"a345_"]
-    _bad_values = [1, "", u"€", "9g", "!", "#abc", "aj@", "a.b", "a()", "a[0]",
+    _good_values = ["a", "gh", "g9", "g_", "_G", "a345_"]
+    _bad_values = [1, "", "€", "9g", "!", "#abc", "aj@", "a.b", "a()", "a[0]",
                                                         None, object(), object]
-    _good_values.append(u"þ")  # þ=1 is valid in Python 3 (PEP 3131).
+    _good_values.append("þ")  # þ=1 is valid in Python 3 (PEP 3131).
 
 
 class DottedObjectNameTrait(HasTraits):
@@ -1495,10 +1493,10 @@ class TestDottedObjectName(TraitTestBase):
     obj = DottedObjectNameTrait()
 
     _default_value = "a.b"
-    _good_values = ["A", "y.t", "y765.__repr__", "os.path.join", u"os.path.join"]
-    _bad_values = [1, u"abc.€", "_.@", ".", ".abc", "abc.", ".abc.", None]
+    _good_values = ["A", "y.t", "y765.__repr__", "os.path.join", "os.path.join"]
+    _bad_values = [1, "abc.€", "_.@", ".", ".abc", "abc.", ".abc.", None]
     
-    _good_values.append(u"t.þ")
+    _good_values.append("t.þ")
 
 
 class TCPAddressTrait(HasTraits):
@@ -1646,7 +1644,7 @@ class TestMultiTuple(TraitTestBase):
 
     _default_value = (99,b'bottles')
     _good_values = [(1,b'a'), (2,b'b')]
-    _bad_values = ((),10, b'a', (1,b'a',3), (b'a',1), (1, u'a'))
+    _bad_values = ((),10, b'a', (1,b'a',3), (b'a',1), (1, 'a'))
 
 class CRegExpTrait(HasTraits):
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1493,7 +1493,7 @@ class TestDottedObjectName(TraitTestBase):
     obj = DottedObjectNameTrait()
 
     _default_value = "a.b"
-    _good_values = ["A", "y.t", "y765.__repr__", "os.path.join", "os.path.join"]
+    _good_values = ["A", "y.t", "y765.__repr__", "os.path.join"]
     _bad_values = [1, "abc.€", "_.@", ".", ".abc", "abc.", ".abc.", None]
     
     _good_values.append("t.þ")

--- a/traitlets/utils/tests/test_importstring.py
+++ b/traitlets/utils/tests/test_importstring.py
@@ -14,9 +14,9 @@ from ..importstring import import_item
 class TestImportItem(TestCase):
 
     def test_import_unicode(self):
-        self.assertIs(os, import_item(u'os'))
-        self.assertIs(os.path, import_item(u'os.path'))
-        self.assertIs(os.path.join, import_item(u'os.path.join'))
+        self.assertIs(os, import_item('os'))
+        self.assertIs(os.path, import_item('os.path'))
+        self.assertIs(os.path.join, import_item('os.path.join'))
 
     def test_bad_input(self):
         class NotAString(object):


### PR DESCRIPTION
This PR removes the `u` prefixes on strings. The prefixes dont do anything on Python 3 and they are unnecessary noise in the code. 

Note that this PR is one PR in a series of PRs that aim to remove Python 2 support from the code base. This PR has been standalone given the volume of changes and to aid in the review process.