### PR TITLE
Pass **kwds in MetaHasDescriptors __new__ and __init__

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -965,7 +965,7 @@ class MetaHasDescriptors(type):
     instantiated and sets their name attribute.
     """
 
-    def __new__(mcls, name, bases, classdict):  # noqa
+    def __new__(mcls, name, bases, classdict, **kwds):  # noqa
         """Create the HasDescriptors class."""
         for k, v in classdict.items():
             # ----------------------------------------------------------------
@@ -981,11 +981,11 @@ class MetaHasDescriptors(type):
                 classdict[k] = v()
             # ----------------------------------------------------------------
 
-        return super().__new__(mcls, name, bases, classdict)
+        return super().__new__(mcls, name, bases, classdict, **kwds)
 
-    def __init__(cls, name: str, bases: t.Any, classdict: t.Any) -> None:
+    def __init__(cls, name: str, bases: t.Any, classdict: t.Any, **kwds) -> None:
         """Finish initializing the HasDescriptors class."""
-        super().__init__(name, bases, classdict)
+        super().__init__(name, bases, classdict, **kwds)
         cls.setup_class(classdict)
 
     def setup_class(cls, classdict):


### PR DESCRIPTION
This is a modest change that adds `**kwds` to  `MetaHasDescriptors`  `__new__` and `__init__`  to match the signature defined in the [Python docs](https://docs.python.org/3.8/reference/datamodel.html?highlight=__init_subclass__#creating-the-class-object):

```
metaclass(name, bases, namespace, **kwds)
```

This enables the usage [`__init_subclass__`](https://docs.python.org/3/reference/datamodel.html?highlight=__init_subclass__#object.__init_subclass__) without having to overload `MetaHasDescriptors` to intercept the arguments passed to a subclass.

## Trivial example

```
from traitlets import HasTraits
class Philosopher(HasTraits):
    def __init_subclass__(cls, /, default_name, **kwargs):
        super().__init_subclass__(**kwargs)
        cls.default_name = default_name

class AustralianPhilosopher(Philosopher, default_name="Bruce"):
    pass
```
### Before
![image](https://github.com/ipython/traitlets/assets/1474668/b1107ea9-14fa-493c-9b9d-7086fa9b7fd2)

### After
![image](https://github.com/ipython/traitlets/assets/1474668/8fb3f522-08ff-456e-b948-4b08dede2ba9)

