### PR TITLE
FIX: account for changes in py310

### DIFF
--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -928,6 +928,8 @@ class _FlagAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         if self.nargs == 0 or values is Undefined:
+            if not hasattr(namespace, '_flags'):
+                namespace._flags = []
             namespace._flags.append(self.flag)
         else:
             setattr(namespace, self.alias, values)


### PR DESCRIPTION
In https://github.com/python/cpython/pull/28420 the order of setting the
default values on the Namespace object and processing the Actions was reversed.  This means
that in the `__call__` method of `_FlagAction` the `_flags` attribute has not
yet been put on the namespace.

This change makes `_FlagAction.__call__` forgiving if the `_flags` attribute
does not exist (by creating it!).