### PR TITLE
Fix `traitlets.__all__`

### DIFF
--- a/traitlets/__init__.py
+++ b/traitlets/__init__.py
@@ -1,4 +1,5 @@
 """Traitlets Python configuration system"""
+
 from __future__ import annotations
 
 import typing as _t
@@ -12,14 +13,15 @@ from .utils.importstring import import_item
 from .utils.warnings import warn
 
 __all__ = [
-    "traitlets",
-    "__version__",
-    "version_info",
     "Bunch",
-    "signature_has_traits",
-    "import_item",
     "Sentinel",
+    "__version__",
+    "import_item",
+    "signature_has_traits",
+    "traitlets",
+    "version_info",
 ]
+__all__ += traitlets.__all__
 
 
 class Sentinel(traitlets.Sentinel):  # type:ignore[name-defined, misc]


### PR DESCRIPTION
Currently all imports from `traitlets.traitlets` raise a pylance typing error when imported from global scope:

<img width="782" height="121" alt="image" src="https://github.com/user-attachments/assets/c281716e-d80d-431a-b64a-248cc436b03c" />

You need to re-export the underlying `__all__` through the top level to fix these errors.