### PR TITLE
Fix error configuring nested tuple

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -279,7 +279,7 @@ class Configurable(HasTraits):
             lines.append(indent('Choices: %s' % trait.info()))
 
         if inst is not None:
-            lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))
+            lines.append(indent('Current: %r' % (getattr(inst, trait.name),), 4))
         else:
             try:
                 dvr = trait.default_value_repr()


### PR DESCRIPTION
Adding configuration to a nested tuple in IPython and running `%config RelevantClassName` caused `TypeError: not all arguments converted during string formatting`. This wraps any argument in a one element tuple and prevents the error.