### PR TITLE
parse version_info from __version__

### DIFF
--- a/traitlets/_version.py
+++ b/traitlets/_version.py
@@ -1,12 +1,20 @@
-version_info = (5, 4, 0, "dev0")
+import re
+
 __version__ = "5.4.0.dev0"
 
-# unlike `.dev`, alpha, beta and rc _must not_ have dots,
-# or the wheel and tgz won't look to pip like the same version.
 
-assert __version__ == (
-    ".".join(map(str, version_info)).replace(".b", "b").replace(".a", "a").replace(".rc", "rc")
+# light version of the pep440 subset we use
+# to build version_info tuple
+_match = re.match(
+    r"(\d+)+\.(\d+)\.(\d+)((?:(a|b|rc)\d+)|(?:\.dev\d+)|)$",
+    __version__,
 )
-assert ".b" not in __version__
-assert ".a" not in __version__
-assert ".rc" not in __version__
+assert _match is not None, f"Invalid __version__: {__version__}"
+
+_v = _match.groups()
+version_info = tuple(int(_v[i]) for i in range(3))
+if _v[3]:
+    # item 3 is _any_ extra info on the end (pre, .post, etc.)
+    version_info = version_info + (_v[3],)
+
+print(version_info)


### PR DESCRIPTION
rather than the other way around, since tooling doesn't seem to support building version strings from version tuples these days.

use lighter subset of pep440 since we don't need every kind of version [it can handle](https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions)

alternative: use `packaging.version.Version` for parsing, build tuple from there, e.g.

```python
_v = Version(__version__)
version_info = _v.release # (x, y, z)
if v.pre or v.dev or v.post:
    version_info = version_info + (__version__[len(_v.base_version):].lstrip("."),)
```