### PR TITLE
Fix and refactor downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: ipython
+          package_spec: pip install -e ".[test]"
 
   nbconvert:
     runs-on: ubuntu-latest

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -51,16 +51,13 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: ipywidgets
-
-  notebook:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Test notebook
-        run: |
-          git clone https://github.com/jupyter/notebook.git
-          cd notebook
-          pip install -e ".[test]"
-          python -m pytest -ra -x -vv --full-trace --color=yes
+# TODO: reinstate when notebook 7 is released.
+# notebook:
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 10
+#   steps:
+#     - uses: actions/checkout@v2
+#     - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+#     - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+#       with:
+#         package_name: notebook

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -2,54 +2,61 @@ name: Test downstream projects
 
 on:
   push:
+    branches: ["main"]
   pull_request:
 
+concurrency:
+  group: downstream-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  tests:
+  ipython:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
-          python-version: 3.8
+          package_name: ipython
 
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install build
-          python -m build .
-          pip install dist/traitlets*.whl
-          pip install --pre --upgrade traitlets[test] pytest pytest-cov
-          pip install ipython[test] nbconvert[test] \
-                      notebook>=7.0.0a5[test] ipywidgets[test]
-          pip freeze
+  nbconvert:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: nbconvert
+          package_spec: pip install -e ".[test]"
 
-      - name: Run tests IPython
-        run: |
-          cd $HOME
-          pytest -ra --cov traitlets --cov-report=xml:coverage-from-ipython.xml --pyargs IPython
+  jupyter_server:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: jupyter_server
 
-      - name: Run tests nbconvert
-        run: |
-          cd $HOME
-          pytest -ra --cov traitlets --cov-report=xml:coverage-from-nbconvert.xml \
-                 --pyargs nbconvert -p no:unraisableexception -k 'not network'
+  ipywidgets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: ipywidgets
 
-      - name: Run tests notebook
-        run: |
-          cd $HOME
-          pytest -ra --cov traitlets --cov-report=xml:coverage-from-notebook.xml \
-                 --pyargs notebook
-
-      - name: Run tests ipywidgets
-        run: |
-          cd $HOME
-          pytest -ra --cov traitlets --cov-report=xml:coverage-from-ipywidgets.xml \
-                 --pyargs ipywidgets
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+  notebook:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: notebook>=7.0.0a5

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -25,7 +25,7 @@ jobs:
           pip install dist/traitlets*.whl
           pip install --pre --upgrade traitlets[test] pytest pytest-cov
           pip install ipython[test] nbconvert[test] \
-                      notebook[test] ipywidgets[test]
+                      notebook>=7.0.0a5[test] ipywidgets[test]
           pip freeze
 
       - name: Run tests IPython

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -58,8 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - Name: Test notebook
-      - run: git clone https://github.com/jupyter/notebook.git
+      - name: Test notebook
+        run: |
+          git clone https://github.com/jupyter/notebook.git
           cd notebook
           pip install -e ".[test]"
           python -m pytest -ra -x -vv --full-trace --color=yes

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
-        with:
-          package_name: notebook>=7.0.0a5
+      - Name: Test notebook
+      - run: git clone https://github.com/jupyter/notebook.git
+          cd notebook
+          pip install -e ".[test]"
+          python -m pytest -ra -x -vv --full-trace --color=yes

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           cd $HOME
           pytest -ra --cov traitlets --cov-report=xml:coverage-from-notebook.xml \
-                 --pyargs notebook -k 'not selenium and not integration_tests'
+                 --pyargs notebook
 
       - name: Run tests ipywidgets
         run: |


### PR DESCRIPTION
Add placeholder for notebook test for when Notebook 7 is released, because Notebook 6 is unlikely to have a passing test suite in the near future.   Add test against `jupyter_server` instead.

Use the same test pattern as `jupyter_client`, with the actions from `jupyterlab/maintainer-tools`.