### PR TITLE
Add option to load  traitlets values from environement.

### DIFF
--- a/examples/myapp.py
+++ b/examples/myapp.py
@@ -36,6 +36,14 @@ from traitlets.config.application import Application
 from traitlets.config.configurable import Configurable
 
 
+class SubConfigurable(Configurable):
+    subvalue = Int(0, help="The integer subvalue.").tag(config=True)
+
+    def describe(self):
+        print("I am SubConfigurable with:")
+        print("    subvalue =", self.subvalue)
+
+
 class Foo(Configurable):
     """A class that has configurable, typed attributes."""
 
@@ -44,9 +52,39 @@ class Foo(Configurable):
     name = Unicode("Brian", help="First name.").tag(config=True, shortname="B")
     mode = Enum(values=["on", "off", "other"], default_value="on").tag(config=True)
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # using parent=self allows configuration in the form c.Foo.SubConfigurable.subvalue=1
+        # while c.SubConfigurable.subvalue=1 will still work, this allow to
+        # target specific instances of SubConfigurables
+        self.subconf = SubConfigurable(parent=self)
+
+    def describe(self):
+        print("I am Foo with:")
+        print("    i    =", self.i)
+        print("    j    =", self.j)
+        print("    name =", self.name)
+        print("    mode =", self.mode)
+        self.subconf.describe()
+
 
 class Bar(Configurable):
     enabled = Bool(True, help="Enable bar.").tag(config=True)
+    mylist = List([1, 2, 3], help="Just a list.").tag(config=True)
+
+    def describe(self):
+        print("I am Bar with:")
+        print("    enabled = ", self.enabled)
+        print("    mylist  = ", self.mylist)
+        self.subconf.describe()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # here we do not use parent=self, so configuration in the form
+        # c.Bar.SubConfigurable.subvalue=1 will not work. Only
+        # c.SubConfigurable.subvalue=1 will work and affect all instances of
+        # SubConfigurable
+        self.subconf = SubConfigurable(config=self.config)
 
 
 class MyApp(Application):
@@ -76,8 +114,8 @@ class MyApp(Application):
     )
 
     def init_foo(self):
-        # Pass config to other classes for them to inherit the config.
-        self.foo = Foo(config=self.config)
+        # You can pass self as parent to automatically propagate config.
+        self.foo = Foo(parent=self)
 
     def init_bar(self):
         # Pass config to other classes for them to inherit the config.
@@ -87,18 +125,25 @@ class MyApp(Application):
         self.parse_command_line(argv)
         if self.config_file:
             self.load_config_file(self.config_file)
+        self.load_config_environ()
         self.init_foo()
         self.init_bar()
 
     def start(self):
         print("app.config:")
         print(self.config)
+        self.describe()
         print("try running with --help-all to see all available flags")
         assert self.log is not None
         self.log.debug("Debug Message")
         self.log.info("Info Message")
         self.log.warning("Warning Message")
         self.log.critical("Critical Message")
+
+    def describe(self):
+        print("I am MyApp with", self.name, self.running, "and 2 sub configurables Foo and bar:")
+        self.foo.describe()
+        self.bar.describe()
 
 
 def main():


### PR DESCRIPTION
For example this makes the following works:

With the env variables:

     MYAPP__Foo__j=42
     MYAPP__Bar__mylist='[4,5,3]'
     MYAPP__Foo__SubConfigurable__subvalue=-1

    $ python examples/myapp.py
    app.config:
    {'Foo': {'j': DeferredConfigString('42'), 'SubConfigurable': {'subvalue': DeferredConfigString('-1')}}, 'Bar': {'mylist': DeferredConfigString('[4,5,3]')}}
    I am MyApp with myapp False and 2 sub configurables Foo and bar:
    I am Foo with:
        i    = 0
        j    = 42
        name = Brian
        mode = on
    I am SubConfigurable with:
        subvalue = -1
    I am Bar with:
        enabled =  True
        mylist  =  [4, 5, 3]
    I am SubConfigurable with:
        subvalue = 0
    try running with --help-all to see all available flags
    [MyApp] WARNING | Warning Message
    [MyApp] CRITICAL | Critical Message

We use app.name uppercased as a prefix, as usually env variables are uppercase.

We use `__` instead of `.` as a separator as:
  - `.` is not valid in env variables,
  - `_` can be present in class names, so we can't use it.

I'm not going the full way of a config loader, as I don't think it is necessary.

I'm wondering if we should put env loading by default.


This also extend one of the examples to load from env, show the `parent=self` and describe the status of the various traits at run time instead of just the configuration. 