### PR TITLE
Fix assigning string value to Set

### DIFF
--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -1658,6 +1658,24 @@ class TestList(TraitTestBase):
         return value
 
 
+class SetTrait(HasTraits):
+    value = Set(Unicode())
+
+
+class TestSet(TraitTestBase):
+    obj = SetTrait()
+
+    _default_value: t.Set[str] = set()
+    _good_values = [{"a", "b"}, "ab"]
+    _bad_values = [1]
+
+    def coerce(self, value):
+        if isinstance(value, str):
+            # compatibility handling: convert string to set containing string
+            value = {value}
+        return value
+
+
 class Foo:
     pass
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -3698,12 +3698,7 @@ class Set(Container[t.Set[t.Any]]):
 
     def set(self, obj: t.Any, value: t.Any) -> None:
         if isinstance(value, str):
-            return super().set(
-                obj,
-                set(
-                    value,
-                ),
-            )
+            return super().set(obj, {value})
         else:
             return super().set(obj, value)
 


### PR DESCRIPTION
Assigning a string value to a `Set` trait used to implicitly cast to a set containing the string, but it accidentally was changed to become the set of the string's characters after #883. Fix this and add a unit test.

Fixes #887 #891.