### PR TITLE
Avoid using `return t.cast` which can prevent attribute access during process teardown

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -175,7 +175,7 @@ def isidentifier(s: str) -> bool:
         DeprecationWarning,
         stacklevel=2,
     )
-    s.isidentifier()
+    return s.isidentifier()
 
 
 def _safe_literal_eval(s: str) -> t.Any:


### PR DESCRIPTION
`return t.cast(..., X)` is equivalent to `return X # type:ignore` on the result of the expression, but (negligibly) more expensive and can cause errors e.g. preventing access to attributes during `__del__` in process teardown, as seen in https://github.com/jupyterhub/repo2docker/issues/1379. It's a good idea to try to avoid anything that may prevent access to attribtues. This means trying our best to keep any `module.method` calls out of the `__get__` path (note: importing `from typing import cast` is another way to avoid this _specific_ issue and works for methods we really do want to use in this code, but the ignores just seem better than the casts to me, anyway).

Note this is only applied to `return` statements, since the type narrowing of `t.cast` necessarily has no effect there other than explicitly ignoring a single type check. Other uses of `t.cast` in the middle of some code for type narrowing are still totally sensible.