### PR TITLE
Allow type checkers to infer trait types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ## 5.5.0
 
-* Clean up application typing
-* Update tests and docs to use non-deprecated functions
-* Clean up version handling
-* Prep for jupyter releaser
-* Format the changelog
+- Clean up application typing
+- Update tests and docs to use non-deprecated functions
+- Clean up version handling
+- Prep for jupyter releaser
+- Format the changelog
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.7"
 dynamic = ["description", "version"]
 
 [project.optional-dependencies]
-test = ["pytest", "pre-commit"]
+test = ["pytest", "pre-commit", "pytest-mypy-testing"]
 docs = [
     "myst-parser",
     "pydata-sphinx-theme",

--- a/traitlets/tests/test_typing.py
+++ b/traitlets/tests/test_typing.py
@@ -9,12 +9,13 @@ from traitlets import Bool, HasTraits, TCPAddress
 @pytest.mark.mypy_testing
 def mypy_bool_typing():
     class T(HasTraits):
-        b = Bool()
+        b = Bool().tag(sync=True)
 
     t = T()
     reveal_type(t.b)  # R: Union[builtins.bool, None]
     # we would expect this to be Optional[Union[bool, int]], but...
     t.b = "foo"  # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[int]")  [assignment]
+    T.b.tag(foo=True)
 
 
 @pytest.mark.mypy_testing

--- a/traitlets/tests/test_typing.py
+++ b/traitlets/tests/test_typing.py
@@ -1,27 +1,27 @@
-
 from lib2to3 import pytree
-from typing_extensions import reveal_type
-import pytest
 
-from traitlets import (
-    Bool,
-    HasTraits,
-    TCPAddress,
-)
+import pytest
+from typing_extensions import reveal_type
+
+from traitlets import Bool, HasTraits, TCPAddress
+
 
 @pytest.mark.mypy_testing
 def mypy_bool_typing():
     class T(HasTraits):
         b = Bool()
+
     t = T()
     reveal_type(t.b)  # R: Union[builtins.bool, None]
     # we would expect this to be Optional[Union[bool, int]], but...
-    t.b = 'foo' # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[int]")  [assignment]
+    t.b = "foo"  # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[int]")  [assignment]
+
 
 @pytest.mark.mypy_testing
 def mypy_tcp_typing():
     class T(HasTraits):
         tcp = TCPAddress()
+
     t = T()
     reveal_type(t.tcp)  # R: Union[Tuple[builtins.str, builtins.int], None]
-    t.tcp = 'foo' # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[Tuple[str, int]]")  [assignment]
+    t.tcp = "foo"  # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[Tuple[str, int]]")  [assignment]

--- a/traitlets/tests/test_typing.py
+++ b/traitlets/tests/test_typing.py
@@ -1,0 +1,27 @@
+
+from lib2to3 import pytree
+from typing_extensions import reveal_type
+import pytest
+
+from traitlets import (
+    Bool,
+    HasTraits,
+    TCPAddress,
+)
+
+@pytest.mark.mypy_testing
+def mypy_bool_typing():
+    class T(HasTraits):
+        b = Bool()
+    t = T()
+    reveal_type(t.b)  # R: Union[builtins.bool, None]
+    # we would expect this to be Optional[Union[bool, int]], but...
+    t.b = 'foo' # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[int]")  [assignment]
+
+@pytest.mark.mypy_testing
+def mypy_tcp_typing():
+    class T(HasTraits):
+        tcp = TCPAddress()
+    t = T()
+    reveal_type(t.tcp)  # R: Union[Tuple[builtins.str, builtins.int], None]
+    t.tcp = 'foo' # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[Tuple[str, int]]")  [assignment]

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -518,6 +518,7 @@ class BaseDescriptor:
 G = t.TypeVar("G")
 S = t.TypeVar("S")
 
+Self = t.TypeVar("Self", bound="TraitType")  # Holdover waiting for typings.Self in Python 3.11
 
 class TraitType(BaseDescriptor, t.Generic[G, S]):
     """A base class for all trait types."""
@@ -855,7 +856,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         warn("Deprecated in traitlets 4.1, " + msg, DeprecationWarning, stacklevel=2)
         self.metadata[key] = value
 
-    def tag(self, **metadata):
+    def tag(self, **metadata) -> "TraitType[G, S]":
         """Sets metadata and returns self.
 
         This allows convenient metadata tagging when initializing the trait, such as:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2316,7 +2316,7 @@ class CFloat(Float, TraitType[float, t.Any]):
         return _validate_bounds(self, obj, value)
 
 
-class Complex(TraitType[complex, complex | tuple[float, int]]):
+class Complex(TraitType[complex, complex | float | int]):
     """A trait for complex numbers."""
 
     default_value = 0.0 + 0.0j

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -515,8 +515,9 @@ class BaseDescriptor:
         pass
 
 
-G = t.TypeVar('G')
-S = t.TypeVar('S')
+G = t.TypeVar("G")
+S = t.TypeVar("S")
+
 
 class TraitType(BaseDescriptor, t.Generic[G, S]):
     """A base class for all trait types."""
@@ -644,7 +645,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         obj._trait_values[self.name] = value
         return value
 
-    def get(self, obj: 'HasTraits', cls: t.Any = None) -> t.Optional[G]:
+    def get(self, obj: "HasTraits", cls: t.Any = None) -> t.Optional[G]:
         try:
             value = obj._trait_values[self.name]  # type: ignore
         except KeyError:
@@ -676,7 +677,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         else:
             return value  # type: ignore
 
-    def __get__(self, obj: 'HasTraits', cls: t.Any = None) -> t.Optional[G]:
+    def __get__(self, obj: "HasTraits", cls: t.Any = None) -> t.Optional[G]:
         """Get the value of the trait by self.name for the instance.
 
         Default values are instantiated when :meth:`HasTraits.__new__`
@@ -707,7 +708,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
             # comparison above returns something other than True/False
             obj._notify_trait(self.name, old_value, new_value)
 
-    def __set__(self, obj: 'HasTraits', value: t.Optional[S]) -> None:
+    def __set__(self, obj: "HasTraits", value: t.Optional[S]) -> None:
         """Set the value of the trait by self.name for the instance.
 
         Values pass through a validation stage where errors are raised when
@@ -3467,7 +3468,9 @@ class UseEnum(TraitType[t.Any, t.Any]):
         return self._info(as_rst=True)
 
 
-class Callable(TraitType[collections.abc.Callable[..., t.Any], collections.abc.Callable[..., t.Any]]):
+class Callable(
+    TraitType[collections.abc.Callable[..., t.Any], collections.abc.Callable[..., t.Any]]
+):
     """A trait which is callable.
 
     Notes

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -520,6 +520,7 @@ S = t.TypeVar("S")
 
 Self = t.TypeVar("Self", bound="TraitType")  # Holdover waiting for typings.Self in Python 3.11
 
+
 class TraitType(BaseDescriptor, t.Generic[G, S]):
     """A base class for all trait types."""
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -514,7 +514,10 @@ class BaseDescriptor:
         pass
 
 
-class TraitType(BaseDescriptor):
+G = t.TypeVar('G')
+S = t.TypeVar('S')
+
+class TraitType(BaseDescriptor, t.Generic[G, S]):
     """A base class for all trait types."""
 
     metadata: t.Dict[str, t.Any] = {}
@@ -672,7 +675,7 @@ class TraitType(BaseDescriptor):
         else:
             return value
 
-    def __get__(self, obj, cls=None):
+    def __get__(self, obj, cls=None) -> G:
         """Get the value of the trait by self.name for the instance.
 
         Default values are instantiated when :meth:`HasTraits.__new__`
@@ -703,7 +706,7 @@ class TraitType(BaseDescriptor):
             # comparison above returns something other than True/False
             obj._notify_trait(self.name, old_value, new_value)
 
-    def __set__(self, obj, value):
+    def __set__(self, obj, value: S):
         """Set the value of the trait by self.name for the instance.
 
         Values pass through a validation stage where errors are raised when
@@ -2460,7 +2463,7 @@ class DottedObjectName(ObjectName):
         self.error(obj, value)
 
 
-class Bool(TraitType):
+class Bool(TraitType[str, t.Union[bool, int]]):
     """A boolean (True, False) trait."""
 
     default_value = False
@@ -2488,7 +2491,7 @@ class Bool(TraitType):
             raise ValueError("%r is not 1, 0, true, or false")
 
 
-class CBool(Bool):
+class CBool(Bool, TraitType[bool, t.Any]):
     """A casting version of the boolean trait."""
 
     def validate(self, obj, value):


### PR DESCRIPTION
We are currently encoding typing information for traits without integrating with the Python static typing system. This change is for allowing traitlets users to get static typing "for free" by using our trait types.

Ideally, the typing system would allow for default types, such that `TraitType == TraitType[t.Any, t.Any]`, and `TraitType[U] == TraitType[U, U]`, but for now we have to be verbose for this to work.

This is currently in a draft state, as some of the typings are still not accurately reflecting all the information we have. Potential improvements:
- [ ] The Union type should correctly surface its types as the typings union of those of its components
- [ ] Make the `Optional` part depend on allow_none (is it possible?).
- [ ] Improve types of class based traits
- [ ] Can we make the coercing variants not need to re-inherit `TraitType` ?
- [ ] Make Enum and UseEnum types better
- [ ] etc.

cc @maartenbreddels 