### PR TITLE
Application: add logging_config trait

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
-addopts = --durations=10 -ra --showlocals
+addopts = --durations=10 -ra --showlocals --doctest-modules
+testpaths =
+    traitlets
+    examples
 
 filterwarnings=
    ignore

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -4,16 +4,17 @@
 # Distributed under the terms of the Modified BSD License.
 
 
+from collections import defaultdict, OrderedDict
+from contextlib import suppress
+from copy import deepcopy
 import functools
 import json
 import logging
+from logging.config import dictConfig
 import os
 import pprint
 import re
 import sys
-import warnings
-from collections import OrderedDict, defaultdict
-from copy import deepcopy
 from textwrap import dedent
 
 from traitlets.config.configurable import Configurable, SingletonConfigurable
@@ -38,6 +39,7 @@ from traitlets.traitlets import (
     observe_compat,
 )
 from traitlets.utils.text import indent, wrap_paragraphs
+from traitlets.utils.nested_update import nested_update
 
 from ..utils import cast_unicode
 from ..utils.importstring import import_item
@@ -196,16 +198,6 @@ class Application(SingletonConfigurable):
         help="Set the log level by value or name.",
     ).tag(config=True)
 
-    @observe("log_level")
-    @observe_compat
-    def _log_level_changed(self, change):
-        """Adjust the log level when log_level is set."""
-        new = change.new
-        if isinstance(new, str):
-            new = getattr(logging, new)
-            self.log_level = new
-        self.log.setLevel(new)
-
     _log_formatter_cls = LevelFormatter
 
     log_datefmt = Unicode(
@@ -217,30 +209,77 @@ class Application(SingletonConfigurable):
         help="The Logging format template",
     ).tag(config=True)
 
-    @observe("log_datefmt", "log_format")
-    @observe_compat
-    def _log_format_changed(self, change):
-        """Change the log formatter when log_format is set."""
-        _log_handler = self._get_log_handler()
-        if not _log_handler:
-            warnings.warn(
-                f"No Handler found on {self.log}, setting log_format will have no effect",
-                RuntimeWarning,
-            )
-            return
-        _log_formatter = self._log_formatter_cls(fmt=self.log_format, datefmt=self.log_datefmt)
-        _log_handler.setFormatter(_log_formatter)
-
-    @default("log")
-    def _log_default(self):
-        """Start logging for this application.
+    def get_default_logging_config(self):
+        """Return the base logging configuration.
 
         The default is to log to stderr using a StreamHandler, if no default
-        handler already exists.  The log level starts at logging.WARN, but this
-        can be adjusted by setting the ``log_level`` attribute.
+        handler already exists.
+
+        The log handler level starts at logging.WARN, but this can be adjusted
+        by setting the ``log_level`` attribute.
+
+        The ``logging_config`` trait is merged into this allowing for finer
+        control of logging.
+
         """
+        config = {
+            'version': 1,
+            'handlers': {
+                'console': {
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'console',
+                    'level': logging.getLevelName(self.log_level),
+                    'stream': 'ext://sys.stderr',
+                },
+            },
+            'formatters': {
+                'console': {
+                    'class': (
+                        f'{self._log_formatter_cls.__module__}'
+                        f'.{self._log_formatter_cls.__name__}'
+                    ),
+                    'format': self.log_format,
+                    'datefmt': self.log_datefmt,
+                },
+            },
+            'loggers': {
+                self.__class__.__name__: {
+                    'level': 'DEBUG',
+                    'handlers': ['console'],
+                }
+            },
+            'disable_existing_loggers': False,
+        }
+
+        if sys.executable and sys.executable.endswith('pythonw.exe'):
+            # disable logging
+            # (this should really go to a file, but file-logging is only
+            # hooked up in parallel applications)
+            del config['handlers']['loggers']
+
+        return config
+
+    @observe('log_datefmt', 'log_format', 'log_level', 'logging_config')
+    def _observe_logging_change(self, change):
+        # convert log level strings to ints
+        log_level = self.log_level
+        if isinstance(log_level, str):
+            self.log_level = getattr(logging, log_level)
+        self._configure_logging()
+
+    @observe('log', type='default')
+    def _observe_logging_default(self, change):
+        self._configure_logging()
+
+    def _configure_logging(self):
+        config = self.get_default_logging_config()
+        nested_update(config, self.logging_config or {})
+        dictConfig(config)
+
+    @default('log')
+    def _log_default(self):
+        """Start logging for this application."""
         log = logging.getLogger(self.__class__.__name__)
-        log.setLevel(self.log_level)
         log.propagate = False
         _log = log  # copied from Logger.hasHandlers() (new in Python 3.2)
         while _log:
@@ -250,16 +289,57 @@ class Application(SingletonConfigurable):
                 break
             else:
                 _log = _log.parent
-        if sys.executable and sys.executable.endswith("pythonw.exe"):
-            # this should really go to a file, but file-logging is only
-            # hooked up in parallel applications
-            _log_handler = logging.StreamHandler(open(os.devnull, "w"))
-        else:
-            _log_handler = logging.StreamHandler()
-        _log_formatter = self._log_formatter_cls(fmt=self.log_format, datefmt=self.log_datefmt)
-        _log_handler.setFormatter(_log_formatter)
-        log.addHandler(_log_handler)
         return log
+
+    logging_config = Dict(
+        help="""
+            Configure additional log handlers.
+
+            The default stderr logs handler is configured by the
+            log_level, log_datefmt and log_format settings.
+
+            This configuration can be used to configure additional handlers
+            (e.g. to output the log to a file) or for finer control over the
+            default handlers.
+
+            If provided this should be a logging configuration dictionary, for
+            more information see:
+            https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+
+            This dictionary is merged with the base logging configuration which
+            defines the following:
+
+            * A logging formatter intended for interactive use called
+              ``console``.
+            * A logging handler that writes to stderr called
+              ``console`` which uses the formatter ``console``.
+            * A logger with the name of this application set to ``DEBUG``
+              level.
+
+            This example adds a new handler that writes to a file:
+
+            .. code-block:: python
+
+               c.Application.logging_configuration = {
+                   'handlers': {
+                       'file': {
+                           'class': 'logging.FileHandler',
+                           'level': 'DEBUG',
+                           'filename': '<path/to/file>',
+                       }
+                   },
+                   'loggers': {
+                       '<application-name>': {
+                           'level': 'DEBUG',
+                           # NOTE: if you don't list the default "console"
+                           # handler here then it will be disabled
+                           'handlers': ['console', 'file'],
+                       },
+                   }
+               }
+
+        """,
+    ).tag(config=True)
 
     #: the alias map for configurables
     #: Keys might strings or tuples for additional options; single-letter alias accessed like `-v`.
@@ -860,9 +940,18 @@ class Application(SingletonConfigurable):
             lines.append(cls.class_config_section(config_classes))
         return "\n".join(lines)
 
+    def close_handlers(self):
+        for handler in self.log.handlers:
+            with suppress(Exception):
+                handler.close()
+
     def exit(self, exit_status=0):
         self.log.debug("Exiting application: %s" % self.name)
+        self.close_handlers()
         sys.exit(exit_status)
+
+    def __del__(self):
+        self.close_handlers()
 
     @classmethod
     def launch_instance(cls, argv=None, **kwargs):

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -4,17 +4,17 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-from collections import defaultdict, OrderedDict
-from contextlib import suppress
-from copy import deepcopy
 import functools
 import json
 import logging
-from logging.config import dictConfig
 import os
 import pprint
 import re
 import sys
+from collections import OrderedDict, defaultdict
+from contextlib import suppress
+from copy import deepcopy
+from logging.config import dictConfig
 from textwrap import dedent
 
 from traitlets.config.configurable import Configurable, SingletonConfigurable
@@ -38,8 +38,8 @@ from traitlets.traitlets import (
     observe,
     observe_compat,
 )
-from traitlets.utils.text import indent, wrap_paragraphs
 from traitlets.utils.nested_update import nested_update
+from traitlets.utils.text import indent, wrap_paragraphs
 
 from ..utils import cast_unicode
 from ..utils.importstring import import_item
@@ -223,43 +223,43 @@ class Application(SingletonConfigurable):
 
         """
         config = {
-            'version': 1,
-            'handlers': {
-                'console': {
-                    'class': 'logging.StreamHandler',
-                    'formatter': 'console',
-                    'level': logging.getLevelName(self.log_level),
-                    'stream': 'ext://sys.stderr',
+            "version": 1,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "console",
+                    "level": logging.getLevelName(self.log_level),
+                    "stream": "ext://sys.stderr",
                 },
             },
-            'formatters': {
-                'console': {
-                    'class': (
-                        f'{self._log_formatter_cls.__module__}'
-                        f'.{self._log_formatter_cls.__name__}'
+            "formatters": {
+                "console": {
+                    "class": (
+                        f"{self._log_formatter_cls.__module__}"
+                        f".{self._log_formatter_cls.__name__}"
                     ),
-                    'format': self.log_format,
-                    'datefmt': self.log_datefmt,
+                    "format": self.log_format,
+                    "datefmt": self.log_datefmt,
                 },
             },
-            'loggers': {
+            "loggers": {
                 self.__class__.__name__: {
-                    'level': 'DEBUG',
-                    'handlers': ['console'],
+                    "level": "DEBUG",
+                    "handlers": ["console"],
                 }
             },
-            'disable_existing_loggers': False,
+            "disable_existing_loggers": False,
         }
 
-        if sys.executable and sys.executable.endswith('pythonw.exe'):
+        if sys.executable and sys.executable.endswith("pythonw.exe"):
             # disable logging
             # (this should really go to a file, but file-logging is only
             # hooked up in parallel applications)
-            del config['handlers']['loggers']
+            del config["handlers"]["loggers"]
 
         return config
 
-    @observe('log_datefmt', 'log_format', 'log_level', 'logging_config')
+    @observe("log_datefmt", "log_format", "log_level", "logging_config")
     def _observe_logging_change(self, change):
         # convert log level strings to ints
         log_level = self.log_level
@@ -267,7 +267,7 @@ class Application(SingletonConfigurable):
             self.log_level = getattr(logging, log_level)
         self._configure_logging()
 
-    @observe('log', type='default')
+    @observe("log", type="default")
     def _observe_logging_default(self, change):
         self._configure_logging()
 
@@ -276,7 +276,7 @@ class Application(SingletonConfigurable):
         nested_update(config, self.logging_config or {})
         dictConfig(config)
 
-    @default('log')
+    @default("log")
     def _log_default(self):
         """Start logging for this application."""
         log = logging.getLogger(self.__class__.__name__)

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -469,6 +469,9 @@ class LoggingConfigurable(Configurable):
         """Return the default Handler
 
         Returns None if none can be found
+
+        Deprecated, this now returns the first log handler which may or may
+        not be the default one.
         """
         logger = self.log
         if isinstance(logger, logging.LoggerAdapter):

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -770,40 +770,40 @@ def test_deep_alias():
 
 def test_logging_config(tmp_path, capsys):
     """We should be able to configure additional log handlers."""
-    log_file = tmp_path / 'log_file'
+    log_file = tmp_path / "log_file"
     app = Application(
         logging_config={
-            'version': 1,
-            'handlers': {
-                'file': {
-                    'class': 'logging.FileHandler',
-                    'level': 'DEBUG',
-                    'filename': str(log_file),
+            "version": 1,
+            "handlers": {
+                "file": {
+                    "class": "logging.FileHandler",
+                    "level": "DEBUG",
+                    "filename": str(log_file),
                 },
             },
-            'loggers': {
-                'Application': {
-                    'level': 'DEBUG',
-                    'handlers': ['console', 'file'],
+            "loggers": {
+                "Application": {
+                    "level": "DEBUG",
+                    "handlers": ["console", "file"],
                 },
-            }
+            },
         }
     )
     # the default "console" handler + our new "file" handler
     assert len(app.log.handlers) == 2
 
     # log a couple of messages
-    app.log.info('info')
-    app.log.warn('warn')
+    app.log.info("info")
+    app.log.warn("warn")
 
     # test that log messages get written to the file
-    with open(log_file, 'r') as log_handle:
-        assert log_handle.read() == 'info\nwarn\n'
+    with open(log_file) as log_handle:
+        assert log_handle.read() == "info\nwarn\n"
 
     # test that log messages get written to stderr (default console handler)
-    assert capsys.readouterr().err == '[Application] WARNING | warn\n'
+    assert capsys.readouterr().err == "[Application] WARNING | warn\n"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # for test_help_output:
     MyApp.launch_instance()

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -121,9 +121,9 @@ class TestApplication(TestCase):
         app = MyApp(log_level=logging.INFO)
         handler = logging.StreamHandler(stream)
         # trigger reconstruction of the log formatter
-        app.log.handlers = [handler]
         app.log_format = "%(message)s"
         app.log_datefmt = "%Y-%m-%d %H:%M"
+        app.log.handlers = [handler]
         app.log.info("hello")
         assert "hello" in stream.getvalue()
 
@@ -768,6 +768,42 @@ def test_deep_alias():
     assert len(list(app.emit_alias_help())) > 0
 
 
-if __name__ == "__main__":
+def test_logging_config(tmp_path, capsys):
+    """We should be able to configure additional log handlers."""
+    log_file = tmp_path / 'log_file'
+    app = Application(
+        logging_config={
+            'version': 1,
+            'handlers': {
+                'file': {
+                    'class': 'logging.FileHandler',
+                    'level': 'DEBUG',
+                    'filename': str(log_file),
+                },
+            },
+            'loggers': {
+                'Application': {
+                    'level': 'DEBUG',
+                    'handlers': ['console', 'file'],
+                },
+            }
+        }
+    )
+    # the default "console" handler + our new "file" handler
+    assert len(app.log.handlers) == 2
+
+    # log a couple of messages
+    app.log.info('info')
+    app.log.warn('warn')
+
+    # test that log messages get written to the file
+    with open(log_file, 'r') as log_handle:
+        assert log_handle.read() == 'info\nwarn\n'
+
+    # test that log messages get written to stderr (default console handler)
+    assert capsys.readouterr().err == '[Application] WARNING | warn\n'
+
+
+if __name__ == '__main__':
     # for test_help_output:
     MyApp.launch_instance()

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -704,14 +704,13 @@ class TestLogger(TestCase):
         self.assertIn("Config option `totally_wrong` not recognized by `A`.", output)
         self.assertNotIn("Did you mean", output)
 
-    def test_logger_adapter(self):
-        logger = logging.getLogger("test_logger_adapter")
-        adapter = logging.LoggerAdapter(logger, {"key": "adapted"})
 
-        with self.assertLogs(logger, logging.INFO) as captured:
-            app = Application(log=adapter, log_level=logging.INFO)
-            app.log_format = "%(key)s %(message)s"
-            app.log.info("test message")
+def test_logger_adapter(caplog, capsys):
+    logger = logging.getLogger("Application")
+    adapter = logging.LoggerAdapter(logger, {"key": "adapted"})
 
-        output = "\n".join(captured.output)
-        assert "adapted test message" in output
+    app = Application(log=adapter, log_level=logging.INFO)
+    app.log_format = "%(key)s %(message)s"
+    app.log.info("test message")
+
+    assert 'adapted test message' in capsys.readouterr().err

--- a/traitlets/config/tests/test_configurable.py
+++ b/traitlets/config/tests/test_configurable.py
@@ -713,4 +713,4 @@ def test_logger_adapter(caplog, capsys):
     app.log_format = "%(key)s %(message)s"
     app.log.info("test message")
 
-    assert 'adapted test message' in capsys.readouterr().err
+    assert "adapted test message" in capsys.readouterr().err

--- a/traitlets/tests/_warnings.py
+++ b/traitlets/tests/_warnings.py
@@ -21,16 +21,19 @@ def all_warnings():
     >>> import warnings
     >>> def foo():
     ...     warnings.warn(RuntimeWarning("bar"))
+
     We raise the warning once, while the warning filter is set to "once".
     Hereafter, the warning is invisible, even with custom filters:
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter('once')
     ...     foo()
+
     We can now run ``foo()`` without a warning being raised:
-    >>> from numpy.testing import assert_warns
-    >>> foo()
+    >>> from numpy.testing import assert_warns  # doctest: +SKIP
+    >>> foo()  # doctest: +SKIP
+
     To catch the warning, we call in the help of ``all_warnings``:
-    >>> with all_warnings():
+    >>> with all_warnings():  # doctest: +SKIP
     ...     assert_warns(RuntimeWarning, foo)
     """
 
@@ -73,9 +76,9 @@ def expected_warnings(matching):
 
     Examples
     --------
-    >>> from skimage import data, img_as_ubyte, img_as_float
-    >>> with expected_warnings(["precision loss"]):
-    ...     d = img_as_ubyte(img_as_float(data.coins()))
+    >>> from skimage import data, img_as_ubyte, img_as_float  # doctest: +SKIP
+    >>> with expected_warnings(["precision loss"]):           # doctest: +SKIP
+    ...     d = img_as_ubyte(img_as_float(data.coins()))      # doctest: +SKIP
 
     Notes
     -----

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -189,9 +189,7 @@ def _safe_literal_eval(s):
 
 def is_trait(t):
     """Returns whether the given value is an instance or subclass of TraitType."""
-    return isinstance(t, TraitType) or (
-        isinstance(t, type) and issubclass(t, TraitType)
-    )
+    return isinstance(t, TraitType) or (isinstance(t, type) and issubclass(t, TraitType))
 
 
 def parse_notifier_name(names):
@@ -258,8 +256,7 @@ def _validate_link(*tuples):
     for t in tuples:
         if not len(t) == 2:
             raise TypeError(
-                "Each linked traitlet must be specified as (HasTraits, 'trait_name'), not %r"
-                % t
+                "Each linked traitlet must be specified as (HasTraits, 'trait_name'), not %r" % t
             )
         obj, trait_name = t
         if not isinstance(obj, HasTraits):
@@ -298,9 +295,7 @@ class link:
     def __init__(self, source, target, transform=None):
         _validate_link(source, target)
         self.source, self.target = source, target
-        self._transform, self._transform_inv = (
-            transform if transform else (lambda x: x,) * 2
-        )
+        self._transform, self._transform_inv = transform if transform else (lambda x: x,) * 2
 
         self.link()
 
@@ -629,9 +624,7 @@ class TraitType(BaseDescriptor):
             return value
         except Exception:
             # This should never be reached.
-            raise TraitError(
-                "Unexpected error in TraitType: " "default value not set properly"
-            )
+            raise TraitError("Unexpected error in TraitType: " "default value not set properly")
         else:
             return value
 
@@ -970,9 +963,7 @@ def observe(*names, type="change"):
         raise TypeError("Please specify at least one trait name to observe.")
     for name in names:
         if name is not All and not isinstance(name, str):
-            raise TypeError(
-                "trait names to observe must be strings or All, not %r" % name
-            )
+            raise TypeError("trait names to observe must be strings or All, not %r" % name)
     return ObserveHandler(names, type=type)
 
 
@@ -1041,9 +1032,7 @@ def validate(*names):
         raise TypeError("Please specify at least one trait name to validate.")
     for name in names:
         if name is not All and not isinstance(name, str):
-            raise TypeError(
-                "trait names to validate must be strings or All, not %r" % name
-            )
+            raise TypeError("trait names to validate must be strings or All, not %r" % name)
     return ValidateHandler(names)
 
 
@@ -1592,9 +1581,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         the output.  If a metadata key doesn't exist, None will be passed
         to the function.
         """
-        traits = dict(
-            [memb for memb in getmembers(cls) if isinstance(memb[1], TraitType)]
-        )
+        traits = dict([memb for memb in getmembers(cls) if isinstance(memb[1], TraitType)])
 
         if len(metadata) == 0:
             return traits
@@ -1707,8 +1694,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         for n in names:
             if not self.has_trait(n):
                 raise TraitError(
-                    "'%s' is not a trait of '%s' "
-                    "instances" % (n, type(self).__name__)
+                    "'%s' is not a trait of '%s' " "instances" % (n, type(self).__name__)
                 )
 
         if len(names) == 1 and len(metadata) == 0:
@@ -1741,11 +1727,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         to the function.
         """
         traits = dict(
-            [
-                memb
-                for memb in getmembers(self.__class__)
-                if isinstance(memb[1], TraitType)
-            ]
+            [memb for memb in getmembers(self.__class__) if isinstance(memb[1], TraitType)]
         )
 
         if len(metadata) == 0:
@@ -1784,11 +1766,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         Works like ``event_handlers``, except for excluding traits from parents.
         """
         sup = super(cls, cls)
-        return {
-            n: e
-            for (n, e) in cls.events(name).items()
-            if getattr(sup, n, None) is not e
-        }
+        return {n: e for (n, e) in cls.events(name).items() if getattr(sup, n, None) is not e}
 
     @classmethod
     def trait_events(cls, name=None):
@@ -2352,8 +2330,7 @@ class Unicode(TraitType):
                     s = s[1:-1]
                     warn(
                         "Supporting extra quotes around strings is deprecated in traitlets 5.0. "
-                        "You can use %r instead of %r if you require traitlets >=5."
-                        % (s, old_s),
+                        "You can use %r instead of %r if you require traitlets >=5." % (s, old_s),
                         FutureWarning,
                     )
         return s
@@ -2533,11 +2510,7 @@ class FuzzyEnum(Enum):
 
         conv_func = (lambda c: c) if self.case_sensitive else lambda c: c.lower()
         substring_matching = self.substring_matching
-        match_func = (
-            (lambda v, c: v in c)
-            if substring_matching
-            else (lambda v, c: c.startswith(v))
-        )
+        match_func = (lambda v, c: v in c) if substring_matching else (lambda v, c: c.startswith(v))
         value = conv_func(value)
         choices = self.values
         matches = [match_func(value, conv_func(c)) for c in choices]
@@ -2630,9 +2603,7 @@ class Container(Instance):
         elif isinstance(default_value, self._valid_defaults):
             args = (default_value,)
         else:
-            raise TypeError(
-                f"default value of {self.__class__.__name__} was {default_value}"
-            )
+            raise TypeError(f"default value of {self.__class__.__name__} was {default_value}")
 
         if is_trait(trait):
             if isinstance(trait, type):
@@ -2644,9 +2615,7 @@ class Container(Instance):
                 )
             self._trait = trait() if isinstance(trait, type) else trait
         elif trait is not None:
-            raise TypeError(
-                "`trait` must be a Trait or None, got %s" % repr_type(trait)
-            )
+            raise TypeError("`trait` must be a Trait or None, got %s" % repr_type(trait))
 
         super().__init__(klass=self.klass, args=args, **kwargs)
 
@@ -2727,9 +2696,7 @@ class Container(Instance):
         else:
             # backward-compat: allow item_from_string to ignore index arg
             item_from_string = lambda s, index=None: self.item_from_string(s)
-        return self.klass(
-            [item_from_string(s, index=idx) for idx, s in enumerate(s_list)]
-        )
+        return self.klass([item_from_string(s, index=idx) for idx, s in enumerate(s_list)])
 
     def item_from_string(self, s, index=None):
         """Cast a single item from a string
@@ -2924,9 +2891,7 @@ class Tuple(Container):
         elif isinstance(default_value, self._valid_defaults):
             args = (default_value,)
         else:
-            raise TypeError(
-                f"default value of {self.__class__.__name__} was {default_value}"
-            )
+            raise TypeError(f"default value of {self.__class__.__name__} was {default_value}")
 
         self._traits = []
         for trait in traits:
@@ -3129,9 +3094,7 @@ class Dict(Instance):
                 key_trait = key_trait()
             self._key_trait = key_trait
         elif key_trait is not None:
-            raise TypeError(
-                "`key_trait` must be a Trait or None, got %s" % repr_type(key_trait)
-            )
+            raise TypeError("`key_trait` must be a Trait or None, got %s" % repr_type(key_trait))
 
         self._per_key_traits = per_key_traits
 
@@ -3200,9 +3163,7 @@ class Dict(Instance):
     def from_string(self, s):
         """Load value from a single string"""
         if not isinstance(s, str):
-            raise TypeError(
-                f"from_string expects a string, got {repr(s)} of type {type(s)}"
-            )
+            raise TypeError(f"from_string expects a string, got {repr(s)} of type {type(s)}")
         try:
             return self.from_string_list([s])
         except Exception:
@@ -3345,9 +3306,7 @@ class UseEnum(TraitType):
     info_text = "Trait type adapter to a Enum class"
 
     def __init__(self, enum_class, default_value=None, **kwargs):
-        assert issubclass(enum_class, enum.Enum), (
-            "REQUIRE: enum.Enum, but was: %r" % enum_class
-        )
+        assert issubclass(enum_class, enum.Enum), "REQUIRE: enum.Enum, but was: %r" % enum_class
         allow_none = kwargs.get("allow_none", False)
         if default_value is None and not allow_none:
             default_value = list(enum_class.__members__.values())[0]
@@ -3436,11 +3395,7 @@ def _add_all():
     do in a function to avoid iterating through globals while defining local variables
     """
     for _name, _value in globals().items():
-        if (
-            not _name.startswith("_")
-            and isinstance(_value, type)
-            and issubclass(_value, TraitType)
-        ):
+        if not _name.startswith("_") and isinstance(_value, type) and issubclass(_value, TraitType):
             __all__.append(_name)
 
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -189,7 +189,9 @@ def _safe_literal_eval(s):
 
 def is_trait(t):
     """Returns whether the given value is an instance or subclass of TraitType."""
-    return isinstance(t, TraitType) or (isinstance(t, type) and issubclass(t, TraitType))
+    return isinstance(t, TraitType) or (
+        isinstance(t, type) and issubclass(t, TraitType)
+    )
 
 
 def parse_notifier_name(names):
@@ -198,13 +200,13 @@ def parse_notifier_name(names):
     Examples
     --------
     >>> parse_notifier_name([])
-    [All]
+    [traitlets.All]
     >>> parse_notifier_name("a")
     ['a']
     >>> parse_notifier_name(["a", "b"])
     ['a', 'b']
     >>> parse_notifier_name(All)
-    [All]
+    [traitlets.All]
     """
     if names is All or isinstance(names, str):
         return [names]
@@ -256,7 +258,8 @@ def _validate_link(*tuples):
     for t in tuples:
         if not len(t) == 2:
             raise TypeError(
-                "Each linked traitlet must be specified as (HasTraits, 'trait_name'), not %r" % t
+                "Each linked traitlet must be specified as (HasTraits, 'trait_name'), not %r"
+                % t
             )
         obj, trait_name = t
         if not isinstance(obj, HasTraits):
@@ -277,8 +280,17 @@ class link:
 
     Examples
     --------
+    >>> class X(HasTraits):
+    ...     value = Int()
+
+    >>> src = X(value=1)
+    >>> tgt = X(value=42)
     >>> c = link((src, "value"), (tgt, "value"))
-    >>> src.value = 5  # updates other objects as well
+
+    Setting source updates target objects:
+    >>> src.value = 5
+    >>> tgt.value
+    5
     """
 
     updating = False
@@ -286,7 +298,9 @@ class link:
     def __init__(self, source, target, transform=None):
         _validate_link(source, target)
         self.source, self.target = source, target
-        self._transform, self._transform_inv = transform if transform else (lambda x: x,) * 2
+        self._transform, self._transform_inv = (
+            transform if transform else (lambda x: x,) * 2
+        )
 
         self.link()
 
@@ -349,9 +363,23 @@ class directional_link:
 
     Examples
     --------
+    >>> class X(HasTraits):
+    ...     value = Int()
+
+    >>> src = X(value=1)
+    >>> tgt = X(value=42)
     >>> c = directional_link((src, "value"), (tgt, "value"))
-    >>> src.value = 5  # updates target objects
-    >>> tgt.value = 6  # does not update source object
+
+    Setting source updates target objects:
+    >>> src.value = 5
+    >>> tgt.value
+    5
+
+    Setting target does not update source object:
+    >>> tgt.value = 6
+    >>> src.value
+    5
+
     """
 
     updating = False
@@ -601,7 +629,9 @@ class TraitType(BaseDescriptor):
             return value
         except Exception:
             # This should never be reached.
-            raise TraitError("Unexpected error in TraitType: " "default value not set properly")
+            raise TraitError(
+                "Unexpected error in TraitType: " "default value not set properly"
+            )
         else:
             return value
 
@@ -664,7 +694,10 @@ class TraitType(BaseDescriptor):
             meth_name = "_%s_validate" % self.name
             cross_validate = getattr(obj, meth_name)
             _deprecated_method(
-                cross_validate, obj.__class__, meth_name, "use @validate decorator instead."
+                cross_validate,
+                obj.__class__,
+                meth_name,
+                "use @validate decorator instead.",
             )
             value = cross_validate(value, self)
         return value
@@ -726,7 +759,12 @@ class TraitType(BaseDescriptor):
                     error.args = (
                         "The '%s' trait contains %s which "
                         "expected %s, not %s."
-                        % (self.name, chain, error.args[1], describe("the", error.args[0])),
+                        % (
+                            self.name,
+                            chain,
+                            error.args[1],
+                            describe("the", error.args[0]),
+                        ),
                     )
             raise error
         else:
@@ -780,7 +818,11 @@ class TraitType(BaseDescriptor):
 
         This allows convenient metadata tagging when initializing the trait, such as:
 
+        Examples
+        --------
         >>> Int(0).tag(config=True, sync=True)
+        <traitlets.traitlets.Int object at ...>
+
         """
         maybe_constructor_keywords = set(metadata.keys()).intersection(
             {"help", "allow_none", "read_only", "default_value"}
@@ -928,7 +970,9 @@ def observe(*names, type="change"):
         raise TypeError("Please specify at least one trait name to observe.")
     for name in names:
         if name is not All and not isinstance(name, str):
-            raise TypeError("trait names to observe must be strings or All, not %r" % name)
+            raise TypeError(
+                "trait names to observe must be strings or All, not %r" % name
+            )
     return ObserveHandler(names, type=type)
 
 
@@ -997,7 +1041,9 @@ def validate(*names):
         raise TypeError("Please specify at least one trait name to validate.")
     for name in names:
         if name is not All and not isinstance(name, str):
-            raise TypeError("trait names to validate must be strings or All, not %r" % name)
+            raise TypeError(
+                "trait names to validate must be strings or All, not %r" % name
+            )
     return ValidateHandler(names)
 
 
@@ -1320,7 +1366,10 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             class_value = getattr(self.__class__, magic_name)
             if not isinstance(class_value, ObserveHandler):
                 _deprecated_method(
-                    class_value, self.__class__, magic_name, "use @observe and @unobserve instead."
+                    class_value,
+                    self.__class__,
+                    magic_name,
+                    "use @observe and @unobserve instead.",
                 )
                 cb = getattr(self, magic_name)
                 # Only append the magic method if it was not manually registered
@@ -1489,7 +1538,10 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
                 class_value = getattr(self.__class__, magic_name)
                 if not isinstance(class_value, ValidateHandler):
                     _deprecated_method(
-                        class_value, self.__class__, magic_name, "use @validate decorator instead."
+                        class_value,
+                        self.__class__,
+                        magic_name,
+                        "use @validate decorator instead.",
                     )
         for name in names:
             self._trait_validators[name] = handler
@@ -1540,7 +1592,9 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         the output.  If a metadata key doesn't exist, None will be passed
         to the function.
         """
-        traits = dict([memb for memb in getmembers(cls) if isinstance(memb[1], TraitType)])
+        traits = dict(
+            [memb for memb in getmembers(cls) if isinstance(memb[1], TraitType)]
+        )
 
         if len(metadata) == 0:
             return traits
@@ -1653,7 +1707,8 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         for n in names:
             if not self.has_trait(n):
                 raise TraitError(
-                    "'%s' is not a trait of '%s' " "instances" % (n, type(self).__name__)
+                    "'%s' is not a trait of '%s' "
+                    "instances" % (n, type(self).__name__)
                 )
 
         if len(names) == 1 and len(metadata) == 0:
@@ -1686,7 +1741,11 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         to the function.
         """
         traits = dict(
-            [memb for memb in getmembers(self.__class__) if isinstance(memb[1], TraitType)]
+            [
+                memb
+                for memb in getmembers(self.__class__)
+                if isinstance(memb[1], TraitType)
+            ]
         )
 
         if len(metadata) == 0:
@@ -1725,7 +1784,11 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         Works like ``event_handlers``, except for excluding traits from parents.
         """
         sup = super(cls, cls)
-        return {n: e for (n, e) in cls.events(name).items() if getattr(sup, n, None) is not e}
+        return {
+            n: e
+            for (n, e) in cls.events(name).items()
+            if getattr(sup, n, None) is not e
+        }
 
     @classmethod
     def trait_events(cls, name=None):
@@ -2289,7 +2352,8 @@ class Unicode(TraitType):
                     s = s[1:-1]
                     warn(
                         "Supporting extra quotes around strings is deprecated in traitlets 5.0. "
-                        "You can use %r instead of %r if you require traitlets >=5." % (s, old_s),
+                        "You can use %r instead of %r if you require traitlets >=5."
+                        % (s, old_s),
                         FutureWarning,
                     )
         return s
@@ -2469,7 +2533,11 @@ class FuzzyEnum(Enum):
 
         conv_func = (lambda c: c) if self.case_sensitive else lambda c: c.lower()
         substring_matching = self.substring_matching
-        match_func = (lambda v, c: v in c) if substring_matching else (lambda v, c: c.startswith(v))
+        match_func = (
+            (lambda v, c: v in c)
+            if substring_matching
+            else (lambda v, c: c.startswith(v))
+        )
         value = conv_func(value)
         choices = self.values
         matches = [match_func(value, conv_func(c)) for c in choices]
@@ -2562,7 +2630,9 @@ class Container(Instance):
         elif isinstance(default_value, self._valid_defaults):
             args = (default_value,)
         else:
-            raise TypeError(f"default value of {self.__class__.__name__} was {default_value}")
+            raise TypeError(
+                f"default value of {self.__class__.__name__} was {default_value}"
+            )
 
         if is_trait(trait):
             if isinstance(trait, type):
@@ -2574,7 +2644,9 @@ class Container(Instance):
                 )
             self._trait = trait() if isinstance(trait, type) else trait
         elif trait is not None:
-            raise TypeError("`trait` must be a Trait or None, got %s" % repr_type(trait))
+            raise TypeError(
+                "`trait` must be a Trait or None, got %s" % repr_type(trait)
+            )
 
         super().__init__(klass=self.klass, args=args, **kwargs)
 
@@ -2655,7 +2727,9 @@ class Container(Instance):
         else:
             # backward-compat: allow item_from_string to ignore index arg
             item_from_string = lambda s, index=None: self.item_from_string(s)
-        return self.klass([item_from_string(s, index=idx) for idx, s in enumerate(s_list)])
+        return self.klass(
+            [item_from_string(s, index=idx) for idx, s in enumerate(s_list)]
+        )
 
     def item_from_string(self, s, index=None):
         """Cast a single item from a string
@@ -2850,7 +2924,9 @@ class Tuple(Container):
         elif isinstance(default_value, self._valid_defaults):
             args = (default_value,)
         else:
-            raise TypeError(f"default value of {self.__class__.__name__} was {default_value}")
+            raise TypeError(
+                f"default value of {self.__class__.__name__} was {default_value}"
+            )
 
         self._traits = []
         for trait in traits:
@@ -2964,16 +3040,17 @@ class Dict(Instance):
 
         Examples
         --------
-        >>> d = Dict(Unicode())
         a dict whose values must be text
+        >>> d = Dict(Unicode())
 
-        >>> d2 = Dict(per_key_traits={"n": Integer(), "s": Unicode()})
         d2['n'] must be an integer
         d2['s'] must be text
+        >>> d2 = Dict(per_key_traits={"n": Integer(), "s": Unicode()})
 
-        >>> d3 = Dict(value_trait=Integer(), key_trait=Unicode())
         d3's keys must be text
         d3's values must be integers
+        >>> d3 = Dict(value_trait=Integer(), key_trait=Unicode())
+
         """
 
         # handle deprecated keywords
@@ -3052,7 +3129,9 @@ class Dict(Instance):
                 key_trait = key_trait()
             self._key_trait = key_trait
         elif key_trait is not None:
-            raise TypeError("`key_trait` must be a Trait or None, got %s" % repr_type(key_trait))
+            raise TypeError(
+                "`key_trait` must be a Trait or None, got %s" % repr_type(key_trait)
+            )
 
         self._per_key_traits = per_key_traits
 
@@ -3121,7 +3200,9 @@ class Dict(Instance):
     def from_string(self, s):
         """Load value from a single string"""
         if not isinstance(s, str):
-            raise TypeError(f"from_string expects a string, got {repr(s)} of type {type(s)}")
+            raise TypeError(
+                f"from_string expects a string, got {repr(s)} of type {type(s)}"
+            )
         try:
             return self.from_string_list([s])
         except Exception:
@@ -3264,7 +3345,9 @@ class UseEnum(TraitType):
     info_text = "Trait type adapter to a Enum class"
 
     def __init__(self, enum_class, default_value=None, **kwargs):
-        assert issubclass(enum_class, enum.Enum), "REQUIRE: enum.Enum, but was: %r" % enum_class
+        assert issubclass(enum_class, enum.Enum), (
+            "REQUIRE: enum.Enum, but was: %r" % enum_class
+        )
         allow_none = kwargs.get("allow_none", False)
         if default_value is None and not allow_none:
             default_value = list(enum_class.__members__.values())[0]
@@ -3353,7 +3436,11 @@ def _add_all():
     do in a function to avoid iterating through globals while defining local variables
     """
     for _name, _value in globals().items():
-        if not _name.startswith("_") and isinstance(_value, type) and issubclass(_value, TraitType):
+        if (
+            not _name.startswith("_")
+            and isinstance(_value, type)
+            and issubclass(_value, TraitType)
+        ):
             __all__.append(_name)
 
 

--- a/traitlets/utils/descriptions.py
+++ b/traitlets/utils/descriptions.py
@@ -103,8 +103,7 @@ def describe(article, value, name=None, verbose=False, capital=False):
         return add_article(typename, False, capital)
     else:
         raise ValueError(
-            "The 'article' argument should "
-            "be 'the', 'a', 'an', or None not %r" % article
+            "The 'article' argument should " "be 'the', 'a', 'an', or None not %r" % article
         )
 
 

--- a/traitlets/utils/descriptions.py
+++ b/traitlets/utils/descriptions.py
@@ -46,11 +46,11 @@ def describe(article, value, name=None, verbose=False, capital=False):
     Definite description:
 
     >>> describe("the", object())
-    "the object at '0x10741f1b0'"
+    "the object at '...'"
     >>> describe("the", object)
-    "the type 'object'"
+    'the object object'
     >>> describe("the", type(object))
-    "the type 'type'"
+    'the type type'
 
     Definitely named description:
 
@@ -103,7 +103,8 @@ def describe(article, value, name=None, verbose=False, capital=False):
         return add_article(typename, False, capital)
     else:
         raise ValueError(
-            "The 'article' argument should " "be 'the', 'a', 'an', or None not %r" % article
+            "The 'article' argument should "
+            "be 'the', 'a', 'an', or None not %r" % article
         )
 
 

--- a/traitlets/utils/nested_update.py
+++ b/traitlets/utils/nested_update.py
@@ -1,0 +1,38 @@
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+
+def nested_update(this, that):
+    """Merge two nested dictionaries.
+
+    Effectively a recursive ``dict.update``.
+
+    Examples
+    --------
+    Merge two flat dictionaries:
+    >>> nested_update(
+    ...     {'a': 1, 'b': 2},
+    ...     {'b': 3, 'c': 4}
+    ... )
+    {'a': 1, 'b': 3, 'c': 4}
+
+    Merge two nested dictionaries:
+    >>> nested_update(
+    ...     {'x': {'a': 1, 'b': 2}, 'y': 5, 'z': 6},
+    ...     {'x': {'b': 3, 'c': 4}, 'z': 7, '0': 8},
+    ... )
+    {'x': {'a': 1, 'b': 3, 'c': 4}, 'y': 5, 'z': 7, '0': 8}
+
+    """
+    for key, value in this.items():
+        if isinstance(value, dict):
+            if key in that and isinstance(that[key], dict):
+                nested_update(this[key], that[key])
+        elif key in that:
+            this[key] = that[key]
+
+    for key, value in that.items():
+        if key not in this:
+            this[key] = value
+
+    return this


### PR DESCRIPTION
Closes #688

Allows fine configuration of logging via a `logging.config.dictConfig`, useful for configuring additional log handlers/formatters and advanced logging setups.

* Fixes doctests and gets them running with pytest.
* Unifies the pre-existing logging configurations into a standard "base" logging configuration dict.
* Adds a new trait for providing a logging config dict which is merged into the "base" configuration allowing adding configs as well as redefining existing ones.
* Changes the default logger level from WARN to DEBUG and the default handler level from undefined to WARN (I think the log_level should apply to the handler not the logger otherwise).