### PR TITLE
allow LoggerAdapter in Application.log

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -13,6 +13,7 @@ import os
 import pprint
 import re
 import sys
+import warnings
 
 from traitlets.config.configurable import Configurable, SingletonConfigurable
 from traitlets.config.loader import (
@@ -199,7 +200,13 @@ class Application(SingletonConfigurable):
     @observe_compat
     def _log_format_changed(self, change):
         """Change the log formatter when log_format is set."""
-        _log_handler = self.log.handlers[0]
+        _log_handler = self._get_log_handler()
+        if not _log_handler:
+            warnings.warn(
+                f"No Handler found on {self.log}, setting log_format will have no effect",
+                RuntimeWarning,
+            )
+            return
         _log_formatter = self._log_formatter_cls(fmt=self.log_format, datefmt=self.log_datefmt)
         _log_handler.setFormatter(_log_formatter)
 

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 
 from pytest import mark
 
+from traitlets.config.application import Application
 from traitlets.config.configurable import (
     Configurable,
     LoggingConfigurable,
@@ -666,3 +667,14 @@ class TestLogger(TestCase):
         self.assertIn('Config option `totally_wrong` not recognized by `A`.', output)
         self.assertNotIn('Did you mean', output)
 
+    def test_logger_adapter(self):
+        logger = logging.getLogger("test_logger_adapter")
+        adapter = logging.LoggerAdapter(logger, {"key": "adapted"})
+
+        with self.assertLogs(logger, logging.INFO) as captured:
+            app = Application(log=adapter, log_level=logging.INFO)
+            app.log_format = "%(key)s %(message)s"
+            app.log.info("test message")
+
+        output = "\n".join(captured.output)
+        assert "adapted test message" in output


### PR DESCRIPTION
Relax Instance type check to a warning to allow for duck typing, and handle LoggerAdapter when setting `Application.log_format`.

Individual Applications may still make assumptions that Application.log is a Logger and not a LoggerAdapter, but this is probably rare.

closes #606