### PR TITLE
handle deprecated eval syntax for Bytes on the command-line

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2690,6 +2690,22 @@ def test_cunicode_from_string(s, expected):
 
 @pytest.mark.parametrize(
     "s, expected",
+    [("xyz", b"xyz"), ("1", b"1"), ('b"xx"', b"xx"), ("b'abc'", b"abc"), ("None", None)],
+)
+def test_bytes_from_string(s, expected):
+    _from_string_test(Bytes, s, expected)
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [("xyz", b"xyz"), ("1", b"1"), ('b"xx"', b"xx"), ("b'abc'", b"abc"), ("None", None)],
+)
+def test_cbytes_from_string(s, expected):
+    _from_string_test(CBytes, s, expected)
+
+
+@pytest.mark.parametrize(
+    "s, expected",
     [("x", ValueError), ("1", 1), ("123", 123), ("2.0", ValueError), ("None", None)],
 )
 def test_int_from_string(s, expected):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2139,9 +2139,20 @@ class Bytes(TraitType):
         self.error(obj, value)
 
     def from_string(self, s):
-        if self.allow_none and s == 'None':
+        if self.allow_none and s == "None":
             return None
-        return s.encode('utf8')
+        if len(s) >= 3:
+            # handle deprecated b"string"
+            for quote in ('"', "'"):
+                if s[:2] == f"b{quote}" and s[-1] == quote:
+                    old_s = s
+                    s = s[2:-1]
+                    warn(
+                        "Supporting extra quotes around Bytes is deprecated in traitlets 5.0. "
+                        "Use %r instead of %r." % (s, old_s),
+                        FutureWarning)
+                    break
+        return s.encode("utf8")
 
 
 class CBytes(Bytes):


### PR DESCRIPTION
closes ipython/ipykernel#543
closes #608