### PR TITLE
Fix container from_string collation for a single allow_none value (#908)

### DIFF
--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -3040,6 +3040,41 @@ def test_list_items_from_string(s, expected, value_trait):
     _from_string_test(List(value_trait), s, expected)
 
 
+@pytest.mark.parametrize("container", [List, Set, Tuple])
+def test_container_from_string_single_value_allow_none(container):
+    """Regression test for https://github.com/ipython/traitlets/issues/908.
+
+    ``from_string`` receives a single, non-literal string. It must not
+    silently coerce it to ``None`` on ``allow_none`` containers: a bare
+    string is not a container, so validation must reject it. This lets the
+    config loader fall back to collating the value into a single-item list
+    (e.g. ``--Class.trait=value`` -> ``['value']``) instead of ``None``.
+    """
+    trait = container(allow_none=True)
+    trait.name = "a_trait"
+    with pytest.raises(TraitError):
+        trait.from_string("a_value")
+
+
+def test_list_allow_none_single_cli_value_is_collated():
+    """End-to-end regression for issue #908.
+
+    ``--MyApp.a_list=a_value`` with ``a_list = List(allow_none=True)`` must
+    yield ``['a_value']``, not ``None`` (regression introduced in #885).
+    """
+    from traitlets.config import Application, Config
+    from traitlets.config.loader import DeferredConfigString
+
+    class MyApp(Application):
+        a_list = List(allow_none=True).tag(config=True)
+
+    config = Config()
+    config.MyApp.a_list = DeferredConfigString("a_value")
+    app = MyApp()
+    app.update_config(config)
+    assert app.a_list == ["a_value"]
+
+
 @pytest.mark.parametrize(
     "s, expected",
     [

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -3530,7 +3530,11 @@ class Container(Instance[T]):
         try:
             test = literal_eval(s)
         except Exception:
-            test = None
+            # Not a literal; validate the original string so it is rejected
+            # (a bare string is not a container) and callers can fall back to
+            # collating it into a single-item list. Substituting ``None`` here
+            # would be wrongly accepted by ``allow_none`` containers.
+            test = s
         return self.validate(None, test)
 
     def from_string_list(self, s_list: list[str]) -> T | None:


### PR DESCRIPTION
Fixes #908.

## Root cause

`Container.from_string` (`traitlets/traitlets.py`) turns a value that fails `literal_eval` into `None`, then passes it to `validate`:

```python
try:
    test = literal_eval(s)
except Exception:
    test = None
return self.validate(None, test)
```

Before #885, `Instance.validate(None, None)` always raised (`None` is not a `list`/`set`/`tuple`), so `DeferredConfigString.get_value` / `DeferredConfigList.get_value` caught the error and let the original string "lie", which is later collated into a single-item list.

PR #885 added an `allow_none` short-circuit to `Instance.validate`:

```python
if self.allow_none and value is None:
    return value
```

For an `allow_none=True` container this now accepts the substituted `None` instead of raising, so `from_string` returns `None` and the collation fallback never happens. A single `--Class.trait=value` therefore resolves to `None` instead of `['value']`.

(The regression was bisected to #885 in the issue, and the mechanism was identified by @krassowski there.)

## Reproduction

```python
from traitlets.config import Application, Config
from traitlets.config.loader import DeferredConfigString
from traitlets import List

class MyApp(Application):
    a_list = List(allow_none=True).tag(config=True)

config = Config()
config.MyApp.a_list = DeferredConfigString("a_value")
app = MyApp()
app.update_config(config)
print(repr(app.a_list))
```

Observed on current `main` (wrong):

```
None
```

Expected / after this fix (and the behaviour on 5.12.0, before #885):

```
['a_value']
```

## Fix

In `Container.from_string`, when `literal_eval` fails, validate the original string instead of substituting `None`:

```python
try:
    test = literal_eval(s)
except Exception:
    test = s
return self.validate(None, test)
```

A bare string is not a container, so `validate` raises exactly as it did before #885 (independent of `allow_none`), and `DeferredConfig.get_value` falls back to collating the value into a single-item list. This is localized to the `except` branch and does not touch the `allow_none` handling in `Instance.validate`; the successful-parse path (including the `"None"` convention already covered by `from_string_list`) is unchanged.

## Tests

Added to `tests/test_traitlets.py`:

- `test_container_from_string_single_value_allow_none` (parametrized over `List`, `Set`, `Tuple`): asserts `from_string("a_value")` on an `allow_none=True` container raises `TraitError` rather than silently returning `None`.
- `test_list_allow_none_single_cli_value_is_collated`: end-to-end check that a single deferred config value resolves to `['a_value']`.

Both tests fail on unmodified `main` (the end-to-end one fails with `assert None == ['a_value']`) and pass with the fix. The full existing suite passes (591 passed, 1 skipped), and `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

Disclosure: prepared with AI assistance; reviewed and verified locally.
