### PR TITLE
Update tests and docs to use non-deprecated functions

### DIFF
--- a/docs/source/using_traitlets.rst
+++ b/docs/source/using_traitlets.rst
@@ -143,8 +143,8 @@ properties.
 
     class Nested(HasTraits):
 
-        value = Dict(traits={
-            'configuration': Dict(trait=Unicode()),
+        value = Dict(per_key_traits={
+            'configuration': Dict(value_trait=Unicode()),
             'flag': Bool()
         })
 

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -237,7 +237,7 @@ class Configurable(HasTraits):
     def class_get_help(cls, inst=None):
         """Get the help string for this class in ReST format.
 
-        If `inst` is given, it's current trait values will be used in place of
+        If `inst` is given, its current trait values will be used in place of
         class defaults.
         """
         assert inst is None or isinstance(inst, cls)
@@ -255,7 +255,7 @@ class Configurable(HasTraits):
         """Get the helptext string for a single trait.
 
         :param inst:
-            If given, it's current trait values will be used in place of
+            If given, its current trait values will be used in place of
             the class default.
         :param helptext:
             If not given, uses the `help` attribute of the current trait.

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1953,7 +1953,10 @@ class TestInstanceKeyValidatedDict(TraitTestBase):
 class FullyValidatedDictTrait(HasTraits):
 
     value = Dict(
-        value_trait=Unicode(), key_trait=Unicode(), per_key_traits={"foo": Int()}, default_value={"foo": 1}
+        value_trait=Unicode(),
+        key_trait=Unicode(),
+        per_key_traits={"foo": Int()},
+        default_value={"foo": 1},
     )
 
 

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1910,7 +1910,7 @@ def test_dict_assignment():
 
 class UniformlyValueValidatedDictTrait(HasTraits):
 
-    value = Dict(trait=Unicode(), default_value={"foo": "1"})
+    value = Dict(value_trait=Unicode(), default_value={"foo": "1"})
 
 
 class TestInstanceUniformlyValueValidatedDict(TraitTestBase):
@@ -1924,7 +1924,7 @@ class TestInstanceUniformlyValueValidatedDict(TraitTestBase):
 
 class NonuniformlyValueValidatedDictTrait(HasTraits):
 
-    value = Dict(traits={"foo": Int()}, default_value={"foo": 1})
+    value = Dict(per_key_traits={"foo": Int()}, default_value={"foo": 1})
 
 
 class TestInstanceNonuniformlyValueValidatedDict(TraitTestBase):
@@ -1953,7 +1953,7 @@ class TestInstanceKeyValidatedDict(TraitTestBase):
 class FullyValidatedDictTrait(HasTraits):
 
     value = Dict(
-        trait=Unicode(), key_trait=Unicode(), traits={"foo": Int()}, default_value={"foo": 1}
+        value_trait=Unicode(), key_trait=Unicode(), per_key_traits={"foo": Int()}, default_value={"foo": 1}
     )
 
 


### PR DESCRIPTION
As a followup to https://github.com/ipython/traitlets/pull/306, this updates tests and docs to use the non-deprecated value_trait and per_key_traits arguments.

I also fixed two spelling typos.