### PR TITLE
update cast_unicode to use Python 3 decode method

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -61,6 +61,8 @@ from traitlets import (
     HasDescriptors,
     CUnicode,
 )
+from traitlets.utils import cast_unicode
+
 
 def change_dict(*ordered_values):
     change_names = ('name', 'old', 'new', 'owner', 'type')
@@ -1462,15 +1464,19 @@ class UnicodeTrait(HasTraits):
 
     value = Unicode('unicode')
 
+
 class TestUnicode(TraitTestBase):
 
     obj = UnicodeTrait()
 
     _default_value = 'unicode'
     _good_values   = ['10', '-10', '10L', '-10L', '10.1',
-                      '-10.1', '', 'string', "€"]
+                      '-10.1', '', 'string', "€", b"bytestring"]
     _bad_values    = [10, -10, 10.1, -10.1, 1j,
                       [10], ['ten'], {'ten': 10},(10,), None]
+
+    def coerce(self, v):
+        return cast_unicode(v)
 
 
 class ObjectNameTrait(HasTraits):
@@ -1495,7 +1501,7 @@ class TestDottedObjectName(TraitTestBase):
     _default_value = "a.b"
     _good_values = ["A", "y.t", "y765.__repr__", "os.path.join"]
     _bad_values = [1, "abc.€", "_.@", ".", ".abc", "abc.", ".abc.", None]
-    
+
     _good_values.append("t.þ")
 
 

--- a/traitlets/utils/__init__.py
+++ b/traitlets/utils/__init__.py
@@ -1,6 +1,6 @@
 
 # vestigal things from IPython_genutils.
-def cast_unicode(s, encoding=None):
+def cast_unicode(s, encoding='utf-8'):
     if isinstance(s, bytes):
-        return decode(s, encoding)
+        return s.decode(encoding, 'replace')
     return s


### PR DESCRIPTION
Fixes ipython/ipykernel#543.

`traitlets.utils` was still pointing at an old `decode` function from `ipython_genutils`. Here, I'm updating it to use Python 3's sting decode method.