### PR TITLE
Use passed-in `info` argument for `TraitType.error()`

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -848,13 +848,13 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
                     e = "The '{}' trait of {} instance expected {}, not {}.".format(
                         self.name,
                         class_of(obj),
-                        self.info(),
+                        info or self.info(),
                         describe("the", value),
                     )
                 else:
                     e = "The '{}' trait expected {}, not {}.".format(
                         self.name,
-                        self.info(),
+                        info or self.info(),
                         describe("the", value),
                     )
                 raise TraitError(e)


### PR DESCRIPTION
In my own project I'm subclassing `TraitType` to create my own traitlets, and working to provide good validation inside `validate()`, but my custom `info` messages weren't being shown to the user.