### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -26,8 +26,6 @@ jobs:
           pip install --pre --upgrade traitlets[test] pytest pytest-cov
           pip install ipython[test] nbconvert[test] \
                       notebook[test] ipywidgets[test]
-          # Work around https://github.com/jupyter/nbconvert/issues/1754
-          pip install "bleach<5"
           pip freeze
 
       - name: Run tests IPython

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,18 +37,68 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install build
-          python -m build .
-          pip install dist/traitlets*.whl
-          pip install --pre --upgrade traitlets[test] pytest pytest-cov
+          pip install ".[test]" pytest-cov
           pip freeze
 
       - name: Test with pytest
         run: |
-          python -m pytest --cov traitlets --cov-report=xml -v --color yes traitlets
+          python -m pytest --cov traitlets --cov-report=xml -v traitlets
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
+
+  test_miniumum_verisons:
+    name: Test Minimum Versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_version: "3.7"
+      - name: Install miniumum versions
+        uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
+      - name: Run the unit tests
+        run: pytest -vv -W default traitlets || pytest -vv -W default traitlets --lf
+
+  test_prereleases:
+    name: Test Prereleases
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install the Python dependencies
+        run: |
+          pip install --upgrade --upgrade-strategy eager --pre -e ".[test]"
+      - name: List installed packages
+        run: |
+          pip freeze
+          pip check
+      - name: Run the tests
+        run: |
+          pytest -vv traitlets || pytest -vv traitlets --lf
+
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/make-sdist@v1
+
+  test_sdist:
+    runs-on: ubuntu-latest
+    needs: [make_sdist]
+    name: Install from SDist and Test
+    timeout-minutes: 20
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
 
   pre-commit:
     name: pre-commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest --cov traitlets --cov-report=xml -v --color yes traitlets
+          python -m pytest --cov traitlets --cov-report=xml -v --color yes traitlets
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,34 +3,40 @@ name: Tests
 on:
   push:
   pull_request:
+  schedule:
+    - cron: "0 8 * * *"
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version:
-          - 3.7
-          - 3.8
-          - 3.9
-          - 3.10.0-rc.2
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.7", "3.10"]
+        include:
+          - os: windows-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "pypy-3.8"
+          - os: macos-latest
+            python-version: "3.8"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
           pip install build
           python -m build .
           pip install dist/traitlets*.whl
@@ -39,7 +45,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest --cov traitlets --cov-report=xml -v traitlets
+          pytest --cov traitlets --cov-report=xml -v --color yes traitlets
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --durations=10 -ra --showlocals --doctest-modules
+addopts = --durations=10 -ra --showlocals --doctest-modules --color yes
 testpaths =
     traitlets
     examples


### PR DESCRIPTION
- Add pypy-3.8 test
- Add concurrency limit handling for GitHub Actions
- Add cron job to run tests daily
- Use base-setup from maintainer-tools to handle python version, caching, and pip upgrades
- Add tests for minimum versions, pre-releases, and sdist testing
- Add color to pytest output 