### PR TITLE
CI: Start testing on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,16 +24,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.13"]
         include:
-          - os: windows-latest
+          - os: ubuntu-latest
             python-version: "3.9"
           - os: ubuntu-latest
-            python-version: "pypy-3.8"
-          - os: ubuntu-latest
             python-version: "3.10"
-          - os: macos-latest
+          - os: ubuntu-latest
             python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.12"
+          - os: ubuntu-latest
+            python-version: "pypy-3.10"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update the GitHub Actions workflows to include testing on Python 3.13.

Also updates the remainder of the matrix, to use the cheaper ubuntu jobs and to the latest PyPy.