### PR TITLE
Minor fixes for Application.aliases

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -358,19 +358,15 @@ class Application(SingletonConfigurable):
     #: Values might be like "Class.trait" strings of two-tuples: (Class.trait, help-text),
     #  or just the "Class.trait" string, in which case the help text is inferred from the
     #  corresponding trait
-    aliases: t.Dict[
-        t.Union[str, t.Tuple[str, ...]],
-        t.Union[str, t.Tuple[str, str]]
-    ] = {"log-level": "Application.log_level"}
+    aliases: t.Dict[t.Union[str, t.Tuple[str, ...]], t.Union[str, t.Tuple[str, str]]] = {
+        "log-level": "Application.log_level"
+    }
 
     # flags for loading Configurables or store_const style flags
     # flags are loaded from this dict by '--key' flags
     # this must be a dict of two-tuples, the first element being the Config/dict
     # and the second being the help string for the flag
-    flags: t.Dict[
-        t.Union[str, t.Tuple[str, ...]],
-        t.Tuple[t.Union[t.Dict, Config], str]
-    ] = {
+    flags: t.Dict[t.Union[str, t.Tuple[str, ...]], t.Tuple[t.Union[t.Dict, Config], str]] = {
         "debug": (
             {
                 "Application": {

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -355,14 +355,22 @@ class Application(SingletonConfigurable):
 
     #: the alias map for configurables
     #: Keys might strings or tuples for additional options; single-letter alias accessed like `-v`.
-    #: Values might be like "Class.trait" strings of two-tuples: (Class.trait, help-text).
-    aliases: t.Dict[str, t.Any] = {"log-level": "Application.log_level"}
+    #: Values might be like "Class.trait" strings of two-tuples: (Class.trait, help-text),
+    #  or just the "Class.trait" string, in which case the help text is inferred from the
+    #  corresponding trait
+    aliases: t.Dict[
+        t.Union[str, t.Tuple[str, ...]],
+        t.Union[str, t.Tuple[str, str]]
+    ] = {"log-level": "Application.log_level"}
 
     # flags for loading Configurables or store_const style flags
     # flags are loaded from this dict by '--key' flags
     # this must be a dict of two-tuples, the first element being the Config/dict
     # and the second being the help string for the flag
-    flags: t.Dict[str, t.Any] = {
+    flags: t.Dict[
+        t.Union[str, t.Tuple[str, ...]],
+        t.Tuple[t.Union[t.Dict, Config], str]
+    ] = {
         "debug": (
             {
                 "Application": {

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -1049,8 +1049,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
 
             lhs = lhs.replace(_DOT_REPLACEMENT, ".")
             if "." not in lhs:
-                # probably a mistyped alias, but not technically illegal
-                self.log.warning("Unrecognized alias: '%s', it will have no effect.", lhs)
+                self._handle_unrecognized_alias(lhs)
                 trait = None
 
             if isinstance(rhs, list):
@@ -1074,6 +1073,15 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
 
         for subc in self.parsed_data._flags:
             self._load_flag(subc)
+
+    def _handle_unrecognized_alias(self, arg: str):
+        """Handling for unrecognized alias arguments
+
+        Probably a mistyped alias. By default just log a warning,
+        but users can override this to raise an error instead, e.g.
+        self.parser.error("Unrecognized alias: '%s'" % arg)
+        """
+        self.log.warning("Unrecognized alias: '%s', it will have no effect.", arg)
 
 
 class KeyValueConfigLoader(KVArgParseConfigLoader):

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -403,6 +403,7 @@ class TestApplication(TestCase):
 
     def test_alias_unrecognized(self):
         """Check ability to override handling for unrecognized aliases"""
+
         class StrictLoader(KVArgParseConfigLoader):
             def _handle_unrecognized_alias(self, arg):
                 self.parser.error("Unrecognized alias: %s" % arg)


### PR DESCRIPTION
1. Fix the type annotations for Applications.flags / aliases, which support tuples as keys and results in linting errors (e.g. in the test suite).
2. Move the logic for determining what to do with an unrecognized command-line argument to a helper method. Currently a warning is logged, but in past versions of traitlets an error was raised, and this might be more user-friendly in some cases especially where the stderr can be pretty verbose (e.g. launching Jupyterlab).