### PR TITLE
DOC: change flag -l -> -d

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -551,7 +551,7 @@ to produce the list ``["a", "b"]``
 
 or for dictionaries use `key=value`::
 
-    myprogram -d a=5 -l b=10
+    myprogram -d a=5 -d b=10
 
 to produce the dict ``{"a": 5, "b": 10}``.
 


### PR DESCRIPTION
I guess this is a hypothetical example and there is no way to test this, but I guess it makes more sense to use the same flag twice. Otherwise it would create to separate `dict` objects I guess?