### PR TITLE
rename `MyClass` to `School`

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -127,28 +127,28 @@ subclass
     from traitlets.config.configurable import Configurable
     from traitlets import Int, Float, Unicode, Bool
 
-    class MyClass(Configurable):
+    class School(Configurable):
         name = Unicode('defaultname', help="the name of the object").tag(config=True)
         ranking = Integer(0, help="the class's ranking").tag(config=True)
         value = Float(99.0)
         # The rest of the class implementation would go here..
 
-    # Construct from config via MyClass(config=..)
+    # Construct from config via School(config=..)
 
-In this example, we see that :class:`MyClass` has three attributes, two
+In this example, we see that :class:`School` has three attributes, two
 of which (``name``, ``ranking``) can be configured.  All of the attributes
-are given types and default values.  If a :class:`MyClass` is instantiated,
+are given types and default values.  If a :class:`School` is instantiated,
 but not configured, these default values will be used.  But let's see how
 to configure this class in a configuration file
 
 .. code-block:: python
 
     # Sample config file
-    c.MyClass.name = 'coolname'
-    c.MyClass.ranking = 10
+    c.School.name = 'coolname'
+    c.School.ranking = 10
 
 After this configuration file is loaded, the values set in it will override
-the class defaults anytime a :class:`MyClass` is created.  Furthermore,
+the class defaults anytime a :class:`School` is created.  Furthermore,
 these attributes will be type checked and validated anytime they are set.
 This type checking is handled by the :mod:`traitlets` module,
 which provides the :class:`~traitlets.Unicode`, :class:`~traitlets.Integer` and
@@ -167,7 +167,7 @@ attribute of ``c`` is not the actual class, but instead is another
 
 .. note::
 
-    The careful reader may wonder how the ``ClassName`` (``MyClass`` in
+    The careful reader may wonder how the ``ClassName`` (``School`` in
     the above example) attribute of the configuration object ``c`` gets
     created. These attributes are created on the fly by the
     :class:`~traitlets.config.Config` instance, using a simple naming
@@ -191,7 +191,7 @@ JSON configuration file:
 .. code-block:: json
 
     {
-      "MyClass": {
+      "School": {
         "name": "coolname",
         "ranking": 10
       }
@@ -218,8 +218,8 @@ example that loads all of the values from the file :file:`base_config.py`:
     :caption: examples/docs/configs/base_config.py
 
     c = get_config()  # noqa
-    c.MyClass.name = 'coolname'
-    c.MyClass.ranking = 100
+    c.School.name = 'Harvard'
+    c.School.ranking = 100
 
 into the configuration file :file:`main_config.py`:
 
@@ -233,7 +233,7 @@ into the configuration file :file:`main_config.py`:
     load_subconfig('base_config.py')  # noqa
 
     # Now override one of the values
-    c.MyClass.name = 'bettername'
+    c.School.name = 'bettername'
 
 In a situation like this the :func:`load_subconfig` makes sure that the
 search path for sub-configuration files is inherited from that of the parent.

--- a/examples/docs/configs/base_config.py
+++ b/examples/docs/configs/base_config.py
@@ -1,5 +1,5 @@
 # Example config used by load_config_app.py
 
 c = get_config()  # noqa
-c.MyClass.name = 'coolname'
+c.MyClass.name = 'Harvard'
 c.MyClass.ranking = 100

--- a/examples/docs/configs/main_config.py
+++ b/examples/docs/configs/main_config.py
@@ -6,4 +6,4 @@ c = get_config()  # noqa
 load_subconfig('base_config.py')  # noqa
 
 # Now override one of the values
-c.MyClass.name = 'bettername'
+c.School.name = 'Caltech'

--- a/examples/docs/load_config_app.py
+++ b/examples/docs/load_config_app.py
@@ -5,16 +5,16 @@
 Example:
 
     $ ./examples/docs/load_config_app.py
-    bettername ranking:100
+    The school Caltech has a rank of 1.
 
-    $ ./examples/docs/load_config_app.py --name cli_name
-    cli_name ranking:100
+    $ ./examples/docs/load_config_app.py --name Duke
+    The school Duke has a rank of 1.
 
-    $ ./examples/docs/load_config_app.py --name cli_name --MyApp.MyClass.ranking=99
-    cli_name ranking:99
+    $ ./examples/docs/load_config_app.py --name Duke --MyApp.MyClass.ranking=12
+    The school Duke has a rank of 12.
 
     $ ./examples/docs/load_config_app.py -c ""
-    default ranking:0
+    The school MIT has a rank of 1.
 """
 
 from pathlib import Path
@@ -23,22 +23,22 @@ from traitlets import Int, Unicode
 from traitlets.config import Application, Configurable
 
 
-class MyClass(Configurable):
-    name = Unicode(default_value="default").tag(config=True)
-    ranking = Int().tag(config=True)
+class School(Configurable):
+    name = Unicode(default_value="MIT").tag(config=True)
+    ranking = Int(default_value=1).tag(config=True)
 
     def __str__(self):
-        return f"{self.name} ranking:{self.ranking}"
+        return f"The school {self.name} has a rank of {self.ranking}."
 
 
 class MyApp(Application):
-    classes = [MyClass]
+    classes = [School]
     config_file = Unicode(default_value="main_config", help="base name of config file").tag(
         config=True
     )
     aliases = {
-        "name": "MyClass.name",
-        "ranking": "MyClass.ranking",
+        "name": "School.name",
+        "ranking": "School.ranking",
         ("c", "config-file"): "MyApp.config_file",
     }
 
@@ -48,7 +48,7 @@ class MyApp(Application):
             self.load_config_file(self.config_file, [Path(__file__).parent / "configs"])
 
     def start(self):
-        print(MyClass(parent=self))
+        print(School(parent=self))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the docs and sample code, `MyClass` is a rather confusing and artificial name. To give the docs and example a more practical flavor, I have renamed `MyClass` to `School` in both the docs and the example code.
