### PR TITLE
Use extension:filetype mapping in sphinx configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,7 @@ github_project_url = "https://github.com/ipython/traitlets"
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
 # Add dev disclaimer.
 if version_info[-1] == "dev":


### PR DESCRIPTION
This is possible since sphinx 1.8, and avoid the message:
>  "Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`"
at docs build time. See https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-source_suffix