### PR TITLE
Disambiguate the use of the term value in the example.

### DIFF
--- a/docs/source/using_traitlets.rst
+++ b/docs/source/using_traitlets.rst
@@ -95,13 +95,13 @@ Basic Example: Validating the Parity of a Trait
     from traitlets import HasTraits, TraitError, Int, Bool, validate
 
     class Parity(HasTraits):
-        value = Int()
+        data = Int()
         parity = Int()
 
-        @validate('value')
-        def _valid_value(self, proposal):
+        @validate('data')
+        def _valid_data(self, proposal):
             if proposal['value'] % 2 != self.parity:
-                raise TraitError('value and parity should be consistent')
+                raise TraitError('data and parity should be consistent')
             return proposal['value']
 
         @validate('parity')
@@ -109,15 +109,16 @@ Basic Example: Validating the Parity of a Trait
             parity = proposal['value']
             if parity not in [0, 1]:
                 raise TraitError('parity should be 0 or 1')
-            if self.value % 2 != parity:
-                raise TraitError('value and parity should be consistent')
+            if self.data % 2 != parity:
+                raise TraitError('data and parity should be consistent')
             return proposal['value']
 
-    parity_check = Parity(value=2)
+
+    parity_check = Parity(data=2)
 
     # Changing required parity and value together while holding cross validation
     with parity_check.hold_trait_notifications():
-        parity_check.value = 1
+        parity_check.data = 1
         parity_check.parity = 1
 
 Notice how all of the examples above return


### PR DESCRIPTION
The [basic example in the docs](https://traitlets.readthedocs.io/en/stable/using_traitlets.html#basic-example-validating-the-parity-of-a-trait) is confusing because an attribute is named `value` (one use of value in the example) and the dictionary with the proposed-new-value has a key named `value`. 

Because the dictionary key cannot be easily changed, I renamed the class attribute to `data` to disambiguate it.