### PR TITLE
Maint: Remove potentially extra usage of Unicode.

### DIFF
--- a/examples/subcommands_app.py
+++ b/examples/subcommands_app.py
@@ -27,7 +27,7 @@ class PrintHello(Configurable):
 
 
 class FooApp(Application):
-    name = Unicode("foo")
+    name = "foo"
     classes = [PrintHello]
     aliases = {
         "print-name": "PrintHello.greet_name",
@@ -41,7 +41,7 @@ class FooApp(Application):
 
 
 class BarApp(Application):
-    name = Unicode("bar")
+    name = "bar"
     classes = [PrintHello]
     aliases = {
         "print-name": "PrintHello.greet_name",
@@ -60,8 +60,8 @@ class BarApp(Application):
 
 
 class MainApp(Application):
-    name = Unicode("subcommand-example-app")
-    description = Unicode("demonstrates app with subcommands")
+    name = "subcommand-example-app"
+    description = "demonstrates app with subcommands"
     subcommands = {
         # Subcommands should be a dictionary mapping from the subcommand name
         # to one of the following:

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -149,11 +149,11 @@ class Application(SingletonConfigurable):
 
     # The name of the application, will usually match the name of the command
     # line application
-    name: t.Union[str, Unicode] = Unicode("application")
+    name: t.Union[str, Unicode] = "application"
 
     # The description of the application that is printed at the beginning
     # of the help.
-    description: t.Union[str, Unicode] = Unicode("This is an application.")
+    description: str = "This is an application."
     # default section descriptions
     option_description: t.Union[str, Unicode] = Unicode(option_description)
     keyvalue_description: t.Union[str, Unicode] = Unicode(keyvalue_description)


### PR DESCRIPTION
As far as I can tell setting this to `Unicode` does not achieve much. For example the IPython application that derives from it set it to a plain string and it works.

Same for description.

From my dev folder I haven't found any usage of name or description that needs this to be a `Unicode`, we we might as well make it always a str, which simplify a bit the codebase/types.

Usually the simpler the better.

It is _technically_ backward incompatible.

See https://github.com/ipython/ipython/pull/13895 that remove the usage of Unicode in description