### PR TITLE
Deprecate empty `isidentifier` utility

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -170,6 +170,11 @@ class TraitError(Exception):
 
 
 def isidentifier(s: t.Any) -> bool:
+    warn(
+        "traitlets.traitlets.isidentifier(s) is deprecated since traitlets 5.14.4 Use `s.isidentifier()`.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return t.cast(bool, s.isidentifier())
 
 
@@ -3025,7 +3030,7 @@ class ObjectName(TraitType[str, str]):
     def validate(self, obj: t.Any, value: t.Any) -> str:
         value = self.coerce_str(obj, value)
 
-        if isinstance(value, str) and isidentifier(value):
+        if isinstance(value, str) and value.isidentifier():
             return value
         self.error(obj, value)
 
@@ -3041,7 +3046,7 @@ class DottedObjectName(ObjectName):
     def validate(self, obj: t.Any, value: t.Any) -> str:
         value = self.coerce_str(obj, value)
 
-        if isinstance(value, str) and all(isidentifier(a) for a in value.split(".")):
+        if isinstance(value, str) and all(a.isidentifier() for a in value.split(".")):
             return value
         self.error(obj, value)
 


### PR DESCRIPTION
This has become a straight passthrough to `s.isidentifier()` after removal of Python 2 compatibility over the years.

`isidentifier` is not exported or documented since 5.0, so probably safe to remove, but better to be extra conservative in this package.