### PR TITLE
Revert "Fix string assertion for python3.10"

### DIFF
--- a/traitlets/tests/test_traitlets_enum.py
+++ b/traitlets/tests/test_traitlets_enum.py
@@ -5,7 +5,6 @@ Test the trait-type ``UseEnum``.
 
 import unittest
 import enum
-import sys
 from traitlets import HasTraits, TraitError, Enum, UseEnum, CaselessStrEnum, FuzzyEnum
 
 
@@ -88,10 +87,7 @@ class TestUseEnum(unittest.TestCase):
             example = self.Example()
             example.color = value
             self.assertIsInstance(example.color, Color)
-            if sys.version_info < (3, 10):
-                self.assertEqual(str(example.color), value)
-            else:
-                self.assertEqual(repr(example.color), value)
+            self.assertEqual(str(example.color), value)
 
     def test_assign_bad_enum_value_name__raises_error(self):
         # -- CONVERT: string => Enum value (item)


### PR DESCRIPTION
This reverts commit dbb604946745ed90c6e9f6ed17f2bde253042d52.
The relevant change has been reverted in Python 3.10.0rc1, breaking
the test again.

closes #676 