### PR TITLE
Test that name and description can be set via constructor.

### DIFF
--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -137,6 +137,10 @@ class TestApplication(TestCase):
         self.assertEqual(app.classes, [MyApp, Bar, Foo])  # type:ignore
         self.assertEqual(app.config_file, "")
 
+    def test_app_name_set_via_constructor(self):
+        app = MyApp(name='set_via_constructor')
+        assert app.name == "set_via_constructor"
+
     def test_mro_discovery(self):
         app = MyApp()
 


### PR DESCRIPTION
Alternative to #825, that adds tests for behavior.

I don't think we _need_ the ability to set the value via a constructor, And I'm generally in favor of simplifying, but at least this should have tests.