### PR TITLE
improve backward-compatibility for Container subclasses with default_value=None

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1686,6 +1686,26 @@ def test_default_value(Trait, default_value):
     assert c.t == default_value
 
 
+@pytest.mark.parametrize(
+    "Trait, default_value",
+    ((List, []), (Tuple, ()), (Set, set())),
+)
+def test_subclass_default_value(Trait, default_value):
+    """Test deprecated default_value=None behavior for Container subclass traits"""
+
+    class SubclassTrait(Trait):
+        def __init__(self, default_value=None):
+            super().__init__(default_value=default_value)
+
+    class C(HasTraits):
+        t = SubclassTrait()
+
+    # test default value
+    c = C()
+    assert type(c.t) is type(default_value)
+    assert c.t == default_value
+
+
 class CRegExpTrait(HasTraits):
 
     value = CRegExp(r'')


### PR DESCRIPTION
fixes failures caused by #630 in subclasses of Container that had the same `default_value=None` signature, preserving behavior unless `allow_none=True` is given explicitly

cf https://github.com/jupyterhub/jupyterhub/pull/3208