### PR TITLE
logging: don't attempt to close handlers unless they have been opened

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,12 @@ Changes in Traitlets
 Traitlets 5.2
 -------------
 
+5.2.1
+*****
+
+  - logging: Don't attempt to close handlers unless they have been opened.
+    Fixes ``ValueError: Unable to configure formatter 'console'`` traceback.
+
 5.2.0
 *****
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -944,7 +944,7 @@ class Application(SingletonConfigurable):
         return "\n".join(lines)
 
     def close_handlers(self):
-        if getattr(self, '_logging_configured', False):
+        if getattr(self, "_logging_configured", False):
             # don't attempt to close handlers unless they have been opened
             # (note accessing self.log.handlers will create handlers if they
             # have not yet been initialised)

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -276,6 +276,8 @@ class Application(SingletonConfigurable):
         config = self.get_default_logging_config()
         nested_update(config, self.logging_config or {})
         dictConfig(config)
+        # make a note that we have configured logging
+        self._logging_configured = True
 
     @default("log")
     def _log_default(self):
@@ -942,9 +944,14 @@ class Application(SingletonConfigurable):
         return "\n".join(lines)
 
     def close_handlers(self):
-        for handler in self.log.handlers:
-            with suppress(Exception):
-                handler.close()
+        if getattr(self, '_logging_configured', False):
+            # don't attempt to close handlers unless they have been opened
+            # (note accessing self.log.handlers will create handlers if they
+            # have not yet been initialised)
+            for handler in self.log.handlers:
+                with suppress(Exception):
+                    handler.close()
+            self._logging_configured = False
 
     def exit(self, exit_status=0):
         self.log.debug("Exiting application: %s" % self.name)

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -804,37 +804,48 @@ def test_logging_config(tmp_path, capsys):
     assert capsys.readouterr().err == "[Application] WARNING | warn\n"
 
 
-def test_logging_teardown_on_error(monkeypatch, capsys):
-    """Ensure we don't try to open logs in order to close them (See #722).
+@pytest.fixture
+def caplogconfig(monkeypatch):
+    """Capture logging config events for DictConfigurator objects.
 
-    If you try to configure logging handlers whilst Python is shutting down
-    you'll get traceback.
+    This suppresses the event (so the configuration doesn't happen).
+
+    Returns a list of (args, kwargs).
     """
-    # simulate a failure configuring logging handlers
-    # (this can happen if you try to configure handlers whilst Python is
-    # shutting down).
+    calls = []
+
     def _configure(*args, **kwargs):
-        raise Exception()
+        nonlocal calls
+        calls.append((args, kwargs))
 
     monkeypatch.setattr(
         "logging.config.DictConfigurator.configure",
         _configure,
     )
 
+    return calls
+
+
+def test_logging_teardown_on_error(capsys, caplogconfig):
+    """Ensure we don't try to open logs in order to close them (See #722).
+
+    If you try to configure logging handlers whilst Python is shutting down
+    you may get traceback.
+    """
     # create and destroy an app (without configuring logging)
-    # (ensure that we don't get any traceback)
+    # (ensure that the logs were not configured)
     app = Application()
     del app
+    assert len(caplogconfig) == 0  # logging was not configured
     out, err = capsys.readouterr()
     assert "Traceback" not in err
 
-    # ensure that we would get traceback otherwise
+    # ensure that the logs would have been configured otherwise
     # (to prevent this test from yielding false-negatives)
     app = Application()
     app._logging_configured = True  # make it look like logging was configured
     del app
-    out, err = capsys.readouterr()
-    assert "Traceback" in err
+    assert len(caplogconfig) == 1  # logging was configured
 
 
 if __name__ == "__main__":

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -815,6 +815,7 @@ def test_logging_teardown_on_error(monkeypatch, capsys):
     # shutting down).
     def _configure(*args, **kwargs):
         raise Exception()
+
     monkeypatch.setattr(
         "logging.config.DictConfigurator.configure",
         _configure,
@@ -825,7 +826,7 @@ def test_logging_teardown_on_error(monkeypatch, capsys):
     app = Application()
     del app
     out, err = capsys.readouterr()
-    assert 'Traceback' not in err
+    assert "Traceback" not in err
 
     # ensure that we would get traceback otherwise
     # (to prevent this test from yielding false-negatives)
@@ -833,7 +834,7 @@ def test_logging_teardown_on_error(monkeypatch, capsys):
     app._logging_configured = True  # make it look like logging was configured
     del app
     out, err = capsys.readouterr()
-    assert 'Traceback' in err
+    assert "Traceback" in err
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Accessing `Application.log.handlers` causes them to be opened if not done already.
* Attempting to open log handlers whilst Python is shutting down causes traceback.
* Closes #722
* Traceback introduced by https://github.com/ipython/traitlets/pull/698 (apologies)