### PR TITLE
Setting one element of a trait list from cli not working

### DIFF
--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -327,6 +327,14 @@ class TestKeyValueCL(TestCase):
         c = C(config=config)
         assert c.list_trait == ["x", "y"]
 
+    def test_list_single_item(self):
+        cl = self.klass(log=log)
+        argv = ["--C.list_trait", "x"]
+        config = cl.load_config(argv)
+        assert config.C.list_trait == ["x"]
+        c = C(config=config)
+        assert c.list_trait == ["x"]
+
     def test_dict(self):
         cl = self.klass(log=log)
         argv = ["--C.dict_trait", "x=5", "--C.dict_trait", "y=10"]


### PR DESCRIPTION
Specifying only one element in a list is not working:

--C.list_trait x

The element will be interpreted as string => no matching type error.

Cause: https://github.com/ipython/traitlets/blob/191ff75e93d56446b2c051f4dbb33e2f0e7be71d/traitlets/config/loader.py#L671