### PR TITLE
stop recommending CUnicode for redundant-quotes

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2194,8 +2194,8 @@ class Unicode(TraitType):
                     old_s = s
                     s = s[1:-1]
                     warn(
-                        "Supporting extra quotes around Unicode is deprecated in traitlets 5.0. "
-                        "Use %r instead of %r – or use CUnicode." % (s, old_s),
+                        "Supporting extra quotes around strings is deprecated in traitlets 5.0. "
+                        "You can use %r instead of %r if you require traitlets >=5." % (s, old_s),
                         FutureWarning)
         return s
 


### PR DESCRIPTION
it's not actually a valid solution to the problem, and not a good recommendation

cf jupyter/jupyter_server#306