### PR TITLE
DOC: Document *read_only* argument

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -439,7 +439,9 @@ class TraitType(BaseDescriptor):
         If *allow_none* is True, None is a valid value in addition to any
         values that are normally valid. The default is up to the subclass.
         For most trait types, the default value for ``allow_none`` is False.
-
+        
+        If *read_only* is True, attempts to directly modify a trait attribute raises a TraitError.
+        
         Extra metadata can be associated with the traitlet using the .tag() convenience method
         or by using the traitlet instance's .metadata dictionary.
         """


### PR DESCRIPTION
The documentation is derived from the code, with a bit of help from https://github.com/ipython/traitlets/blob/2bb2597224ca5ae485761781b11c06141770f110/docs/source/changelog.rst#41---2016-01-15