### PR TITLE
speed up setting attributes

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -616,12 +616,15 @@ class TraitType(BaseDescriptor):
         if self.name in obj._trait_validators:
             proposal = Bunch({'trait': self, 'value': value, 'owner': obj})
             value = obj._trait_validators[self.name](obj, proposal)
-        elif hasattr(obj, '_%s_validate' % self.name):
-            meth_name = '_%s_validate' % self.name
-            cross_validate = getattr(obj, meth_name)
-            _deprecated_method(cross_validate, obj.__class__, meth_name,
-                "use @validate decorator instead.")
-            value = cross_validate(value, self)
+        else:
+            if self.name not in obj._magic_trait_notifiers_found:
+                obj._magic_trait_notifiers_found[self.name] = hasattr(obj, '_%s_validate' % self.name)
+            if obj._magic_trait_notifiers_found[self.name]:
+                meth_name = '_%s_validate' % self.name
+                cross_validate = getattr(obj, meth_name)
+                _deprecated_method(cross_validate, obj.__class__, meth_name,
+                    "use @validate decorator instead.")
+                value = cross_validate(value, self)
         return value
 
     def __or__(self, other):
@@ -1063,6 +1066,8 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         self._trait_values = {}
         self._trait_notifiers = {}
         self._trait_validators = {}
+        # keep track which magic trait notifier is found and not
+        self._magic_trait_notifiers_found = dict()
         super(HasTraits, self).setup_instance(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):
@@ -1213,7 +1218,17 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
                     for change in changes:
                         self.notify_change(change)
 
+    def _may_have_observer_for_name(self, name):
+        if self._trait_notifiers:
+            return True
+        if name not in self._magic_trait_notifiers_found:
+            magic_name = '_%s_changed' % name
+            self._magic_trait_notifiers_found[name] = hasattr(self, magic_name)
+        return self._magic_trait_notifiers_found[name]
+
     def _notify_trait(self, name, old_value, new_value):
+        if not self._may_have_observer_for_name(name):
+            return
         self.notify_change(Bunch(
             name=name,
             old=old_value,
@@ -1228,6 +1243,12 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
 
     def _notify_observers(self, event):
         """Notify observers of any event"""
+        if not isinstance(event, Bunch):
+            name = event['name']
+        else:
+            name = event.name
+        if not self._may_have_observer_for_name(name):
+            return
         if not isinstance(event, Bunch):
             # cast to bunch if given a dict
             event = Bunch(event)


### PR DESCRIPTION
Setting an attribute on a trait is slow, because we always trigger callbacks, even when they are not there. This speeds it up by 3x.

Before:
```
------------------------------------------------- benchmark: 1 tests ------------------------------------------------
Name (time in us)           Min      Max    Mean  StdDev  Median     IQR   Outliers  OPS (Kops/s)  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------
test_performance_set     5.5110  94.8380  6.9445  2.8176  6.0430  0.2957  3040;3721      143.9978   21575           1
---------------------------------------------------------------------------------------------------------------------
```

After:
```
------------------------------------------------- benchmark: 1 tests ------------------------------------------------
Name (time in us)           Min      Max    Mean  StdDev  Median     IQR   Outliers  OPS (Kops/s)  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------
test_performance_set     1.8560  89.3450  2.2384  1.3132  2.0570  0.0880  2200;2725      446.7546   37368           1
---------------------------------------------------------------------------------------------------------------------
```

