### PR TITLE
closes: #622

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - 3.7
 install:
   - pip install --upgrade pip
-  - pip install pep517
-  - python -m pep517.build .
+  - pip install build
+  - python -m build .
   - pip install dist/traitlets*.whl
   - pip install --pre --upgrade traitlets[test] pytest pytest-cov codecov
   - test -z ${TEST_DEPS} || pip install --upgrade ${TEST_DEPS}

--- a/README.md
+++ b/README.md
@@ -157,6 +157,6 @@ of the HasTraits instance.
 ### Release build:
 
 ```bash
-$ pip install pep517
-$ python -m pep517.build .
+$ pip install build
+$ python -m build .
 ```


### PR DESCRIPTION
pep517.build is deprecated

see: https://github.com/pypa/pep517/pull/83