### PR TITLE
allow from_string to be specified via metadata

### DIFF
--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import sys
+from binascii import a2b_hex
 from io import StringIO
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -627,6 +628,25 @@ class TestApplication(TestCase):
             app.load_config_file(name, path=[td1])
             self.assertEqual(len(app.loaded_config_files), 1)
             self.assertEqual(app.running, False)
+
+
+def test_custom_from_string():
+    path_items = sys.path[:5]
+
+    path_str = os.pathsep.join(path_items)
+
+    def from_path_string(s):
+        return s.split(os.pathsep)
+
+    class App(Application):
+        path = List().tag(config=True, from_string=from_path_string)
+        hex = Bytes().tag(config=True, from_string=a2b_hex)
+        aliases = {"path": "App.path", "hex": "App.hex"}
+
+    app = App()
+    app.parse_command_line(["--path", path_str, "--hex", "a1b2"])
+    assert app.path == path_items
+    assert app.hex == b"\xa1\xb2"
 
 
 def test_cli_multi_scalar(caplog):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -720,12 +720,29 @@ class TraitType(BaseDescriptor):
 
         >>> Int(0).tag(config=True, sync=True)
         """
-        maybe_constructor_keywords = set(metadata.keys()).intersection({'help','allow_none', 'read_only', 'default_value'})
+        maybe_constructor_keywords = set(metadata.keys()).intersection(
+            {"help", "allow_none", "read_only", "default_value"}
+        )
         if maybe_constructor_keywords:
             warn('The following attributes are set in using `tag`, but seem to be constructor keywords arguments: %s '%
                     maybe_constructor_keywords, UserWarning, stacklevel=2)
 
         self.metadata.update(metadata)
+
+        # allow from_string to be overridden via metadata
+        if self.metadata.get("from_string"):
+            self.from_string = self.metadata["from_string"]
+            if (not self.metadata.get("from_string_list")) and getattr(
+                self, "from_string_list", None
+            ):
+                self.from_string_list = None
+                # from_string overridden, from_string_list inherited and not overridden
+                # ensure inherited from_string_list does not take priority over our new from_string
+                # by removing it
+
+        if self.metadata.get("from_string_list"):
+            self.from_string_list = self.metadata["from_string_list"]
+
         return self
 
     def default_value_repr(self):


### PR DESCRIPTION
avoids need to define custom Trait subclasses just to define how strings are parsed, e.g.

```python
class C(Configurable):
    path = List().tag(config=True, from_string=os.pathsep.split)
```