### PR TITLE
Update `__new__` method to use Self type for improved type hinting

### DIFF
--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1290,7 +1290,7 @@ class DefaultHandler(EventHandler):
 class HasDescriptors(metaclass=MetaHasDescriptors):
     """The base class for all classes that have descriptors."""
 
-    def __new__(*args: t.Any, **kwargs: t.Any) -> t.Any:
+    def __new__(*args: t.Any, **kwargs: t.Any) -> Self: # type:ignore[misc, type-var]
         # Pass cls as args[0] to allow "cls" as keyword argument
         cls = args[0]
         args = args[1:]
@@ -1303,7 +1303,7 @@ class HasDescriptors(metaclass=MetaHasDescriptors):
         else:
             inst = new_meth(cls, *args, **kwargs)
         inst.setup_instance(*args, **kwargs)
-        return inst
+        return inst # type:ignore[no-any-return]
 
     def setup_instance(*args: t.Any, **kwargs: t.Any) -> None:
         """

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1291,8 +1291,6 @@ class HasDescriptors(metaclass=MetaHasDescriptors):
     """The base class for all classes that have descriptors."""
 
     def __new__(cls, /, *args: t.Any, **kwargs: t.Any) -> Self:
-
-
         # This is needed because object.__new__ only accepts
         # the cls argument.
         new_meth = super(HasDescriptors, cls).__new__

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1290,7 +1290,7 @@ class DefaultHandler(EventHandler):
 class HasDescriptors(metaclass=MetaHasDescriptors):
     """The base class for all classes that have descriptors."""
 
-    def __new__(*args: t.Any, **kwargs: t.Any) -> Self: # type:ignore[misc, type-var]
+    def __new__(*args: t.Any, **kwargs: t.Any) -> Self:  # type:ignore[misc, type-var]
         # Pass cls as args[0] to allow "cls" as keyword argument
         cls = args[0]
         args = args[1:]
@@ -1303,7 +1303,7 @@ class HasDescriptors(metaclass=MetaHasDescriptors):
         else:
             inst = new_meth(cls, *args, **kwargs)
         inst.setup_instance(*args, **kwargs)
-        return inst # type:ignore[no-any-return]
+        return inst  # type:ignore[no-any-return]
 
     def setup_instance(*args: t.Any, **kwargs: t.Any) -> None:
         """

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1301,13 +1301,10 @@ class HasDescriptors(metaclass=MetaHasDescriptors):
         inst.setup_instance(*args, **kwargs)
         return inst
 
-    def setup_instance(*args: t.Any, **kwargs: t.Any) -> None:
+    def setup_instance(self, /, *args: t.Any, **kwargs: t.Any) -> None:
         """
         This is called **before** self.__init__ is called.
         """
-        # Pass self as args[0] to allow "self" as keyword argument
-        self = args[0]
-        args = args[1:]
 
         self._cross_validation_lock = False
         cls = self.__class__
@@ -1329,11 +1326,8 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
     _traits: dict[str, t.Any]
     _all_trait_default_generators: dict[str, t.Any]
 
-    def setup_instance(*args: t.Any, **kwargs: t.Any) -> None:
-        # Pass self as args[0] to allow "self" as keyword argument
-        self = args[0]
-        args = args[1:]
-
+    def setup_instance(self, /, *args: t.Any, **kwargs: t.Any) -> None:
+        
         # although we'd prefer to set only the initial values not present
         # in kwargs, we will overwrite them in `__init__`, and simply making
         # a copy of a dict is faster than checking for each key.

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1290,10 +1290,8 @@ class DefaultHandler(EventHandler):
 class HasDescriptors(metaclass=MetaHasDescriptors):
     """The base class for all classes that have descriptors."""
 
-    def __new__(*args: t.Any, **kwargs: t.Any) -> Self:  # type:ignore[misc, type-var]
-        # Pass cls as args[0] to allow "cls" as keyword argument
-        cls = args[0]
-        args = args[1:]
+    def __new__(cls, /, *args: t.Any, **kwargs: t.Any) -> Self:
+
 
         # This is needed because object.__new__ only accepts
         # the cls argument.
@@ -1303,7 +1301,7 @@ class HasDescriptors(metaclass=MetaHasDescriptors):
         else:
             inst = new_meth(cls, *args, **kwargs)
         inst.setup_instance(*args, **kwargs)
-        return inst  # type:ignore[no-any-return]
+        return inst
 
     def setup_instance(*args: t.Any, **kwargs: t.Any) -> None:
         """

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1327,7 +1327,6 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
     _all_trait_default_generators: dict[str, t.Any]
 
     def setup_instance(self, /, *args: t.Any, **kwargs: t.Any) -> None:
-        
         # although we'd prefer to set only the initial values not present
         # in kwargs, we will overwrite them in `__init__`, and simply making
         # a copy of a dict is faster than checking for each key.


### PR DESCRIPTION
Recently Pylance (Pyright) started producing  `Any` as the type hint for HasTraits objects since Pylance v 2025.2.102 & Pyright v 1.1.395. This may be related to the first dot point in the Pyright release notes here: https://github.com/microsoft/pyright/releases/tag/1.1.395.

### Before
![image](https://github.com/user-attachments/assets/31dd11c0-1f53-45d5-a5a1-1a14bb75b89b)

### After
![image](https://github.com/user-attachments/assets/db3d6bd1-2f5d-431b-aad1-c07971746037)

Reference: https://typing.python.org/en/latest/spec/constructors.html#consistency-of-new-and-init