### PR TITLE
Suppress exceptions when closing handlers during `__del__`

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -1062,7 +1062,11 @@ class Application(SingletonConfigurable):
         sys.exit(exit_status)
 
     def __del__(self) -> None:
-        self.close_handlers()
+        # __del__ may be called during process teardown,
+        # at which point any fraction of attributes and modules may have been cleared,
+        # e.g. even _accessing_ self.log may fail.
+        with suppress(Exception):
+            self.close_handlers()
 
     @classmethod
     def launch_instance(cls, argv: ArgvType = None, **kwargs: t.Any) -> None:


### PR DESCRIPTION
when `__del__` is called during process teardown, any amount of things may already be torn down and fail. Suppress those errors.

currently seeing this with `typing.cast` being None, preventing access of `self.log` (or any trait) from succeeding: https://github.com/jupyterhub/repo2docker/issues/1379

I'll work on a separate PR to remove most if not all use of `return cast(...)` which doesn't do anything more than `return x # type:ignore` other than introduce possible errors like this and (negligible) performance cost.