### PR TITLE
Fix whitespace formatting in CLI help.

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -300,7 +300,7 @@ class Configurable(HasTraits):
         if helptext is None:
             helptext = trait.help
         if helptext != "":
-            helptext = "\n".join(wrap_paragraphs(helptext, 76))
+            helptext = "\n\n".join(wrap_paragraphs(helptext, 76))
             lines.append(indent(helptext))
 
         if "Enum" in trait.__class__.__name__:

--- a/traitlets/utils/text.py
+++ b/traitlets/utils/text.py
@@ -5,13 +5,31 @@ from __future__ import annotations
 
 import re
 import textwrap
-from textwrap import dedent
 from textwrap import indent as _indent
 from typing import List
 
 
 def indent(val: str) -> str:
     return _indent(val, "    ")
+
+
+def _dedent(text: str) -> str:
+    """Equivalent of textwrap.dedent that ignores unindented first line."""
+
+    if text.startswith("\n"):
+        # text starts with blank line, don't ignore the first line
+        return textwrap.dedent(text)
+
+    # split first line
+    splits = text.split("\n", 1)
+    if len(splits) == 1:
+        # only one line
+        return textwrap.dedent(text)
+
+    first, rest = splits
+    # dedent everything but the first line
+    rest = textwrap.dedent(rest)
+    return "\n".join([first, rest])
 
 
 def wrap_paragraphs(text: str, ncols: int = 80) -> List[str]:
@@ -26,7 +44,7 @@ def wrap_paragraphs(text: str, ncols: int = 80) -> List[str]:
     list of complete paragraphs, wrapped to fill `ncols` columns.
     """
     paragraph_re = re.compile(r"\n(\s*\n)+", re.MULTILINE)
-    text = dedent(text).strip()
+    text = _dedent(text).strip()
     paragraphs = paragraph_re.split(text)[::2]  # every other entry is space
     out_ps = []
     indent_re = re.compile(r"\n\s+", re.MULTILINE)


### PR DESCRIPTION
For traitlets that have long descriptions, and in particular that uses multiline strings, this lead to inconsistant indentation – and mmissing newlines in rewrapped paragraphs.

 - Each paragraph in wrap_paragraphs would be a list item, and thus need to be joined by 2 newlines (or we need to ensure that each list item in wrap_paragraph would end in a NL, but that woudl change API
 - When help is ina multiline string, if the line start on the first line:

    """like in

    this kind of help"""

    but not like

    """
    in this kind

    of documentation help
    """

    Wrap parragraph would not properly dedent.