### PR TITLE
Add ability to set a trait link directly

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -2024,7 +2024,7 @@ class TestLink(TestCase):
             a = Int()
 
         x1 = A()
-        x2 = A(a = SourceLink(x1, "a", (lambda x: x+1, lambda x: x-1)))
+        x2 = A(a = SourceLink(x1, "a", transform=(lambda x: x+1, lambda x: x-1)))
         x1.a = 3
         self.assertEqual(x2.a, 4)
         x2.a = 1
@@ -2120,6 +2120,17 @@ class TestDirectionalLink(TestCase):
         self.assertEqual(a.value, b.value)
         a.value += 1
         self.assertEqual(a.value, b.value)
+
+    def test_source_directional_link(self):
+        class A(HasTraits):
+            a = Int()
+
+        x1 = A()
+        x2 = A(a = SourceLink(x1, "a", link_type=directional_link, transform=lambda x: x+1))
+        x1.a = 3
+        self.assertEqual(x2.a, 4)
+        x2.a = 1
+        self.assertEqual(x1.a, 3)
 
 class Pickleable(HasTraits):
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -60,7 +60,7 @@ from traitlets import (
     BaseDescriptor,
     HasDescriptors,
     CUnicode,
-)
+    SourceLink)
 from traitlets.utils import cast_unicode
 
 
@@ -2018,6 +2018,17 @@ class TestLink(TestCase):
         mc = MyClass()
         l = link((mc, "i"), (mc, "j"))
         self.assertRaises(TraitError, setattr, mc, 'j', 2)
+
+    def test_source_link(self):
+        class A(HasTraits):
+            a = Int()
+
+        x1 = A()
+        x2 = A(a = SourceLink(x1, "a", (lambda x: x+1, lambda x: x-1)))
+        x1.a = 3
+        self.assertEqual(x2.a, 4)
+        x2.a = 1
+        self.assertEqual(x1.a, 0)
 
 class TestDirectionalLink(TestCase):
     def test_connect_same(self):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -39,21 +39,21 @@ Inheritance diagram:
 # Adapted from enthought.traits, Copyright (c) Enthought, Inc.,
 # also under the terms of the Modified BSD License.
 
-from ast import literal_eval
 import contextlib
+import enum
 import inspect
 import os
 import re
 import sys
 import types
-import enum
+from ast import literal_eval
 from warnings import warn, warn_explicit
 
+from .utils.bunch import Bunch
+from .utils.descriptions import describe, class_of, add_article, repr_type
 from .utils.getargspec import getargspec
 from .utils.importstring import import_item
 from .utils.sentinel import Sentinel
-from .utils.bunch import Bunch
-from .utils.descriptions import describe, class_of, add_article, repr_type
 
 SequenceTypes = (list, tuple, set, frozenset)
 
@@ -81,6 +81,7 @@ __all__ = [
     "BaseDescriptor",
     "TraitType",
     "parse_notifier_name",
+    "SourceLink"
 ]
 
 # any TraitType subclass (that doesn't start with _) will be added automatically
@@ -245,6 +246,14 @@ def _validate_link(*tuples):
             raise TypeError("Each object must be HasTraits, not %r" % type(obj))
         if not trait_name in obj.traits():
             raise TypeError("%r has no trait %r" % (obj, trait_name))
+
+
+class SourceLink:
+    def __init__(self, obj, attr, transform = None):
+        self.obj = obj
+        self.attr = attr
+        self.transform = transform
+
 
 class link(object):
     """Link traits from different objects together so they remain in sync.
@@ -600,6 +609,8 @@ class TraitType(BaseDescriptor):
         """
         if self.read_only:
             raise TraitError('The "%s" trait is read-only.' % self.name)
+        elif isinstance(value, SourceLink):
+            link((value.obj, value.attr), (obj, self.name), transform=value.transform)
         else:
             self.set(obj, value)
 
@@ -730,6 +741,7 @@ class TraitType(BaseDescriptor):
 
     def default_value_repr(self):
         return repr(self.default_value)
+
 
 #-----------------------------------------------------------------------------
 # The HasTraits implementation

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -248,13 +248,6 @@ def _validate_link(*tuples):
             raise TypeError("%r has no trait %r" % (obj, trait_name))
 
 
-class SourceLink:
-    def __init__(self, obj, attr, transform = None):
-        self.obj = obj
-        self.attr = attr
-        self.transform = transform
-
-
 class link(object):
     """Link traits from different objects together so they remain in sync.
 
@@ -373,6 +366,14 @@ class directional_link(object):
         self.source[0].unobserve(self._update, names=self.source[1])
 
 dlink = directional_link
+
+
+class SourceLink:
+    def __init__(self, obj, attr, link_type=link, transform=None):
+        self.obj = obj
+        self.attr = attr
+        self.link_type = link_type
+        self.transform = transform
 
 
 #-----------------------------------------------------------------------------
@@ -610,7 +611,7 @@ class TraitType(BaseDescriptor):
         if self.read_only:
             raise TraitError('The "%s" trait is read-only.' % self.name)
         elif isinstance(value, SourceLink):
-            link((value.obj, value.attr), (obj, self.name), transform=value.transform)
+            value.link_type((value.obj, value.attr), (obj, self.name), transform=value.transform)
         else:
             self.set(obj, value)
 


### PR DESCRIPTION
Proposed change to allow setting of a link directly on a trait property, rather than needing to use an explicit link between target and source.
Closes #641 