### PR TITLE
Fix docs for trait_has_value

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,8 @@ Any class with trait attributes must inherit from :class:`HasTraits`.
 
    .. automethod:: has_trait
 
+   .. automethod:: trait_has_value
+
    .. automethod:: trait_names
 
    .. automethod:: class_trait_names

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1504,6 +1504,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         Example
 
         .. code-block:: python
+
             class MyClass(HasTraits):
                 i = Int()
 


### PR DESCRIPTION
`code-block` directive needs a blank line following it, otherwise it fails and produces a warning. This also adds this method to the API docs.