### PR TITLE
Add `Path` trait for `pathlib.Path` values

### DIFF
--- a/docs/source/trait_types.rst
+++ b/docs/source/trait_types.rst
@@ -109,6 +109,8 @@ Miscellaneous
 
 .. autoclass:: CRegExp
 
+.. autoclass:: Path
+
 .. autoclass:: Union
    :members: __init__
 

--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import decimal
+import pathlib
 import pickle
 import re
 import typing as t
@@ -44,6 +45,7 @@ from traitlets import (
     Long,
     MetaHasTraits,
     ObjectName,
+    Path,
     Set,
     TCPAddress,
     This,
@@ -1641,6 +1643,20 @@ class TestTCPAddress(TraitTestBase):
     _default_value = ("127.0.0.1", 0)
     _good_values = [("localhost", 0), ("192.168.0.1", 1000), ("www.google.com", 80)]
     _bad_values = [(0, 0), ("localhost", 10.0), ("localhost", -1), None]
+
+
+class PathTrait(HasTraits):
+    value = Path()
+
+
+class TestPath(TraitTestBase):
+    obj = PathTrait()
+
+    _good_values = ["foo", "foo/bar", pathlib.Path("foo"), pathlib.PurePath("foo")]
+    _bad_values = [0, 10.0, None, ["foo"]]
+
+    def coerce(self, value):
+        return pathlib.Path(value)
 
 
 class ListTrait(HasTraits):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -46,6 +46,7 @@ import enum
 import inspect
 import numbers
 import os
+import pathlib
 import re
 import sys
 import types
@@ -111,6 +112,7 @@ __all__ = [
     "MetaHasTraits",
     "ObjectName",
     "ObserveHandler",
+    "Path",
     "Set",
     "TCPAddress",
     "This",
@@ -4206,6 +4208,25 @@ class CRegExp(TraitType["re.Pattern[t.Any]", t.Union["re.Pattern[t.Any]", str]])
             return re.compile(value)
         except Exception:
             self.error(obj, value)
+
+
+class Path(TraitType["pathlib.Path", t.Union["pathlib.Path", str, "os.PathLike[str]"]]):
+    """A trait for filesystem paths.
+
+    Accepts strings and :class:`os.PathLike` objects. The resulting
+    attribute will be a :class:`pathlib.Path` instance."""
+
+    info_text = "a filesystem path"
+
+    def validate(self, obj: t.Any, value: t.Any) -> pathlib.Path | None:
+        if isinstance(value, (str, os.PathLike)):
+            return pathlib.Path(value)
+        self.error(obj, value)
+
+    def from_string(self, s: str) -> pathlib.Path | None:
+        if self.allow_none and s == "None":
+            return None
+        return pathlib.Path(s)
 
 
 class UseEnum(TraitType[t.Any, t.Any]):


### PR DESCRIPTION
Adds a `Path` trait that accepts strings and `os.PathLike` objects and stores them as `pathlib.Path` instances, including `from_string` support for command-line configuration. This implements the request in #607, where the design (mapping onto `pathlib.Path`) was confirmed by maintainers.

Closes #607