### PR TITLE
Ensure a recent enough virtualenv on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.7
 install:
   - pip install --upgrade pip
-  - pip install build
+  - pip install "build[virtualenv]>=0.2.0"
   - python -m build .
   - pip install dist/traitlets*.whl
   - pip install --pre --upgrade traitlets[test] pytest pytest-cov codecov


### PR DESCRIPTION
A recent PR (#643) failed on Travis CI due to (a) a new version (0.2.0) of the `build` package being released to PyPI, and (b) that new version of `build` requiring a minimum version of `virtualenv` that apparently wasn't present on Travis CI.

This PR adds the `virtualenv` extra when `pip` installing `build`. But that extra isn't provided for build 0.1.0, so we also require `build>=0.2.0`. (I'm not 100% sure what the failure mode is if you try  to install an extra that's not specified in `extras_require`.)