### PR TITLE
Update README URL for the Traits library

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Traitlets is a pure Python library enabling:
 
 Its implementation relies on the [descriptor](https://docs.python.org/howto/descriptor.html)
 pattern, and it is a lightweight pure-python alternative of the
-[*traits* library](http://code.enthought.com/pages/traits.html).
+[*traits* library](https://docs.enthought.com/traits/).
 
 Traitlets powers the configuration system of IPython and Jupyter
 and the declarative API of IPython interactive widgets.


### PR DESCRIPTION
The Traitlets README refers to the Traits library and gives a `code.enthought.com` URL, but the resources at `code.enthought.com` are unmaintained and out of date. This PR updates that URL to something more current. This URL _should_ be reasonably stable going forward. (Another alternative that ought to be fairly safe stability-wise would be to refer to the PyPI page: https://pypi.org/project/traits/ .)