### PR TITLE
Remove dead code and stale Python 2 leftovers (with the help of Claude Fable)

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -67,7 +67,7 @@ For instance, to set `C.a=[0,1,2]`, you may type this:
 """.strip()  # trim newlines of front and back
 
 # sys.argv can be missing, for example when python is embedded. See the docs
-# for details: http://docs.python.org/2/c-api/intro.html#embedding-python
+# for details: https://docs.python.org/3/c-api/intro.html#embedding-python
 if not hasattr(sys, "argv"):
     sys.argv = [""]
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -77,11 +77,6 @@ class ArgumentParser(argparse.ArgumentParser):
 # -----------------------------------------------------------------------------
 
 
-def execfile(fname: str, glob: dict[str, Any]) -> None:
-    with open(fname, "rb") as f:
-        exec(compile(f.read(), fname, "exec"), glob, glob)  # noqa: S102
-
-
 class LazyConfigValue(HasTraits):
     """Proxy object for exposing methods on configurable containers
 
@@ -249,10 +244,6 @@ class Config(dict):  # type:ignore[type-arg]
             obj = self[key]
             if _is_section_key(key) and isinstance(obj, dict) and not isinstance(obj, Config):
                 setattr(self, key, Config(obj))
-
-    def _merge(self, other: t.Any) -> None:
-        """deprecated alias, use Config.merge()"""
-        self.merge(other)
 
     def merge(self, other: t.Any) -> None:
         """merge another config object into this one"""

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -62,9 +62,6 @@ from .utils.warnings import deprecated_method, should_warn, warn
 
 SequenceTypes = (list, tuple, set, frozenset)
 
-# backward compatibility, use to differ between Python 2 and 3.
-ClassTypes = (type,)
-
 if t.TYPE_CHECKING:
     from typing_extensions import TypeVar
 else:


### PR DESCRIPTION
- ClassTypes tuple in traitlets.py, a Python 2/3 compat constant never used and not exported
- execfile() shim in config/loader.py, shadowing the removed Python 2 builtin, never called
- Config._merge in config/loader.py, a deprecated private alias for Config.merge that was never called and never warned