### PR TITLE
Removed pinning on virtualenv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.13", "3.14", "3.14t"]
         include:
-          - os: ubuntu-latest
-            python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.11"
           - os: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Pin virtualenv to pre-breaking major version
-        run: pipx inject --force hatch "virtualenv<21"
       - name: Run Tests
         run: hatch run cov:test
       - uses: jupyterlab/maintainer-tools/.github/actions/upload-coverage@v1
@@ -62,8 +60,6 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: minimum
-      - name: Pin virtualenv to pre-breaking major version
-        run: pipx inject --force hatch "virtualenv<21"
       - name: Run the unit tests
         run: |
           hatch run test:nowarn || hatch -v run test:nowarn --lf
@@ -74,8 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Pin virtualenv to pre-breaking major version
-        run: pipx inject --force hatch "virtualenv<21"
       - name: Run Linters
         run: |
           hatch run typing:test
@@ -89,8 +83,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Pin virtualenv to pre-breaking major version
-        run: pipx inject --force hatch "virtualenv<21"
       - name: Build the docs
         run: hatch run docs:build
 
@@ -105,8 +97,6 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: pre
-      - name: Pin virtualenv to pre-breaking major version
-        run: pipx inject --force hatch "virtualenv<21"
       - name: Run the tests
         run: |
           hatch run test:nowarn || hatch run test:nowarn --lf
@@ -143,8 +133,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Pin virtualenv to pre-breaking major version
-        run: pipx inject --force hatch "virtualenv<21"
       - name: Install Dependencies
         run: |
           pip install -e .


### PR DESCRIPTION
Fixes #938 

This also upgrades the minimal Python version to 3.10 since Python 3.9 has reached EOL.