### PR TITLE
Require Python 3.10 and support pytest 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python",
     "Typing :: Typed",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 
 [project.urls]
@@ -40,7 +40,7 @@ test = [
     "pre-commit",
     "pytest-mock",
     "pytest-mypy-testing",
-    "pytest>=7.0,<8.2",
+    "pytest>=7.0,<10.0",
 ]
 docs = [
     "myst-parser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ Tracker = "https://github.com/ipython/traitlets/issues"
 
 [project.optional-dependencies]
 test = [
-    "argcomplete>=3.0.3",
+    "argcomplete>=3.0.3; python_version < '3.12'",
+    "argcomplete>=3.5.2; python_version >= '3.12'",
     # See https://github.com/python/mypy/issues/20329 for PyPy support issue.
     # Also, test assertions will need to be updated for 1.20+ because
     # `reveal_type()` representations were simplified in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,8 +189,7 @@ ignore = [
   "S105", "S106",   # Possible hardcoded password
   "S110",   # S110 `try`-`except`-`pass` detected
   "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
-  "UP006",  # non-pep585-annotation
-  "UP007",  # non-pep604-annotation
+  "UP038",  # non-pep604-isinstance (removed in ruff 0.13.0)
   "ARG001", "ARG002",  # Unused function argument
   "RET503",  # Missing explicit `return` at the end of function
   "RET505",  # Unnecessary `else` after `return` statement

--- a/tests/config/test_application.py
+++ b/tests/config/test_application.py
@@ -66,7 +66,7 @@ class MyApp(Application):
         help="Should print a warning if `MyApp.warn-typo=...` command is passed",
     )
 
-    aliases: t.Dict[t.Any, t.Any] = {}
+    aliases: dict[t.Any, t.Any] = {}
     aliases.update(Application.aliases)
     aliases.update(
         {
@@ -83,7 +83,7 @@ class MyApp(Application):
         }
     )
 
-    flags: t.Dict[t.Any, t.Any] = {}
+    flags: dict[t.Any, t.Any] = {}
     flags.update(Application.flags)
     flags.update(
         {

--- a/tests/config/test_argcomplete.py
+++ b/tests/config/test_argcomplete.py
@@ -23,7 +23,7 @@ from traitlets.config.loader import KVArgParseConfigLoader
 class ArgcompleteApp(Application):
     """Override loader to pass through kwargs for argcomplete testing"""
 
-    argcomplete_kwargs: t.Dict[str, t.Any]
+    argcomplete_kwargs: dict[str, t.Any]
 
     def __init__(self, *args, **kwargs):
         # For subcommands, inherit argcomplete_kwargs from parent app
@@ -99,9 +99,9 @@ class TestArgcomplete:
         self,
         app: ArgcompleteApp,
         command: str,
-        point: t.Union[str, int, None] = None,
+        point: str | int | None = None,
         **kwargs: t.Any,
-    ) -> t.List[str]:
+    ) -> list[str]:
         """Mostly borrowed from argcomplete's unit tests
 
         Modified to take an application instead of an ArgumentParser

--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -69,7 +69,7 @@ from ._warnings import expected_warnings
 
 def change_dict(*ordered_values):
     change_names = ("name", "old", "new", "owner", "type")
-    return dict(zip(change_names, ordered_values))
+    return dict(zip(change_names, ordered_values, strict=True))
 
 
 # -----------------------------------------------------------------------------
@@ -1650,7 +1650,7 @@ class ListTrait(HasTraits):
 class TestList(TraitTestBase):
     obj = ListTrait()
 
-    _default_value: t.List[t.Any] = []
+    _default_value: list[t.Any] = []
     _good_values = [[], [1], list(range(10)), (1, 2)]
     _bad_values = [10, [1, "a"], "a"]
 
@@ -1667,7 +1667,7 @@ class SetTrait(HasTraits):
 class TestSet(TraitTestBase):
     obj = SetTrait()
 
-    _default_value: t.Set[str] = set()
+    _default_value: set[str] = set()
     _good_values = [{"a", "b"}, "ab"]
     _bad_values = [1]
 
@@ -1689,7 +1689,7 @@ class NoneInstanceListTrait(HasTraits):
 class TestNoneInstanceList(TraitTestBase):
     obj = NoneInstanceListTrait()
 
-    _default_value: t.List[t.Any] = []
+    _default_value: list[t.Any] = []
     _good_values = [[Foo(), Foo()], []]
     _bad_values = [[None], [Foo(), None]]
 
@@ -1705,7 +1705,7 @@ class TestInstanceList(TraitTestBase):
         """Test that the instance klass is properly assigned."""
         self.assertIs(self.obj.traits()["value"]._trait.klass, Foo)
 
-    _default_value: t.List[t.Any] = []
+    _default_value: list[t.Any] = []
     _good_values = [[Foo(), Foo()], []]
     _bad_values = [
         [
@@ -1725,7 +1725,7 @@ class UnionListTrait(HasTraits):
 class TestUnionListTrait(TraitTestBase):
     obj = UnionListTrait()
 
-    _default_value: t.List[t.Any] = []
+    _default_value: list[t.Any] = []
     _good_values = [[True, 1], [False, True]]
     _bad_values = [[1, "True"], False]
 
@@ -1881,7 +1881,7 @@ class DictTrait(HasTraits):
 
 
 def test_dict_assignment():
-    d: t.Dict[str, int] = {}
+    d: dict[str, int] = {}
     c = DictTrait()
     c.value = d
     d["a"] = 5
@@ -2504,7 +2504,7 @@ class TestForwardDeclaredInstanceList(TraitTestBase):
         """Test that the instance klass is properly assigned."""
         self.assertIs(self.obj.traits()["value"]._trait.klass, ForwardDeclaredBar)
 
-    _default_value: t.List[t.Any] = []
+    _default_value: list[t.Any] = []
     _good_values = [
         [ForwardDeclaredBar(), ForwardDeclaredBarSub()],
         [],
@@ -2527,7 +2527,7 @@ class TestForwardDeclaredTypeList(TraitTestBase):
         """Test that the instance klass is properly assigned."""
         self.assertIs(self.obj.traits()["value"]._trait.klass, ForwardDeclaredBar)
 
-    _default_value: t.List[t.Any] = []
+    _default_value: list[t.Any] = []
     _good_values = [
         [ForwardDeclaredBar, ForwardDeclaredBarSub],
         [],

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -340,7 +340,7 @@ def mypy_bool_typing() -> None:
     reveal_type(
         T.ob  # R: traitlets.traitlets.Bool[builtins.bool | None, builtins.bool | builtins.int | None]
     )
-    # we would expect this to be Optional[bool | int], but...
+    # we would expect this to be bool | int | None, but...
     t.b = "foo"  # E: Incompatible types in assignment (expression has type "str", variable has type "bool | int")  [assignment]
     t.b = None  # E: Incompatible types in assignment (expression has type "None", variable has type "bool | int")  [assignment]
 

--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -98,9 +98,9 @@ IS_PYTHONW = sys.executable and sys.executable.endswith("pythonw.exe")
 
 T = t.TypeVar("T", bound=t.Callable[..., t.Any])
 AnyLogger = t.Union[logging.Logger, "logging.LoggerAdapter[t.Any]"]
-StrDict = t.Dict[str, t.Any]
-ArgvType = t.Optional[t.List[str]]
-ClassesType = t.List[t.Type[Configurable]]
+StrDict = dict[str, t.Any]
+ArgvType = list[str] | None
+ClassesType = list[type[Configurable]]
 
 
 def catch_config_error(method: T) -> T:
@@ -520,7 +520,7 @@ class Application(SingletonConfigurable):
         for cls in self.classes:
             # include all parents (up to, but excluding Configurable) in available names
             for c in cls.mro()[:-3]:
-                classdict[c.__name__] = t.cast(t.Type[Configurable], c)
+                classdict[c.__name__] = t.cast(type[Configurable], c)
 
         fhelp: str | None
         for alias, longname in self.aliases.items():
@@ -931,7 +931,7 @@ class Application(SingletonConfigurable):
                     if log:
                         log.debug("Loaded config file: %s", loader.full_filename)
                 if config:
-                    for filename, earlier_config in zip(filenames, loaded):
+                    for filename, earlier_config in zip(filenames, loaded, strict=True):
                         collisions = earlier_config.collisions(config)
                         if collisions and log:
                             log.warning(

--- a/traitlets/config/argcomplete_config.py
+++ b/traitlets/config/argcomplete_config.py
@@ -24,7 +24,7 @@ except ImportError:
     CompletionFinder = object  # type:ignore[assignment, misc]
 
 
-def get_argcomplete_cwords() -> t.Optional[t.List[str]]:
+def get_argcomplete_cwords() -> list[str] | None:
     """Get current words prior to completion point
 
     This is normally done in the `argcomplete.CompletionFinder` constructor,
@@ -37,7 +37,7 @@ def get_argcomplete_cwords() -> t.Optional[t.List[str]]:
     comp_line = os.environ["COMP_LINE"]
     comp_point = int(os.environ["COMP_POINT"])
     # argcomplete.debug("splitting COMP_LINE for:", comp_line, comp_point)
-    comp_words: t.List[str]
+    comp_words: list[str]
     try:
         (
             cword_prequote,
@@ -98,10 +98,10 @@ class ExtendedCompletionFinder(CompletionFinder):
     """
 
     _parser: argparse.ArgumentParser
-    config_classes: t.List[t.Any] = []  # Configurables
-    subcommands: t.List[str] = []
+    config_classes: list[t.Any] = []  # Configurables
+    subcommands: list[str] = []
 
-    def match_class_completions(self, cword_prefix: str) -> t.List[t.Tuple[t.Any, str]]:
+    def match_class_completions(self, cword_prefix: str) -> list[tuple[t.Any, str]]:
         """Match the word to be completed against our Configurable classes
 
         Check if cword_prefix could potentially match against --{class}. for any class
@@ -146,9 +146,7 @@ class ExtendedCompletionFinder(CompletionFinder):
         except AttributeError:
             pass
 
-    def _get_completions(
-        self, comp_words: t.List[str], cword_prefix: str, *args: t.Any
-    ) -> t.List[str]:
+    def _get_completions(self, comp_words: list[str], cword_prefix: str, *args: t.Any) -> list[str]:
         """Overridden to dynamically append --Class.trait arguments if appropriate
 
         Warning:
@@ -187,7 +185,7 @@ class ExtendedCompletionFinder(CompletionFinder):
                         self.inject_class_to_parser(matched_cls)
                     break
 
-        completions: t.List[str]
+        completions: list[str]
         completions = super()._get_completions(comp_words, cword_prefix, *args)  # type:ignore[no-untyped-call]
 
         # For subcommand-handling: it is difficult to get this to work
@@ -203,9 +201,9 @@ class ExtendedCompletionFinder(CompletionFinder):
 
     def _get_option_completions(
         self, parser: argparse.ArgumentParser, cword_prefix: str
-    ) -> t.List[str]:
+    ) -> list[str]:
         """Overridden to add --Class. completions when appropriate"""
-        completions: t.List[str]
+        completions: list[str]
         completions = super()._get_option_completions(parser, cword_prefix)  # type:ignore[no-untyped-call]
         if cword_prefix.endswith("."):
             return completions

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -32,7 +32,7 @@ from .loader import Config, DeferredConfig, LazyConfigValue, _is_section_key
 # -----------------------------------------------------------------------------
 
 if t.TYPE_CHECKING:
-    LoggerType = t.Union[logging.Logger, logging.LoggerAdapter[t.Any]]
+    LoggerType = logging.Logger | logging.LoggerAdapter[t.Any]
 else:
     LoggerType = t.Any
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -420,7 +420,7 @@ class DeferredConfigString(str, DeferredConfig):
         return f"{self.__class__.__name__}({self._super_repr()})"
 
 
-class DeferredConfigList(t.List[t.Any], DeferredConfig):
+class DeferredConfigList(list[t.Any], DeferredConfig):
     """Config value for loading config from a list of strings
 
     Interpretation is deferred until it is loaded into the trait.
@@ -791,7 +791,7 @@ class _KVArgParser(argparse.ArgumentParser):
 
 
 # type aliases
-SubcommandsDict = t.Dict[str, t.Any]
+SubcommandsDict = dict[str, t.Any]
 
 
 class ArgParseConfigLoader(CommandLineConfigLoader):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -501,7 +501,9 @@ T = TypeVar("T")
 # see https://peps.python.org/pep-0673/#use-in-generic-classes
 # Self = t.TypeVar("Self", bound="TraitType[Any, Any]")
 if t.TYPE_CHECKING:
-    from typing_extensions import Literal, Self
+    from typing import Literal
+
+    from typing_extensions import Self
 
     K = TypeVar("K", default=str)
     V = TypeVar("V", default=t.Any)
@@ -2375,7 +2377,7 @@ class ForwardDeclaredInstance(ForwardDeclaredMixin, Instance[T]):
     """
 
 
-class This(ClassBasedTraitType[t.Optional[T], t.Optional[T]]):
+class This(ClassBasedTraitType[T | None, T | None]):
     """A trait for instances of the class containing this trait.
 
     Because how how and when class bodies are executed, the ``This``
@@ -2488,7 +2490,7 @@ class Union(TraitType[t.Any, t.Any]):
 # -----------------------------------------------------------------------------
 
 
-class Any(TraitType[t.Optional[t.Any], t.Optional[t.Any]]):
+class Any(TraitType[t.Any | None, t.Any | None]):
     """A trait which allows any value."""
 
     if t.TYPE_CHECKING:
@@ -2587,7 +2589,7 @@ def _validate_bounds(
     return value
 
 
-# I = t.TypeVar('I', t.Optional[int], int)
+# I = t.TypeVar('I', int | None, int)
 
 
 class Int(TraitType[G, S]):
@@ -2829,7 +2831,7 @@ class CFloat(Float[G, S]):
         return _validate_bounds(self, obj, value)  # type:ignore[no-any-return]
 
 
-class Complex(TraitType[complex, t.Union[complex, float, int]]):
+class Complex(TraitType[complex, complex | float | int]):
     """A trait for complex numbers."""
 
     default_value = 0.0 + 0.0j
@@ -3337,7 +3339,7 @@ class FuzzyEnum(Enum[G]):
         choices = self.values or []
         matches = [match_func(value, conv_func(c)) for c in choices]  # type:ignore[no-untyped-call]
         if sum(matches) == 1:
-            for v, m in zip(choices, matches):
+            for v, m in zip(choices, matches, strict=True):
                 if m:
                     return v
 
@@ -3585,7 +3587,7 @@ class Container(Instance[T]):
             return s
 
 
-class List(Container[t.List[T]]):
+class List(Container[list[T]]):
     """An instance of a Python list."""
 
     klass = list  # type:ignore[assignment]
@@ -3593,8 +3595,8 @@ class List(Container[t.List[T]]):
 
     def __init__(
         self,
-        trait: t.List[T] | t.Tuple[T] | t.Set[T] | Sentinel | TraitType[T, t.Any] | None = None,
-        default_value: t.List[T] | t.Tuple[T] | t.Set[T] | Sentinel | None = Undefined,
+        trait: list[T] | tuple[T] | set[T] | Sentinel | TraitType[T, t.Any] | None = None,
+        default_value: list[T] | tuple[T] | set[T] | Sentinel | None = Undefined,
         minlen: int = 0,
         maxlen: int = sys.maxsize,
         **kwargs: t.Any,
@@ -3650,7 +3652,7 @@ class List(Container[t.List[T]]):
             return super().set(obj, value)
 
 
-class Set(Container[t.Set[t.Any]]):
+class Set(Container[set[t.Any]]):
     """An instance of a Python set."""
 
     klass = set
@@ -3725,7 +3727,7 @@ class Set(Container[t.Set[t.Any]]):
         return "{" + list_repr[1:-1] + "}"
 
 
-class Tuple(Container[t.Tuple[t.Any, ...]]):
+class Tuple(Container[tuple[t.Any, ...]]):
     """An instance of a Python tuple."""
 
     klass = tuple
@@ -3831,7 +3833,7 @@ class Tuple(Container[t.Tuple[t.Any, ...]]):
             raise TraitError(e)
 
         validated = []
-        for trait, v in zip(self._traits, value):
+        for trait, v in zip(self._traits, value, strict=True):
             try:
                 v = trait._validate(obj, v)
             except TraitError as error:
@@ -4193,7 +4195,7 @@ class TCPAddress(TraitType[G, S]):
         return (ip, port)  # type:ignore[return-value]
 
 
-class CRegExp(TraitType["re.Pattern[t.Any]", t.Union["re.Pattern[t.Any]", str]]):
+class CRegExp(TraitType[re.Pattern[t.Any], re.Pattern[t.Any] | str]):
     """A casting compiled regular expression trait.
 
     Accepts both strings and compiled regular expressions. The resulting


### PR DESCRIPTION
pytest 9.0.0 began requiring this version, so pytest-mypy-testing now fails when targeting earlier versions.

This also requires mypy 1.17.0 in tests, due to https://github.com/python/mypy/pull/19179.

Fixes #911 in passing while trying to get CI to pass.