### PR TITLE
Switch to hatch backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling >=0.25"]
+build-backend = "hatchling.build"
 
 [project]
 name = "traitlets"
@@ -23,8 +23,8 @@ dynamic = ["description", "version"]
 [project.optional-dependencies]
 test = ["pytest", "pre-commit"]
 
-[tool.flit.sdist]
-include = ['examples/']
+[tool.hatch.version]
+path = "traitlets/_version.py"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/traitlets/_version.py
+++ b/traitlets/_version.py
@@ -1,9 +1,10 @@
 version_info = (5, 3, 0, "dev0")
+__version__ = "5.3.0.dev0"
 
 # unlike `.dev`, alpha, beta and rc _must not_ have dots,
 # or the wheel and tgz won't look to pip like the same version.
 
-__version__ = (
+assert __version__ == (
     ".".join(map(str, version_info)).replace(".b", "b").replace(".a", "a").replace(".rc", "rc")
 )
 assert ".b" not in __version__


### PR DESCRIPTION
[Hatch](https://hatch.pypa.io/latest/) is now part of the pypa, and gives us more flexibility.

Also works around https://github.com/pypa/pip/issues/11110, which is causing builds to fail