### PR TITLE
Fix Container.from_string

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -608,7 +608,7 @@ class TraitType(BaseDescriptor):
             return value
         if hasattr(self, 'validate'):
             value = self.validate(obj, value)
-        if obj._cross_validation_lock is False:
+        if obj is not None and obj._cross_validation_lock is False:
             value = self._cross_validate(obj, value)
         return value
 
@@ -2528,11 +2528,7 @@ class Container(Instance):
         """Load value from a single string"""
         if not isinstance(s, str):
             raise TraitError(f"Expected string, got {s!r}")
-        try:
-            test = literal_eval(s)
-        except Exception:
-            test = None
-        return self.validate(None, test)
+        return self.from_string_list([s])
 
     def from_string_list(self, s_list):
         """Return the value from a list of config strings


### PR DESCRIPTION
Closes: #645 

It looks like #645 might actually be a slightly bigger problem than it would initially seem. You can't even do `"{'tag'}"` and get it to work because the `Container` calls `self.validate(None, value)` and fails because, down the callstack, a `HasTraits` instance is expected instead of `None`.

Assuming we fix that though, it looks like this issue would still persist because `DeferredConfigString` calls `Container.from_string` which blindly attempts a `literal_eval` and fails (because `tag` is not a literal Python expression), resulting in a fallback value (the raw string) being used; thus the `TraitError`. The solution to this (from what I can tell) is for `Container.from_string(s)` to call `Container.from_string_list([s])`.