### PR TITLE
duplicate version info in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "traitlets"
+version = "5.3.0.dev0"
 authors = [{name = "IPython Development Team", email = "ipython-dev@python.org"}]
 license = {file = "COPYING.md"}
 readme = "README.md"
@@ -18,7 +19,7 @@ classifiers = [
 ]
 urls = {Homepage = "https://github.com/ipython/traitlets"}
 requires-python = ">=3.7"
-dynamic = ["description", "version"]
+dynamic = ["description"]
 
 [project.optional-dependencies]
 test = ["pytest", "pre-commit"]


### PR DESCRIPTION
## References

- fixes #725

## Code Changes

- [x] duplicates the version in `pyproject.toml` to avoid triggering extra build stuff during editable install
- [ ] test/lint to ensure they are in sync