### PR TITLE
fix: mro_trait can be unbound when the class is not in mro

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1020,6 +1020,7 @@ class MetaHasTraits(MetaHasDescriptors):
                 cls._traits[name] = value
                 trait = value
                 default_method_name = "_%s_default" % name
+                mro_trait = mro
                 try:
                     mro_trait = mro[: mro.index(trait.this_class) + 1]  # type:ignore[arg-type]
                 except ValueError:


### PR DESCRIPTION
Closes #823

Not so happy that it doesn't include a test yet, and I think a linter should have picked up this mistake. @blink1073 do you know why CI didn't see this lint issue?

