### PR TITLE
Adopt sp-repo-review

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,8 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      -  name: Run Linters
-         run: |
+      - name: Run Linters
+        run: |
           hatch run typing:test
           hatch run lint:style
           pipx run 'validate-pyproject[all]' pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,23 @@
 ci:
   autoupdate_schedule: monthly
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: end-of-file-fixer
       - id: check-case-conflict
+      - id: check-ast
+      - id: check-docstring-first
       - id: check-executables-have-shebangs
-      - id: requirements-txt-fixer
       - id: check-added-large-files
       - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-json
       - id: check-toml
       - id: check-yaml
       - id: debug-statements
-      - id: forbid-new-submodules
-      - id: check-builtin-literals
+      - id: end-of-file-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
@@ -27,14 +29,47 @@ repos:
     rev: 0.7.17
     hooks:
       - id: mdformat
+        additional_dependencies:
+          [mdformat-gfm, mdformat-frontmatter, mdformat-footnote]
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.0.2"
+    hooks:
+      - id: prettier
+        types_or: [yaml, html, json]
+
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: "1.16.0"
+    hooks:
+      - id: blacken-docs
+        additional_dependencies: [black==23.7.0]
+
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.7.0
     hooks:
       - id: black
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: "v2.2.5"
+    hooks:
+      - id: codespell
+        args: ["-L", "sur,nd"]
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: "v1.10.0"
+    hooks:
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.287
+    rev: v0.1.1
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--fix", "--show-fixes"]
+
+  - repo: https://github.com/scientific-python/cookie
+    rev: "2023.08.23"
+    hooks:
+      - id: sp-repo-review
+        additional_dependencies: ["repo-review[cli]"]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-     python: "3.11"
+    python: "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,7 +231,7 @@
 - Fix version_info
 - Make generated config files more lintable
 - Fix union trait from string
-- Add security.md, and tidelift bage
+- Add security.md, and tidelift badge
 
 ## 5.3.0
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -41,7 +41,7 @@ Dynamic default values
 .. autofunction:: default
 
 To calculate a default value dynamically, decorate a method of your class with
-`@default({traitname})`. This method will be called on the instance, and should
+``@default({traitname})``. This method will be called on the instance, and should
 return the default value. For example::
 
     import getpass

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -127,11 +127,13 @@ subclass
     from traitlets.config.configurable import Configurable
     from traitlets import Int, Float, Unicode, Bool
 
+
     class School(Configurable):
-        name = Unicode('defaultname', help="the name of the object").tag(config=True)
+        name = Unicode("defaultname", help="the name of the object").tag(config=True)
         ranking = Integer(0, help="the class's ranking").tag(config=True)
         value = Float(99.0)
         # The rest of the class implementation would go here..
+
 
     # Construct from config via School(config=..)
 
@@ -144,7 +146,7 @@ to configure this class in a configuration file
 .. code-block:: python
 
     # Sample config file
-    c.School.name = 'coolname'
+    c.School.name = "coolname"
     c.School.ranking = 10
 
 After this configuration file is loaded, the values set in it will override
@@ -218,7 +220,7 @@ example that loads all of the values from the file :file:`base_config.py`:
     :caption: examples/docs/configs/base_config.py
 
     c = get_config()  # noqa
-    c.School.name = 'Harvard'
+    c.School.name = "Harvard"
     c.School.ranking = 100
 
 into the configuration file :file:`main_config.py`:
@@ -230,10 +232,10 @@ into the configuration file :file:`main_config.py`:
     c = get_config()  # noqa
 
     # Load everything from base_config.py
-    load_subconfig('base_config.py')  # noqa
+    load_subconfig("base_config.py")  # noqa
 
     # Now override one of the values
-    c.School.name = 'bettername'
+    c.School.name = "bettername"
 
 In a situation like this the :func:`load_subconfig` makes sure that the
 search path for sub-configuration files is inherited from that of the parent.
@@ -253,13 +255,16 @@ to be reflected in the configuration system.  Here is a simple example:
     from traitlets.config import Application, Configurable
     from traitlets import Integer, Float, Unicode, Bool
 
+
     class Foo(Configurable):
-        name = Unicode('fooname', config=True)
+        name = Unicode("fooname", config=True)
         value = Float(100.0, config=True)
 
+
     class Bar(Foo):
-        name = Unicode('barname', config=True)
+        name = Unicode("barname", config=True)
         othervalue = Int(0, config=True)
+
 
     # construct Bar(config=..)
 
@@ -271,7 +276,7 @@ and :class:`Bar`:
     # config file
     c = get_config()  # noqa
 
-    c.Foo.name = 'bestname'
+    c.Foo.name = "bestname"
     c.Bar.othervalue = 10
 
 This class hierarchy and configuration file accomplishes the following:
@@ -306,9 +311,11 @@ start the application:
 
     from traitlets.config import Application
 
+
     class MyApp(Application):
         def start(self):
             pass  # app logic goes here
+
 
     if __name__ == "__main__":
         MyApp.launch_instance()
@@ -325,11 +332,11 @@ is the same as adding:
 .. code-block:: python
 
     c.InteractiveShell.autoindent = False
-    c.BaseIPythonApplication.profile = 'myprofile'
+    c.BaseIPythonApplication.profile = "myprofile"
 
 to your configuration file. Command-line arguments take precedence over
 values read from configuration files. (This is done in
-:meth:`Application.load_config_file()` by merging `Application.cli_config`
+:meth:`Application.load_config_file()` by merging ``Application.cli_config``
 over values read from configuration files.)
 
 Note that even though :class:`Application` is a :class:`SingletonConfigurable`, multiple
@@ -342,17 +349,21 @@ them as one would with any other :class:`Configurable`:
 
     from traitlets.config import Application
 
+
     class OtherApp(Application):
         def start(self):
             print("other")
 
+
     class MyApp(Application):
         classes = [OtherApp]
+
         def start(self):
             # similar to OtherApp.launch_instance(), but without singleton
             self.other_app = OtherApp(config=self.config)
             self.other_app.initialize(["--OtherApp.log_level", "INFO"])
             self.other_app.start()
+
 
     if __name__ == "__main__":
         MyApp.launch_instance()
@@ -451,8 +462,10 @@ For example:
     from traitlets import Bool
     from traitlets.config import Application, Configurable
 
+
     class Foo(Configurable):
         enabled = Bool(False, help="whether enabled").tag(config=True)
+
 
     class App(Application):
         classes = [Foo]
@@ -461,6 +474,7 @@ For example:
             "dry-run": "App.dry_run",
             ("f", "foo-enabled"): ("Foo.enabled", "whether foo is enabled"),
         }
+
 
     if __name__ == "__main__":
         App.launch_instance()
@@ -500,21 +514,30 @@ And a runnable code example:
     from traitlets import Bool
     from traitlets.config import Application, Configurable
 
+
     class Foo(Configurable):
         enabled = Bool(False, help="whether enabled").tag(config=True)
+
 
     class App(Application):
         classes = [Foo]
         dry_run = Bool(False, help="dry run test").tag(config=True)
         flags = {
             "dry-run": ({"App": {"dry_run": True}}, dry_run.help),
-            ("f", "enable-foo"): ({
-               "Foo": {"enabled": True},
-            }, "Enable foo"),
-            ("disable-foo"): ({
-               "Foo": {"enabled": False},
-            }, "Disable foo"),
+            ("f", "enable-foo"): (
+                {
+                    "Foo": {"enabled": True},
+                },
+                "Enable foo",
+            ),
+            ("disable-foo"): (
+                {
+                    "Foo": {"enabled": False},
+                },
+                "Disable foo",
+            ),
         }
+
 
     if __name__ == "__main__":
         App.launch_instance()
@@ -572,8 +595,10 @@ For example (refer to ``examples/subcommands_app.py`` for a more complete exampl
 
     from traitlets.config import Application
 
+
     class SubApp1(Application):
         pass
+
 
     class SubApp2(Application):
         @classmethod
@@ -581,11 +606,13 @@ For example (refer to ``examples/subcommands_app.py`` for a more complete exampl
             app.clear_instance()  # since Application is singleton, need to clear main app
             return cls.instance(parent=app)
 
+
     class MainApp(Application):
         subcommands = {
             "subapp1": (SubApp1, "First subapp"),
             "subapp2": (SubApp2.get_subapp_instance, "Second subapp"),
         }
+
 
     if __name__ == "__main__":
         MainApp.launch_instance()
@@ -600,8 +627,8 @@ of setting up :class:`~traitlets.config.Application`, refer to the
 `application examples <https://github.com/ipython/traitlets/tree/main/examples>`__.
 
 
-Other `Application` members
----------------------------
+Other ``Application`` members
+-----------------------------
 
 The following are typically set as class variables of :class:`~traitlets.config.Application`
 subclasses, but can also be set as instance variables.
@@ -619,7 +646,7 @@ subclasses, but can also be set as instance variables.
   menu and other messages
 
 * ``.log_level``, ``.log_datefmt``, ``.log_format``, ``.logging_config``: Configurable options
-  to control application logging, which is emitted via the logger `Application.log`. For more
+  to control application logging, which is emitted via the logger ``Application.log``. For more
   information about these, refer to their respective traits' ``.help``.
 
 * ``.show_config``, ``.show_config_json``: Configurable boolean options, which if set to ``True``,
@@ -705,9 +732,11 @@ This could for example allow specifying hex-encoded bytes on the command-line:
     from traitlets.config import Application
     from traitlets import Bytes
 
+
     class HexBytes(Bytes):
         def from_string(self, s):
             return a2b_hex(s)
+
 
     class App(Application):
         aliases = {"key": "App.key"}
@@ -717,11 +746,12 @@ This could for example allow specifying hex-encoded bytes on the command-line:
 
             Specify as hex on the command-line.
             """,
-            config=True
+            config=True,
         )
 
         def start(self):
             print(f"key={self.key}")
+
 
     if __name__ == "__main__":
         App.launch_instance()
@@ -742,7 +772,7 @@ by passing the key multiple times, e.g.::
 
 to produce the list ``["a", "b"]``
 
-or for dictionaries use `key=value`::
+or for dictionaries use ``key=value``::
 
     myprogram -d a=5 -d b=10
 
@@ -769,6 +799,7 @@ This handling is good enough that we can recommend defining aliases for containe
     from traitlets.config import Application
     from traitlets import Dict, Integer, List, Unicode
 
+
     class App(Application):
         aliases = {"x": "App.x", "y": "App.y"}
         x = List(Unicode(), config=True)
@@ -777,6 +808,7 @@ This handling is good enough that we can recommend defining aliases for containe
         def start(self):
             print(f"x={self.x}")
             print(f"y={self.y}")
+
 
     if __name__ == "__main__":
         App.launch_instance()
@@ -800,7 +832,7 @@ specified on the command-line and is responsible for turning the list of strings
 into the appropriate type.
 Each item is then passed to :meth:`.List.item_from_string` which is responsible
 for handling the item,
-such as casting to integer or parsing `key=value` in the case of a Dict.
+such as casting to integer or parsing ``key=value`` in the case of a Dict.
 
 The deprecated :py:func:`ast.literal_eval` handling is preserved for backward-compatibility
 in the event of a single item that 'looks like' a list or dict literal.
@@ -824,12 +856,12 @@ to set a ``PathList`` trait with ``["/bin", "/usr/local/bin", "/opt/bin"]``.
 
 .. _argcomplete:
 
-Command-line tab completion with `argcomplete`
-----------------------------------------------
+Command-line tab completion with ``argcomplete``
+------------------------------------------------
 
 .. versionadded:: 5.8
 
-`traitlets` has limited support for command-line tab completion for scripts
+``traitlets`` has limited support for command-line tab completion for scripts
 based on :class:`~traitlets.config.Application` using
 `argcomplete <https://github.com/kislyuk/argcomplete>`__. To use this,
 follow the instructions for setting up argcomplete;
@@ -874,41 +906,41 @@ Detailed examples of these can be found in the docstring of
 `examples/argcomplete_app.py <https://github.com/ipython/traitlets/blob/main/examples/argcomplete_app.py>`__.
 
 
-Caveats with `argcomplete` handling
-***********************************
+Caveats with ``argcomplete`` handling
+*************************************
 
-The support for `argcomplete` is still relatively new and may not work with all ways in
+The support for ``argcomplete`` is still relatively new and may not work with all ways in
 which an :class:`~traitlets.config.Application` is used. Some known caveats:
 
-* `argcomplete` is called when any `Application` first constructs and uses a
+* ``argcomplete`` is called when any ``Application`` first constructs and uses a
   :class:`~traitlets.config.KVArgParseConfigLoader` instance, which constructs
-  a `argparse.ArgumentParser` instance.
+  a ``argparse.ArgumentParser`` instance.
   We assume that this is usually first done in scripts when parsing the command-line arguments,
   but technically a script can first call ``Application.initialize(["other", "args"])`` for
   some other reason.
 
-* `traitlets` does not actually add ``"--Class.trait"`` options to the `ArgumentParser`,
+* ``traitlets`` does not actually add ``"--Class.trait"`` options to the ``ArgumentParser``,
   but instead directly parses them from ``argv``. In order to complete these, a custom
   :class:`~traitlets.config.argcomplete_config.CompletionFinder` is subclassed from
   ``argcomplete.CompletionFinder``, which dynamically inserts the ``"--Class.""`` and ``"--Class.trait"``
   completions when it thinks suitable. However, this handling may be a bit fragile.
 
-* Because `traitlets` initializes configs from `argv` and not from `ArgumentParser`, it may be
+* Because ``traitlets`` initializes configs from ``argv`` and not from ``ArgumentParser``, it may be
   more difficult to write custom completers which dynamically provide completions based on the
   state of other parsed arguments.
 
-* Subcommand handling is especially tricky. `argcomplete`'s strategy is to call the python script
-  with no arguments e.g. ``len(sys.argv) == 1``, run until `argcomplete` is called on an `ArgumentParser`
-  and determine what completions are available. On the other hand, `traitlet`'s subcommand-handling
+* Subcommand handling is especially tricky. ``argcomplete`` libraries' strategy is to call the python script
+  with no arguments e.g. ``len(sys.argv) == 1``, run until ``argcomplete`` is called on an ``ArgumentParser``
+  and determine what completions are available. On the other hand, the ``traitlet``  subcommand-handling
   strategy is to check ``sys.argv[1]`` and see if it matches a subcommand, and if so then dynamically
   load the subcommand app and initialize it with ``sys.argv[1:]``. To reconcile these two different
-  approaches, some hacking was done to get `traitlets` to recognize the current command-line as seen
-  by `argcomplete`, and to get `argcomplete` to start parsing command-line arguments after subcommands
+  approaches, some hacking was done to get ``traitlets`` to recognize the current command-line as seen
+  by ``argcomplete``, and to get ``argcomplete`` to start parsing command-line arguments after subcommands
   have been evaluated.
 
   * Currently, completing subcommands themselves is not yet supported.
 
-  * Some applications like `Jupyter` have custom ways of constructing subcommands or parsing ``argv``
+  * Some applications like ``Jupyter`` have custom ways of constructing subcommands or parsing ``argv``
     which complicates matters even further.
 
 More details about these caveats can be found in the `original pull request <https://github.com/ipython/traitlets/pull/811>`__.

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -7,7 +7,7 @@ configuring traitlets and a couple of other changes.
 However, it is a backward-compatible release and the deprecated APIs
 will be supported for some time.
 
-Separation of metadata and keyword arguments in ``TraitType`` contructors
+Separation of metadata and keyword arguments in ``TraitType`` constructors
 -------------------------------------------------------------------------
 
 In traitlets 4.0, trait types constructors used all unrecognized keyword
@@ -20,7 +20,7 @@ populate the metadata for a trait type instance is to use the new
 
 .. code:: python
 
-    x = Int(allow_none=True, sync=True)      # deprecated
+    x = Int(allow_none=True, sync=True)  # deprecated
     x = Int(allow_none=True).tag(sync=True)  # ok
 
 We also deprecated the ``get_metadata`` method. The metadata of a trait
@@ -50,9 +50,7 @@ register and unregister handlers (instead of passing ``remove=True`` to
 
 .. code:: python
 
-    {
-        'type': The type of notification.
-    }
+    {"type": "<The type of notification.>"}
 
 In the case where ``type`` is the string ``'change'``, the following
 additional attributes are provided:
@@ -60,10 +58,10 @@ additional attributes are provided:
 .. code:: python
 
     {
-        'owner': the HasTraits instance,
-        'old': the old trait attribute value,
-        'new': the new trait attribute value,
-        'name': the name of the changing attribute,
+        "owner": "<the HasTraits instance>",
+        "old": "<the old trait attribute value>",
+        "new": "<the new trait attribute value>",
+        "name": "<the name of the changing attribute>",
     }
 
 The ``type`` key in the change dictionary is meant to enable protocols
@@ -76,16 +74,18 @@ for other notification types. By default, its value is equal to the
 
     from traitlets import HasTraits, Int, Unicode
 
-    class Foo(HasTraits):
 
+    class Foo(HasTraits):
         bar = Int()
         baz = Unicode()
+
 
     def handle_change(change):
         print("{name} changed from {old} to {new}".format(**change))
 
+
     foo = Foo()
-    foo.observe(handle_change, names='bar')
+    foo.observe(handle_change, names="bar")
 
 The new ``@observe`` decorator
 ------------------------------
@@ -104,17 +104,17 @@ by notification type.
     class Foo(HasTraits):
         bar = Int()
         baz = EnventfulContainer()  # hypothetical trait type emitting
-                                    # other notifications types
+        # other notifications types
 
-        @observe('bar')  # 'change' notifications for `bar`
+        @observe("bar")  # 'change' notifications for `bar`
         def handler_bar(self, change):
             pass
 
-        @observe('baz ', type='element_change')  # 'element_change' notifications for `baz`
+        @observe("baz ", type="element_change")  # 'element_change' notifications for `baz`
         def handler_baz(self, change):
             pass
 
-        @observe('bar', 'baz', type=All)  # all notifications for `bar` and `baz`
+        @observe("bar", "baz", type=All)  # all notifications for `bar` and `baz`
         def handler_all(self, change):
             pass
 
@@ -134,23 +134,25 @@ subclasses of ``trait.this_type``.
 
     from traitlets import HasTraits, Int, Float, default
 
+
     class A(HasTraits):
         bar = Int()
 
-        @default('bar')
+        @default("bar")
         def get_bar_default(self):
             return 11
 
+
     class B(A):
         bar = Float()  # This ignores the default generator
-                       # defined in the base class A
+        # defined in the base class A
+
 
     class C(B):
-
-        @default('bar')
+        @default("bar")
         def some_other_default(self):  # This should not be ignored since
-            return 3.0                 # it is defined in a class derived
-                                       # from B.a.this_class.
+            return 3.0  # it is defined in a class derived
+            # from B.a.this_class.
 
 Deprecation of magic method for cross-validation
 ------------------------------------------------
@@ -170,9 +172,9 @@ The method decorated with the ``@validate`` decorator take a single
 .. code:: python
 
     {
-        'trait': the trait type instance being validated
-        'value': the proposed value,
-        'owner': the underlying HasTraits instance,
+        "trait": "<the trait type instance being validated>",
+        "value": "<the proposed value>",
+        "owner": "<the underlying HasTraits instance>",
     }
 
 Custom validators may raise ``TraitError`` exceptions in case of invalid
@@ -184,24 +186,26 @@ proposal, and should return the value that will be eventually assigned.
 
     from traitlets import HasTraits, TraitError, Int, Bool, validate
 
+
     class Parity(HasTraits):
         value = Int()
         parity = Int()
 
-        @validate('value')
+        @validate("value")
         def _valid_value(self, proposal):
-            if proposal['value'] % 2 != self.parity:
-                raise TraitError('value and parity should be consistent')
-            return proposal['value']
+            if proposal["value"] % 2 != self.parity:
+                raise TraitError("value and parity should be consistent")
+            return proposal["value"]
 
-        @validate('parity')
+        @validate("parity")
         def _valid_parity(self, proposal):
-            parity = proposal['value']
+            parity = proposal["value"]
             if parity not in [0, 1]:
-                raise TraitError('parity should be 0 or 1')
+                raise TraitError("parity should be 0 or 1")
             if self.value % 2 != parity:
-                raise TraitError('value and parity should be consistent')
-            return proposal['value']
+                raise TraitError("value and parity should be consistent")
+            return proposal["value"]
+
 
     parity_check = Parity(value=2)
 
@@ -228,9 +232,11 @@ Take for instance the following class:
 
     from traitlets import HasTraits, Unicode
 
+
     class Parent(HasTraits):
         prefix = Unicode()
         path = Unicode()
+
         def _path_changed(self, name, old, new):
             self.prefix = os.path.dirname(new)
 
@@ -239,6 +245,8 @@ And you know another package has the subclass:
 .. code:: python
 
     from parent import Parent
+
+
     class Child(Parent):
         def _path_changed(self, name, old, new):
             super()._path_changed(name, old, new)
@@ -254,11 +262,12 @@ which automatically shims the deprecated signature into the new signature:
 
     from traitlets import HasTraits, Unicode, observe, observe_compat
 
+
     class Parent(HasTraits):
         prefix = Unicode()
         path = Unicode()
 
-        @observe('path')
-        @observe_compat # <- this allows super()._path_changed in subclasses to work with the old signature.
+        @observe("path")
+        @observe_compat  # <- this allows super()._path_changed in subclasses to work with the old signature.
         def _path_changed(self, change):
-            self.prefix = os.path.dirname(change['value'])
+            self.prefix = os.path.dirname(change["value"])

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -8,7 +8,7 @@ However, it is a backward-compatible release and the deprecated APIs
 will be supported for some time.
 
 Separation of metadata and keyword arguments in ``TraitType`` constructors
--------------------------------------------------------------------------
+--------------------------------------------------------------------------
 
 In traitlets 4.0, trait types constructors used all unrecognized keyword
 arguments passed to the constructor (like ``sync`` or ``config``) to

--- a/docs/source/using_traitlets.rst
+++ b/docs/source/using_traitlets.rst
@@ -23,10 +23,11 @@ subclasses:
     from traitlets import HasTraits, Int, Unicode, default
     import getpass
 
+
     class Identity(HasTraits):
         username = Unicode()
 
-        @default('username')
+        @default("username")
         def _default_username(self):
             return getpass.getuser()
 
@@ -35,7 +36,8 @@ subclasses:
     class Foo(HasTraits):
         bar = Int()
 
-    foo = Foo(bar='3')  # raises a TraitError
+
+    foo = Foo(bar="3")  # raises a TraitError
 
 ::
 
@@ -53,16 +55,19 @@ Traitlets implement the observer pattern
         bar = Int()
         baz = Unicode()
 
+
     foo = Foo()
 
-    def func(change):
-        print(change['old'])
-        print(change['new'])   # as of traitlets 4.3, one should be able to
-                               # write print(change.new) instead
 
-    foo.observe(func, names=['bar'])
+    def func(change):
+        print(change["old"])
+        print(change["new"])  # as of traitlets 4.3, one should be able to
+        # write print(change.new) instead
+
+
+    foo.observe(func, names=["bar"])
     foo.bar = 1  # prints '0\n 1'
-    foo.baz = 'abc'  # prints nothing
+    foo.baz = "abc"  # prints nothing
 
 When observers are methods of the class, a decorator syntax can be used.
 
@@ -72,10 +77,10 @@ When observers are methods of the class, a decorator syntax can be used.
         bar = Int()
         baz = Unicode()
 
-        @observe('bar')
+        @observe("bar")
         def _observe_bar(self, change):
-            print(change['old'])
-            print(change['new'])
+            print(change["old"])
+            print(change["new"])
 
 Validation and Coercion
 -----------------------
@@ -94,24 +99,25 @@ Basic Example: Validating the Parity of a Trait
 
     from traitlets import HasTraits, TraitError, Int, Bool, validate
 
+
     class Parity(HasTraits):
         data = Int()
         parity = Int()
 
-        @validate('data')
+        @validate("data")
         def _valid_data(self, proposal):
-            if proposal['value'] % 2 != self.parity:
-                raise TraitError('data and parity should be consistent')
-            return proposal['value']
+            if proposal["value"] % 2 != self.parity:
+                raise TraitError("data and parity should be consistent")
+            return proposal["value"]
 
-        @validate('parity')
+        @validate("parity")
         def _valid_parity(self, proposal):
-            parity = proposal['value']
+            parity = proposal["value"]
             if parity not in [0, 1]:
-                raise TraitError('parity should be 0 or 1')
+                raise TraitError("parity should be 0 or 1")
             if self.data % 2 != parity:
-                raise TraitError('data and parity should be consistent')
-            return proposal['value']
+                raise TraitError("data and parity should be consistent")
+            return proposal["value"]
 
 
     parity_check = Parity(data=2)
@@ -142,16 +148,16 @@ properties.
 
     from traitlets import HasTraits, Dict, Bool, Unicode
 
-    class Nested(HasTraits):
 
-        value = Dict(per_key_traits={
-            'configuration': Dict(value_trait=Unicode()),
-            'flag': Bool()
-        })
+    class Nested(HasTraits):
+        value = Dict(
+            per_key_traits={"configuration": Dict(value_trait=Unicode()), "flag": Bool()}
+        )
+
 
     n = Nested()
     n.value = dict(flag=True, configuration={})  # OK
-    n.value = dict(flag=True, configuration='')  # raises a TraitError.
+    n.value = dict(flag=True, configuration="")  # raises a TraitError.
 
 
 However, for deeply nested properties it might be more appropriate to use an
@@ -162,33 +168,34 @@ external validator:
     import jsonschema
 
     value_schema = {
-         'type' : 'object',
-         'properties' : {
-             'price' : { 'type' : 'number' },
-             'name' : { 'type' : 'string' },
-         },
-     }
+        "type": "object",
+        "properties": {
+            "price": {"type": "number"},
+            "name": {"type": "string"},
+        },
+    }
 
     from traitlets import HasTraits, Dict, TraitError, validate, default
 
-    class Schema(HasTraits):
 
+    class Schema(HasTraits):
         value = Dict()
 
-        @default('value')
+        @default("value")
         def _default_value(self):
-            return dict(name='', price=1)
+            return dict(name="", price=1)
 
-        @validate('value')
+        @validate("value")
         def _validate_value(self, proposal):
             try:
-                jsonschema.validate(proposal['value'], value_schema)
+                jsonschema.validate(proposal["value"], value_schema)
             except jsonschema.ValidationError as e:
                 raise TraitError(e)
-            return proposal['value']
+            return proposal["value"]
+
 
     s = Schema()
-    s.value = dict(name='', price='1')  # raises a TraitError
+    s.value = dict(name="", price="1")  # raises a TraitError
 
 
 Holding Trait Cross-Validation and Notifications

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ log_cli_level = "info"
 addopts = [
   "-raXs", "--durations=10", "--color=yes", "--doctest-modules",
    "--showlocals", "--strict-markers", "--strict-config",
-   "--ignore-glob=tests/dotipython*"
+   "--ignore=examples/docs/configs"
 ]
 testpaths = [
     "tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest>=7.0,<7.5", "pytest-mock", "pre-commit", "argcomplete>=3.0.3", "pytest-mypy-testing", "mypy>=1.5.1"]
+test = ["pytest>=7.0,<7.5", "pytest-mock", "pre-commit", "argcomplete>=3.0.3", "pytest-mypy-testing", "mypy>=1.6.0"]
 docs = [
     "myst-parser",
     "pydata-sphinx-theme",
@@ -76,8 +76,10 @@ fmt = [
 [tool.mypy]
 files = "traitlets"
 python_version = "3.8"
-strict = true
+strict = false
+check_untyped_defs = true
 disallow_any_generics = false
+disable_error_code = ["no-untyped-call"]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 no_implicit_reexport = false
 pretty = true
@@ -231,4 +233,4 @@ unfixable = [
 "examples/*" = ["ANN"]
 
 [tool.repo-review]
-ignore = ["PY007", "PP308", "GH102", "PC140"]
+ignore = ["PY007", "PP308", "GH102", "PC140", "MY101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ features = ["test"]
 test = "mypy --install-types --non-interactive {args}"
 
 [tool.hatch.envs.lint]
-dependencies = ["black==23.3.0", "mdformat>0.7", "ruff==0.0.281"]
+dependencies = ["black==23.3.0", "mdformat>0.7", "ruff==0.1.1"]
 detached = true
 [tool.hatch.envs.lint.scripts]
 style = [
@@ -76,27 +76,26 @@ fmt = [
 [tool.mypy]
 files = "traitlets"
 python_version = "3.8"
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_untyped_decorators = true
-explicit_package_bases = true
-namespace_packages = true
-no_implicit_optional = true
-no_implicit_reexport = true
+strict = true
+disallow_any_generics = false
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+no_implicit_reexport = false
 pretty = true
 show_error_context = true
 show_error_codes = true
-strict_equality = true
-strict_optional = true
-warn_unused_configs = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unused_ignores = true
+warn_return_any = false
+warn_unreachable = true
 exclude = ["examples/docs/configs", "traitlets/tests/test_typing.py"]
 
 [tool.pytest.ini_options]
-addopts = "--durations=10 -ra --showlocals --doctest-modules --color yes --ignore examples/docs/configs"
+minversion = "6.0"
+xfail_strict = true
+log_cli_level = "info"
+addopts = [
+  "-raXs", "--durations=10", "--color=yes", "--doctest-modules",
+   "--showlocals", "--strict-markers", "--strict-config",
+   "--ignore-glob=tests/dotipython*"
+]
 testpaths = [
     "tests",
     "examples",
@@ -230,3 +229,6 @@ unfixable = [
 "traitlets/*__init__.py" = ["F401", "F403"]
 "docs/*" = ["ANN"]
 "examples/*" = ["ANN"]
+
+[tool.repo-review]
+ignore = ["PY007", "PP308", "GH102", "PC140"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,10 @@ ignore = [
   "S110",
   # RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
   "RUF012",
+  # non-pep585-annotation
+  "UP006",
+  # non-pep604-annotation
+  "UP007",
 ]
 unfixable = [
   # Don't touch print statements

--- a/tests/_warnings.py
+++ b/tests/_warnings.py
@@ -38,7 +38,7 @@ def all_warnings():
     """
 
     # Whenever a warning is triggered, Python adds a __warningregistry__
-    # member to the *calling* module.  The exercize here is to find
+    # member to the *calling* module.  The exercise here is to find
     # and eradicate all those breadcrumbs that were left lying around.
     #
     # We proceed by first searching all parent calling frames and explicitly
@@ -88,7 +88,7 @@ def expected_warnings(matching):
     Raises a ValueError if any match was not found or an unexpected
     warning was raised.
     Allows for three types of behaviors: "and", "or", and "optional" matches.
-    This is done to accomodate different build enviroments or loop conditions
+    This is done to accommodate different build environments or loop conditions
     that may produce different warnings.  The behaviors can be combined.
     If you pass multiple patterns, you get an orderless "and", where all of the
     warnings must be raised.

--- a/tests/config/test_application.py
+++ b/tests/config/test_application.py
@@ -665,7 +665,7 @@ class TestApplication(TestCase):
             with self.assertRaises(AttributeError):
                 app.loaded_config_files = "/foo"  # type:ignore
 
-            # ensure it can't be udpated via append
+            # ensure it can't be updated via append
             app.loaded_config_files.append("/bar")
             self.assertEqual(len(app.loaded_config_files), 1)
 

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -629,7 +629,7 @@ class TestConfig(TestCase):
         """
         With multiple config files (systemwide and users), we want compounding.
 
-        If systemwide overwirte and user append, we want both in the right
+        If systemwide overwrite and user append, we want both in the right
         order.
         """
         c1 = Config()
@@ -702,7 +702,7 @@ class TestConfig(TestCase):
         """
         With multiple config files (systemwide and users), we want compounding.
 
-        dict update shoudl be in the right order.
+        dict update should be in the right order.
         """
         c1 = Config()
         c2 = Config()
@@ -720,7 +720,7 @@ class TestConfig(TestCase):
         """
         With multiple config files (systemwide and users), we want compounding.
 
-        Later dict overwrite lazyness
+        Later dict overwrite laziness
         """
         c1 = Config()
         c2 = Config()
@@ -738,7 +738,7 @@ class TestConfig(TestCase):
         """
         With multiple config files (systemwide and users), we want compounding.
 
-        Later dict overwrite lazyness
+        Later dict overwrite laziness
         """
         c1 = Config()
         c2 = Config()

--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -2013,7 +2013,7 @@ class TestLink(TestCase):
         a = A(value=9)
         b = A(value=8)
 
-        # Conenct the two classes.
+        # Connect the two classes.
         c = link((a, "value"), (b, "value"))
 
         # Make sure the values are the same at the point of linking.
@@ -2038,7 +2038,7 @@ class TestLink(TestCase):
         a = A(value=9)
         b = B(count=8)
 
-        # Conenct the two classes.
+        # Connect the two classes.
         c = link((a, "value"), (b, "count"))
 
         # Make sure the values are the same at the point of linking.
@@ -2126,7 +2126,7 @@ class TestLink(TestCase):
         a = A(value=9)
         b = A(value=8)
 
-        # Conenct the two classes.
+        # Connect the two classes.
         c = link((a, "value"), (b, "value"), transform=(lambda x: 2 * x, lambda x: int(x / 2.0)))
 
         # Make sure the values are correct at the point of linking.
@@ -2178,7 +2178,7 @@ class TestDirectionalLink(TestCase):
         a = A(value=9)
         b = A(value=8)
 
-        # Conenct the two classes.
+        # Connect the two classes.
         c = directional_link((a, "value"), (b, "value"))
 
         # Make sure the values are the same at the point of linking.
@@ -2201,7 +2201,7 @@ class TestDirectionalLink(TestCase):
         a = A(value=9)
         b = A(value=8)
 
-        # Conenct the two classes.
+        # Connect the two classes.
         c = directional_link((a, "value"), (b, "value"), lambda x: 2 * x)
 
         # Make sure the values are correct at the point of linking.
@@ -2227,7 +2227,7 @@ class TestDirectionalLink(TestCase):
         a = A(value=9)
         b = B(count=8)
 
-        # Conenct the two classes.
+        # Connect the two classes.
         c = directional_link((a, "value"), (b, "count"))
 
         # Make sure the values are the same at the point of linking.

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -298,7 +298,7 @@ class Application(SingletonConfigurable):
         log = logging.getLogger(self.__class__.__name__)
         log.propagate = False
         _log = log  # copied from Logger.hasHandlers() (new in Python 3.2)
-        while _log:
+        while _log is not None:
             if _log.handlers:
                 return log
             if not _log.propagate:
@@ -337,21 +337,21 @@ class Application(SingletonConfigurable):
             .. code-block:: python
 
                c.Application.logging_config = {
-                   'handlers': {
-                       'file': {
-                           'class': 'logging.FileHandler',
-                           'level': 'DEBUG',
-                           'filename': '<path/to/file>',
+                   "handlers": {
+                       "file": {
+                           "class": "logging.FileHandler",
+                           "level": "DEBUG",
+                           "filename": "<path/to/file>",
                        }
                    },
-                   'loggers': {
-                       '<application-name>': {
-                           'level': 'DEBUG',
+                   "loggers": {
+                       "<application-name>": {
+                           "level": "DEBUG",
                            # NOTE: if you don't list the default "console"
                            # handler here then it will be disabled
-                           'handlers': ['console', 'file'],
+                           "handlers": ["console", "file"],
                        },
-                   }
+                   },
                }
 
         """,
@@ -535,7 +535,7 @@ class Application(SingletonConfigurable):
                 trait = cls.class_traits(config=True)[traitname]
                 fhelp_lines = cls.class_get_trait_help(trait, helptext=fhelp).splitlines()
 
-                if not isinstance(alias, tuple):
+                if not isinstance(alias, tuple):  # type:ignore[unreachable]
                     alias = (alias,)  # type:ignore[assignment]
                 alias = sorted(alias, key=len)  # type:ignore[assignment]
                 alias = ", ".join(("--%s" if len(m) > 1 else "-%s") % m for m in alias)
@@ -559,7 +559,7 @@ class Application(SingletonConfigurable):
 
         for flags, (cfg, fhelp) in self.flags.items():
             try:
-                if not isinstance(flags, tuple):
+                if not isinstance(flags, tuple):  # type:ignore[unreachable]
                     flags = (flags,)  # type:ignore[assignment]
                 flags = sorted(flags, key=len)  # type:ignore[assignment]
                 flags = ", ".join(("--%s" if len(m) > 1 else "-%s") % m for m in flags)
@@ -643,7 +643,7 @@ class Application(SingletonConfigurable):
 
         if classes:
             help_classes = self._classes_with_config_traits()
-            if help_classes:
+            if help_classes is not None:
                 yield "Class options"
                 yield "============="
                 for p in wrap_paragraphs(self.keyvalue_description):
@@ -752,7 +752,7 @@ class Application(SingletonConfigurable):
             if len(children) == 1:
                 # exactly one descendent, promote alias
                 cls = children[0]  # type:ignore[assignment]
-            if not isinstance(aliases, tuple):
+            if not isinstance(aliases, tuple):  # type:ignore[unreachable]
                 alias = (alias,)  # type:ignore[assignment]
             for al in alias:
                 aliases[al] = ".".join([cls, trait])  # type:ignore[list-item]
@@ -773,7 +773,7 @@ class Application(SingletonConfigurable):
                 else:
                     newflag[cls] = subdict
 
-            if not isinstance(key, tuple):
+            if not isinstance(key, tuple):  # type:ignore[unreachable]
                 key = (key,)  # type:ignore[assignment]
             for k in key:
                 flags[k] = (newflag, help)

--- a/traitlets/config/argcomplete_config.py
+++ b/traitlets/config/argcomplete_config.py
@@ -10,7 +10,7 @@ import typing as t
 
 try:
     import argcomplete
-    from argcomplete import CompletionFinder  # type:ignore
+    from argcomplete import CompletionFinder
 except ImportError:
     # This module and its utility methods are written to not crash even
     # if argcomplete is not installed.
@@ -20,8 +20,8 @@ except ImportError:
                 raise ModuleNotFoundError("No module named 'argcomplete'")
             raise AttributeError(f"argcomplete stub module has no attribute '{attr}'")
 
-    argcomplete = StubModule()  # type:ignore
-    CompletionFinder = object  # type:ignore
+    argcomplete = StubModule()  # type:ignore[assignment]
+    CompletionFinder = object  # type:ignore[assignment, misc]
 
 
 def get_argcomplete_cwords() -> t.Optional[t.List[str]]:
@@ -45,9 +45,7 @@ def get_argcomplete_cwords() -> t.Optional[t.List[str]]:
             cword_suffix,
             comp_words,
             last_wordbreak_pos,
-        ) = argcomplete.split_line(  # type:ignore
-            comp_line, comp_point
-        )
+        ) = argcomplete.split_line(comp_line, comp_point)
     except ModuleNotFoundError:
         return None
 
@@ -75,9 +73,7 @@ def increment_argcomplete_index() -> None:
         os.environ["_ARGCOMPLETE"] = str(int(os.environ["_ARGCOMPLETE"]) + 1)
     except Exception:
         try:
-            argcomplete.debug(  # type:ignore
-                "Unable to increment $_ARGCOMPLETE", os.environ["_ARGCOMPLETE"]
-            )
+            argcomplete.debug("Unable to increment $_ARGCOMPLETE", os.environ["_ARGCOMPLETE"])
         except (KeyError, ModuleNotFoundError):
             pass
 
@@ -153,7 +149,7 @@ class ExtendedCompletionFinder(CompletionFinder):
     def _get_completions(
         self, comp_words: t.List[str], cword_prefix: str, *args: t.Any
     ) -> t.List[str]:
-        """Overriden to dynamically append --Class.trait arguments if appropriate
+        """Overridden to dynamically append --Class.trait arguments if appropriate
 
         Warning:
             This does not (currently) support completions of the form
@@ -200,7 +196,7 @@ class ExtendedCompletionFinder(CompletionFinder):
         # Instead, check if comp_words only consists of the script,
         # if so check if any subcommands start with cword_prefix.
         if self.subcommands and len(comp_words) == 1:
-            argcomplete.debug("Adding subcommands for", cword_prefix)  # type:ignore
+            argcomplete.debug("Adding subcommands for", cword_prefix)
             completions.extend(subc for subc in self.subcommands if subc.startswith(cword_prefix))
 
         return completions
@@ -208,7 +204,7 @@ class ExtendedCompletionFinder(CompletionFinder):
     def _get_option_completions(
         self, parser: argparse.ArgumentParser, cword_prefix: str
     ) -> t.List[str]:
-        """Overriden to add --Class. completions when appropriate"""
+        """Overridden to add --Class. completions when appropriate"""
         completions: t.List[str]
         completions = super()._get_option_completions(parser, cword_prefix)
         if cword_prefix.endswith("."):
@@ -217,7 +213,7 @@ class ExtendedCompletionFinder(CompletionFinder):
         matched_completions = self.match_class_completions(cword_prefix)
         if len(matched_completions) > 1:
             completions.extend(opt for cls, opt in matched_completions)
-        # If there is exactly one match, we would expect it to have aleady
+        # If there is exactly one match, we would expect it to have already
         # been handled by the options dynamically added in _get_completions().
         # However, maybe there's an edge cases missed here, for example if the
         # matched class has no configurable traits.

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -123,7 +123,7 @@ class Configurable(HasTraits):
             setattr(self, name, kwargs[name])
 
     # -------------------------------------------------------------------------
-    # Static trait notifiations
+    # Static trait notifications
     # -------------------------------------------------------------------------
 
     @classmethod
@@ -161,7 +161,10 @@ class Configurable(HasTraits):
         return my_config
 
     def _load_config(
-        self, cfg: Config, section_names: list[str] | None = None, traits: list[str] | None = None
+        self,
+        cfg: Config,
+        section_names: list[str] | None = None,
+        traits: dict[str, TraitType] | None = None,
     ) -> None:
         """load traits from a Config object"""
 
@@ -344,6 +347,7 @@ class Configurable(HasTraits):
             if the defining class is not in `classes`.
         """
         defining_cls = cls
+        assert trait.name is not None
         for parent in cls.mro():
             if (
                 issubclass(parent, Configurable)
@@ -382,9 +386,9 @@ class Configurable(HasTraits):
             desc = desc.default_value
         if not desc:
             # no description from trait, use __doc__
-            desc = getattr(cls, "__doc__", "")
+            desc = getattr(cls, "__doc__", "")  # type:ignore[arg-type]
         if desc:
-            lines.append(c(desc))
+            lines.append(c(desc))  # type:ignore[arg-type]
             lines.append("")
 
         for name, trait in sorted(cls.class_traits(config=True).items()):
@@ -424,12 +428,14 @@ class Configurable(HasTraits):
         for _, trait in sorted(cls.class_traits(config=True).items()):
             ttype = trait.__class__.__name__
 
+            if not trait.name:
+                continue
             termline = classname + "." + trait.name
 
             # Choices or type
             if "Enum" in ttype:
                 # include Enum choices
-                termline += " : " + trait.info_rst()
+                termline += " : " + trait.info_rst()  # type:ignore[attr-defined]
             else:
                 termline += " : " + ttype
             lines.append(termline)
@@ -540,7 +546,7 @@ class SingletonConfigurable(LoggingConfigurable):
             if isinstance(subclass._instance, cls):
                 # only clear instances that are instances
                 # of the calling class
-                subclass._instance = None
+                subclass._instance = None  # type:ignore[unreachable]
 
     @classmethod
     def instance(cls: type[CT], *args: t.Any, **kwargs: t.Any) -> CT:
@@ -562,7 +568,7 @@ class SingletonConfigurable(LoggingConfigurable):
             >>> foo == Foo.instance()
             True
 
-        Create a subclass that is retrived using the base class instance::
+        Create a subclass that is retrieved using the base class instance::
 
             >>> class Bar(SingletonConfigurable): pass
             >>> class Bam(Bar): pass

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -176,7 +176,7 @@ class LazyConfigValue(HasTraits):
         after applying any insert / extend / update changes
         """
         if self._value is not None:
-            return self._value
+            return self._value  # type:ignore[unreachable]
         value = copy.deepcopy(initial)
         if isinstance(value, list):
             for idx, obj in self._inserts:
@@ -860,7 +860,7 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
             arguments from. If not given, the instance's self.argv attribute
             (given at construction time) is used.
         flags
-            Deprecated in traitlets 5.0, instanciate the config loader with the flags.
+            Deprecated in traitlets 5.0, instantiate the config loader with the flags.
 
         """
 
@@ -914,7 +914,7 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
             for alias, alias_target in self.aliases.items():
                 if alias in self.flags:
                     continue
-                if not isinstance(alias, tuple):
+                if not isinstance(alias, tuple):  # type:ignore[unreachable]
                     alias = (alias,)  # type:ignore[assignment]
                 for al in alias:
                     if len(al) == 1:
@@ -1057,7 +1057,9 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
                 action = paa(*keys, **argparse_kwds)
                 if argcompleter is not None:
                     # argcomplete's completers are callables returning list of completion strings
-                    action.completer = functools.partial(argcompleter, key=key)  # type: ignore
+                    action.completer = functools.partial(
+                        argcompleter, key=key
+                    )  # type:ignore[attr-defined]
 
     def _convert_to_config(self):
         """self.parsed_data->self.config, parse unrecognized extra args via KVLoader."""

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -1057,9 +1057,9 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
                 action = paa(*keys, **argparse_kwds)
                 if argcompleter is not None:
                     # argcomplete's completers are callables returning list of completion strings
-                    action.completer = functools.partial(
+                    action.completer = functools.partial(  # type:ignore[attr-defined]
                         argcompleter, key=key
-                    )  # type:ignore[attr-defined]
+                    )
 
     def _convert_to_config(self):
         """self.parsed_data->self.config, parse unrecognized extra args via KVLoader."""

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -10,7 +10,7 @@ class TraitTestBase(TestCase):
     """A best testing class for basic trait types."""
 
     def assign(self, value: Any) -> None:
-        self.obj.value = value  # type:ignore
+        self.obj.value = value  # type:ignore[attr-defined]
 
     def coerce(self, value: Any) -> Any:
         return value
@@ -19,7 +19,7 @@ class TraitTestBase(TestCase):
         if hasattr(self, "_good_values"):
             for value in self._good_values:
                 self.assign(value)
-                self.assertEqual(self.obj.value, self.coerce(value))  # type:ignore
+                self.assertEqual(self.obj.value, self.coerce(value))  # type:ignore[attr-defined]
 
     def test_bad_values(self) -> None:
         if hasattr(self, "_bad_values"):
@@ -31,7 +31,7 @@ class TraitTestBase(TestCase):
 
     def test_default_value(self) -> None:
         if hasattr(self, "_default_value"):
-            self.assertEqual(self._default_value, self.obj.value)  # type:ignore
+            self.assertEqual(self._default_value, self.obj.value)  # type:ignore[attr-defined]
 
     def test_allow_none(self) -> None:
         if (
@@ -39,13 +39,13 @@ class TraitTestBase(TestCase):
             and hasattr(self, "_good_values")
             and None in self._bad_values
         ):
-            trait = self.obj.traits()["value"]  # type:ignore
+            trait = self.obj.traits()["value"]  # type:ignore[attr-defined]
             try:
                 trait.allow_none = True
                 self._bad_values.remove(None)
                 # skip coerce. Allow None casts None to None.
                 self.assign(None)
-                self.assertEqual(self.obj.value, None)  # type:ignore
+                self.assertEqual(self.obj.value, None)  # type:ignore[attr-defined]
                 self.test_good_values()
                 self.test_bad_values()
             finally:
@@ -56,4 +56,4 @@ class TraitTestBase(TestCase):
     def tearDown(self) -> None:
         # restore default value after tests, if set
         if hasattr(self, "_default_value"):
-            self.obj.value = self._default_value  # type:ignore
+            self.obj.value = self._default_value  # type:ignore[attr-defined]

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -234,7 +234,7 @@ def getmembers(object, predicate=None):
 
     This is useful when there are descriptor based attributes that for
     some reason raise AttributeError even though they exist.  This happens
-    in zope.inteface with the __provides__ attribute.
+    in zope.interface with the __provides__ attribute.
     """
     results = []
     for key in dir(object):
@@ -437,9 +437,9 @@ class BaseDescriptor:
     """
 
     name: str | None = None
-    this_class: type[t.Any] | None = None
+    this_class: type[HasTraits] | None = None
 
-    def class_init(self, cls, name):
+    def class_init(self, cls: type[HasTraits], name: str | None) -> None:
         """Part of the initialization which may depend on the underlying
         HasDescriptors class.
 
@@ -452,18 +452,18 @@ class BaseDescriptor:
         self.this_class = cls
         self.name = name
 
-    def subclass_init(self, cls):
+    def subclass_init(self, cls: type[HasTraits]) -> None:
         # Instead of HasDescriptors.setup_instance calling
         # every instance_init, we opt in by default.
         # This gives descriptors a change to opt out for
         # performance reasons.
         # Because most traits do not need instance_init,
         # and it will otherwise be called for every HasTrait instance
-        # beging created, this otherwise gives a significant performance
+        # being created, this otherwise gives a significant performance
         # pentalty. Most TypeTraits in traitlets opt out.
         cls._instance_inits.append(self.instance_init)
 
-    def instance_init(self, obj):
+    def instance_init(self, obj: t.Any) -> None:
         """Part of the initialization which may depend on the underlying
         HasDescriptors instance.
 
@@ -497,7 +497,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
     allow_none: bool = False
     read_only: bool = False
     info_text: str = "any value"
-    default_value: t.Any | None = Undefined
+    default_value: t.Any = Undefined
 
     def __init__(
         self: TraitType[G, S],
@@ -567,7 +567,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         if help is not None:
             self.metadata["help"] = help
 
-    def from_string(self, s):
+    def from_string(self, s: str) -> G | None:
         """Get a value from a config string
 
         such as an environment variable or CLI arguments.
@@ -581,9 +581,9 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         """
         if self.allow_none and s == "None":
             return None
-        return s
+        return s  # type:ignore[return-value]
 
-    def default(self, obj=None):
+    def default(self, obj: t.Any = None) -> G | None:
         """The default generator for this trait
 
         Notes
@@ -599,7 +599,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
             # Undefined will raise in TraitType.get
             return self.default_value
 
-    def get_default_value(self):
+    def get_default_value(self) -> G | None:
         """DEPRECATED: Retrieve the static default value for this trait.
         Use self.default_value instead
         """
@@ -610,7 +610,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         )
         return self.default_value
 
-    def init_default_value(self, obj):
+    def init_default_value(self, obj: t.Any) -> G:
         """DEPRECATED: Set the static default value for the trait type."""
         warn(
             "init_default_value is deprecated in traitlets 4.0, and may be removed in the future",
@@ -622,8 +622,9 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         return value
 
     def get(self, obj: HasTraits, cls: t.Any = None) -> G | None:
+        assert self.name is not None
         try:
-            value = obj._trait_values[self.name]  # type: ignore
+            value = obj._trait_values[self.name]  # type: ignore[index]
         except KeyError:
             # Check for a dynamic initializer.
             default = obj.trait_defaults(self.name)
@@ -643,7 +644,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
                 value = self._validate(obj, default)
             finally:
                 obj._cross_validation_lock = _cross_validation_lock
-            obj._trait_values[self.name] = value  # type: ignore
+            obj._trait_values[self.name] = value  # type: ignore[index]
             obj._notify_observers(
                 Bunch(
                     name=self.name,
@@ -652,12 +653,12 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
                     type="default",
                 )
             )
-            return value  # type: ignore
+            return value
         except Exception as e:
             # This should never be reached.
             raise TraitError("Unexpected error in TraitType: default value not set properly") from e
         else:
-            return value  # type: ignore
+            return value
 
     if t.TYPE_CHECKING:
         # This gives ok type information, but not specific enough (e.g. it will)
@@ -718,8 +719,9 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         else:
             return t.cast(G, self.get(obj, cls))  # the G should encode the Optional
 
-    def set(self, obj, value):
+    def set(self, obj: HasTraits, value: S) -> None:
         new_value = self._validate(obj, value)
+        assert self.name is not None
         try:
             old_value = obj._trait_values[self.name]
         except KeyError:
@@ -804,7 +806,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
             the deepest).
         info : str (default: None)
             A description of the expected value. By
-            default this is infered from this trait's
+            default this is inferred from this trait's
             ``info`` method.
         """
         if error is not None:
@@ -999,11 +1001,11 @@ class MetaHasDescriptors(type):
         cls._instance_inits = []
         for k, v in classdict.items():
             if isinstance(v, BaseDescriptor):
-                v.class_init(cls, k)
+                v.class_init(cls, k)  # type:ignore[arg-type]
 
         for _, v in getmembers(cls):
             if isinstance(v, BaseDescriptor):
-                v.subclass_init(cls)
+                v.subclass_init(cls)  # type:ignore[arg-type]
                 cls._descriptors.append(v)
 
 
@@ -1143,8 +1145,8 @@ def observe_compat(func: FuncT) -> FuncT:
     def compatible_observer(
         self: t.Any, change_or_name: str, old: t.Any = Undefined, new: t.Any = Undefined
     ) -> t.Any:
-        if isinstance(change_or_name, dict):
-            change = Bunch(change_or_name)
+        if isinstance(change_or_name, dict):  # type:ignore[unreachable]
+            change = Bunch(change_or_name)  # type:ignore[unreachable]
         else:
             clsname = self.__class__.__name__
             warn(
@@ -1414,7 +1416,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
                 stacklevel=2,
             )
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, t.Any]:
         d = self.__dict__.copy()
         # event handlers stored on an instance are
         # expected to be reinstantiated during a
@@ -1426,7 +1428,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
 
         return d
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, t.Any]) -> None:
         self.__dict__ = state.copy()
 
         # event handlers are reassigned to self
@@ -1507,7 +1509,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
                     self.set_trait(name, value)
             except TraitError as e:
                 # Roll back in case of TraitError during final cross validation.
-                self.notify_change = lambda x: None  # type:ignore[method-assign]
+                self.notify_change = lambda x: None  # type:ignore[method-assign, assignment]
                 for name, changes in cache.items():
                     for change in changes[::-1]:
                         # TODO: Separate in a rollback function per notification type.
@@ -1539,15 +1541,15 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             )
         )
 
-    def notify_change(self, change):
+    def notify_change(self, change: Bunch) -> None:
         """Notify observers of a change event"""
         return self._notify_observers(change)
 
-    def _notify_observers(self, event):
+    def _notify_observers(self, event: Bunch) -> None:
         """Notify observers of any event"""
         if not isinstance(event, Bunch):
             # cast to bunch if given a dict
-            event = Bunch(event)
+            event = Bunch(event)  # type:ignore[unreachable]
         name, type = event['name'], event['type']
 
         callables = []
@@ -1756,7 +1758,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         for name in names:
             self._trait_validators[name] = handler
 
-    def add_traits(self, **traits):
+    def add_traits(self, **traits: t.Any) -> None:
         """Dynamically add trait attributes to the HasTraits instance."""
         cls = self.__class__
         attrs = {"__module__": cls.__module__}
@@ -1768,7 +1770,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         for trait in traits.values():
             trait.instance_init(self)
 
-    def set_trait(self, name, value):
+    def set_trait(self, name: str, value: t.Any) -> None:
         """Forcibly sets trait attribute, including read-only attributes."""
         cls = self.__class__
         if not self.has_trait(name):
@@ -1777,7 +1779,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             getattr(cls, name).set(self, value)
 
     @classmethod
-    def class_trait_names(cls, **metadata):
+    def class_trait_names(cls: type[HasTraits], **metadata: t.Any) -> list[str]:
         """Get a list of all the names of this class' traits.
 
         This method is just like the :meth:`trait_names` method,
@@ -1786,7 +1788,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         return list(cls.class_traits(**metadata))
 
     @classmethod
-    def class_traits(cls, **metadata):
+    def class_traits(cls: type[HasTraits], **metadata: t.Any) -> dict[str, TraitType]:
         """Get a ``dict`` of all the traits of this class.  The dictionary
         is keyed on the name and the values are the TraitType objects.
 
@@ -1820,7 +1822,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         return result
 
     @classmethod
-    def class_own_traits(cls, **metadata):
+    def class_own_traits(cls: type[HasTraits], **metadata: t.Any) -> dict[str, TraitType]:
         """Get a dict of all the traitlets defined on this class, not a parent.
 
         Works like `class_traits`, except for excluding traits from parents.
@@ -1832,11 +1834,11 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             if getattr(sup, n, None) is not t
         }
 
-    def has_trait(self, name):
+    def has_trait(self, name: str) -> bool:
         """Returns True if the object has a trait with the specified name."""
         return name in self._traits
 
-    def trait_has_value(self, name):
+    def trait_has_value(self, name: str) -> bool:
         """Returns True if the specified trait has a value.
 
         This will return false even if ``getattr`` would return a
@@ -1851,14 +1853,15 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             class MyClass(HasTraits):
                 i = Int()
 
+
             mc = MyClass()
             assert not mc.trait_has_value("i")
-            mc.i # generates a default value
+            mc.i  # generates a default value
             assert mc.trait_has_value("i")
         """
         return name in self._trait_values
 
-    def trait_values(self, **metadata):
+    def trait_values(self, **metadata: t.Any) -> dict[str, t.Any]:
         """A ``dict`` of trait names and their values.
 
         The metadata kwargs allow functions to be passed in which
@@ -1892,7 +1895,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             return getattr(self.__class__, method_name)
         return self._all_trait_default_generators[name]
 
-    def trait_defaults(self, *names, **metadata):
+    def trait_defaults(self, *names: str, **metadata: t.Any) -> dict[str, t.Any]:
         """Return a trait's default value or a dictionary of them
 
         Notes
@@ -1914,11 +1917,11 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             defaults[n] = self._get_trait_default_generator(n)(self)
         return defaults
 
-    def trait_names(self, **metadata):
+    def trait_names(self, **metadata: t.Any) -> list[str]:
         """Get a list of all the names of this class' traits."""
         return list(self.traits(**metadata))
 
-    def traits(self, **metadata):
+    def traits(self, **metadata: t.Any) -> dict[str, TraitType]:
         """Get a ``dict`` of all the traits of this class.  The dictionary
         is keyed on the name and the values are the TraitType objects.
 
@@ -1949,7 +1952,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
 
         return result
 
-    def trait_metadata(self, traitname, key, default=None):
+    def trait_metadata(self, traitname: str, key: str, default: t.Any = None) -> t.Any:
         """Get metadata values for trait by key."""
         try:
             trait = getattr(self.__class__, traitname)
@@ -1964,7 +1967,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             return trait.metadata.get(key, default)
 
     @classmethod
-    def class_own_trait_events(cls, name):
+    def class_own_trait_events(cls: type[HasTraits], name: str) -> dict[str, EventHandler]:
         """Get a dict of all event handlers defined on this class, not a parent.
 
         Works like ``event_handlers``, except for excluding traits from parents.
@@ -1977,7 +1980,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         }
 
     @classmethod
-    def trait_events(cls, name=None):
+    def trait_events(cls: type[HasTraits], name: str | None = None) -> dict[str, EventHandler]:
         """Get a ``dict`` of all the event handlers of this class.
 
         Parameters
@@ -3670,7 +3673,12 @@ class Set(Container[t.Set[t.Any]]):
 
     def set(self, obj, value):
         if isinstance(value, str):
-            return super().set(obj, [value])
+            return super().set(
+                obj,
+                set(
+                    value,
+                ),
+            )
         else:
             return super().set(obj, value)
 
@@ -3993,7 +4001,7 @@ class Dict(Instance[t.Dict[t.Any, t.Any]]):
                     self.element_error(obj, v, active_value_trait, "Values")
             validated[key] = v
 
-        return self.klass(validated)  # type:ignore
+        return self.klass(validated)  # type:ignore[misc,operator]
 
     def class_init(self, cls, name):
         if isinstance(self._value_trait, TraitType):
@@ -4174,19 +4182,22 @@ class UseEnum(TraitType[t.Any, t.Any]):
         import enum
         from traitlets import HasTraits, UseEnum
 
+
         class Color(enum.Enum):
-            red = 1         # -- IMPLICIT: default_value
+            red = 1  # -- IMPLICIT: default_value
             blue = 2
             green = 3
+
 
         class MyEntity(HasTraits):
             color = UseEnum(Color, default_value=Color.blue)
 
+
         entity = MyEntity(color=Color.red)
-        entity.color = Color.green    # USE: Enum-value (preferred)
-        entity.color = "green"        # USE: name (as string)
+        entity.color = Color.green  # USE: Enum-value (preferred)
+        entity.color = "green"  # USE: name (as string)
         entity.color = "Color.green"  # USE: scoped-name (as string)
-        entity.color = 3              # USE: number (as int)
+        entity.color = 3  # USE: number (as int)
         assert entity.color is Color.green
     """
 

--- a/traitlets/utils/__init__.py
+++ b/traitlets/utils/__init__.py
@@ -16,7 +16,7 @@ def filefind(filename: str, path_dirs: Sequence[str] | None = None) -> str:
     """Find a file by looking through a sequence of paths.
 
     This iterates through a sequence of paths looking for a file and returns
-    the full, absolute path of the first occurence of the file.  If no set of
+    the full, absolute path of the first occurrence of the file.  If no set of
     path dirs is given, the filename is tested as is, after running through
     :func:`expandvars` and :func:`expanduser`.  Thus a simple call::
 

--- a/traitlets/utils/decorators.py
+++ b/traitlets/utils/decorators.py
@@ -55,9 +55,7 @@ def signature_has_traits(cls: Type[T]) -> Type[T]:
     # because it can't accept traits as keyword arguments
     if old_var_keyword_parameter is None:
         raise RuntimeError(
-            "The {} constructor does not take **kwargs, which means that the signature can not be expanded with trait names".format(
-                cls
-            )
+            f"The {cls} constructor does not take **kwargs, which means that the signature can not be expanded with trait names"
         )
 
     new_parameters = []

--- a/traitlets/utils/descriptions.py
+++ b/traitlets/utils/descriptions.py
@@ -20,7 +20,7 @@ def describe(
     article : str or None
         A definite or indefinite article. If the article is
         indefinite (i.e. "a" or "an") the appropriate one
-        will be infered. Thus, the arguments of ``describe``
+        will be inferred. Thus, the arguments of ``describe``
         can themselves represent what the resulting string
         will actually look like. If None, then no article
         will be prepended to the result. For non-articled
@@ -31,7 +31,7 @@ def describe(
     name : str or None (default: None)
         Only applies when ``article`` is "the" - this
         ``name`` is a definite reference to the value.
-        By default one will be infered from the value's
+        By default one will be inferred from the value's
         type and repr methods.
     verbose : bool (default: False)
         Whether the name should be concise or verbose. When
@@ -145,7 +145,7 @@ def class_of(value: Any) -> Any:
 def add_article(name: str, definite: bool = False, capital: bool = False) -> str:
     """Returns the string with a prepended article.
 
-    The input does not need to begin with a charater.
+    The input does not need to begin with a character.
 
     Parameters
     ----------


### PR DESCRIPTION
Adopt [pypi.org/project/sp-repo-review](https://pypi.org/project/sp-repo-review/), which has a standard set of checks for packages in the scientific python ecosystem, as seen in [learn.scientific-python.org/development](https://learn.scientific-python.org/development/).

Disable strict mypy checks for now, but add types to more of the base classes.