### PR TITLE
Remove tests_check job from CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,21 +138,3 @@ jobs:
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  tests_check: # This job does nothing and is only used for the branch protection
-    if: always()
-    needs:
-      - coverage
-      - test_lint
-      - test_docs
-      - test_minimum_versions
-      - test_prereleases
-      - check_links
-      - check_release
-      - test_sdist
-    runs-on: ubuntu-latest
-    steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
Removed the `tests_check` job from the GitHub Actions workflow that was used for branch protection status checks.

## Changes
- Deleted the `tests_check` job that aggregated the status of all other test jobs using the `alls-green` action
- This job was a no-op that only served to provide a single branch protection rule by collecting results from:
  - coverage
  - test_lint
  - test_docs
  - test_minimum_versions
  - test_prereleases
  - check_links
  - check_release
  - test_sdist

## Notes
Branch protection rules should be updated to reference individual job statuses directly instead of relying on this aggregation job.

https://claude.ai/code/session_01CgaWwFHViCQUgmqTaCpjsq