### PR TITLE
Remove py2-compat hack from `bunch.__dir__`

### DIFF
--- a/tests/utils/test_bunch.py
+++ b/tests/utils/test_bunch.py
@@ -14,5 +14,8 @@ def test_bunch():
 
 def test_bunch_dir():
     b = Bunch(x=5, y=10)
-    assert "x" in dir(b)
     assert "keys" in dir(b)
+    assert "x" in dir(b)
+    assert "z" not in dir(b)
+    b.z = 15
+    assert "z" in dir(b)

--- a/traitlets/utils/bunch.py
+++ b/traitlets/utils/bunch.py
@@ -23,6 +23,7 @@ class Bunch(dict):  # type:ignore[type-arg]
         self.__setitem__(key, value)
 
     def __dir__(self) -> list[str]:
-        names = super().__dir__()
+        names: list[str] = []
+        names.extend(super().__dir__())
         names.extend(self.keys())
         return names

--- a/traitlets/utils/bunch.py
+++ b/traitlets/utils/bunch.py
@@ -23,6 +23,6 @@ class Bunch(dict):  # type:ignore[type-arg]
         self.__setitem__(key, value)
 
     def __dir__(self) -> list[str]:
-        names = dir(Bunch)
+        names = super().__dir__()
         names.extend(self.keys())
         return names

--- a/traitlets/utils/bunch.py
+++ b/traitlets/utils/bunch.py
@@ -23,7 +23,6 @@ class Bunch(dict):  # type:ignore[type-arg]
         self.__setitem__(key, value)
 
     def __dir__(self) -> list[str]:
-        # py2-compat: can't use super because dict doesn't have __dir__
-        names = dir({})
+        names = dir(Bunch)
         names.extend(self.keys())
         return names


### PR DESCRIPTION
This python2 hack was added in #238 but is no longer needed.