### PR TITLE
Update pre-commit hooks and fix the resulting fallout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 ci:
   autoupdate_schedule: monthly
   autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-case-conflict
       - id: check-ast
@@ -21,12 +22,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.4
+    rev: 0.37.4
     hooks:
       - id: check-github-workflows
 
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
     hooks:
       - id: mdformat
         additional_dependencies:
@@ -39,19 +40,19 @@ repos:
         types_or: [yaml, html, json]
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.16.0"
+    rev: "1.20.0"
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.7.0]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
+    rev: "v2.4.3"
     hooks:
       - id: codespell
         args: ["-L", "sur,nd"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.20.2"
+    rev: "v2.3.0"
     hooks:
       - id: mypy
         files: "^traitlets"
@@ -67,7 +68,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         types_or: [python, jupyter]
@@ -76,7 +77,7 @@ repos:
         types_or: [python, jupyter]
 
   - repo: https://github.com/scientific-python/cookie
-    rev: "2024.01.24"
+    rev: "2026.06.18"
     hooks:
       - id: sp-repo-review
         additional_dependencies: ["repo-review[cli]"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 
 ### Enhancements made
 
-- Add option to load  traitlets values from environment. [#856](https://github.com/ipython/traitlets/pull/856) ([@Carreau](https://github.com/Carreau))
+- Add option to load traitlets values from environment. [#856](https://github.com/ipython/traitlets/pull/856) ([@Carreau](https://github.com/Carreau))
 
 ### Maintenance and upkeep improvements
 
@@ -265,7 +265,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 
 ### Other merged PRs
 
-- Clean up license (#832)Co-authored-by: pre-commit-ci\[bot\] \<66853113+pre-commit-ci\[bot\]@users.noreply.github.com> [#832](https://github.com/ipython/traitlets/pull/832) ([@dcsaba89](https://github.com/dcsaba89))
+- Clean up license (#832)Co-authored-by: pre-commit-ci[bot] \<66853113+pre-commit-ci[bot]@users.noreply.github.com> [#832](https://github.com/ipython/traitlets/pull/832) ([@dcsaba89](https://github.com/dcsaba89))
 
 ### Contributors to this release
 
@@ -328,7 +328,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 
 ### Documentation improvements
 
-- Additional `Application` examples and docs  [#811](https://github.com/ipython/traitlets/pull/811) ([@azjps](https://github.com/azjps))
+- Additional `Application` examples and docs [#811](https://github.com/ipython/traitlets/pull/811) ([@azjps](https://github.com/azjps))
 
 ### Contributors to this release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ test = [
     # `reveal_type()` representations were simplified (dropping the `builtins.`
     # prefix) in https://github.com/python/mypy/pull/20929; test assertions in
     # tests/test_typing.py target that newer output, so require >=1.20.
-    # mypy 2.0 narrowed the `int()` overloads, so traitlets.Int carries a
-    # `call-overload` ignore that older versions flag as unused: require >=2.0.
     "mypy>=2.0; implementation_name != 'pypy'",
     "pre-commit",
     "pytest-mock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ test = [
     # `reveal_type()` representations were simplified (dropping the `builtins.`
     # prefix) in https://github.com/python/mypy/pull/20929; test assertions in
     # tests/test_typing.py target that newer output, so require >=1.20.
-    "mypy>=1.20; implementation_name != 'pypy'",
+    # mypy 2.0 narrowed the `int()` overloads, so traitlets.Int carries a
+    # `call-overload` ignore that older versions flag as unused: require >=2.0.
+    "mypy>=2.0; implementation_name != 'pypy'",
     "pre-commit",
     "pytest-mock",
     "pytest-mypy-testing; implementation_name != 'pypy'",
@@ -118,6 +120,7 @@ follow_imports_for_stubs = true
 minversion = "6.0"
 xfail_strict = true
 log_cli_level = "info"
+log_level = "info"
 addopts = [
   "-ra", "--durations=10", "--color=yes", "--doctest-modules",
    "--showlocals", "--strict-markers", "--strict-config",
@@ -171,6 +174,12 @@ exclude_lines = [
 relative_files = true
 source = ["traitlets"]
 
+[tool.repo-review]
+# traitlets publishes `traitlets[test]` / `traitlets[docs]` as documented
+# extras (see README and .github/workflows/downstream.yml), so the extras
+# stay the source of truth rather than [dependency-groups].
+ignore = ["PP006"]
+
 [tool.ruff]
 line-length = 100
 
@@ -213,7 +222,10 @@ ignore = [
   "SIM105", # Use `contextlib.suppress(ValueError)`
   "SIM108", # Use ternary operator
   "SIM114", # Combine `if` branches using logical `or` operator"
-  "PLC0415", # `import` should be at the top-level of a file (traitlets uses lazy/optional imports)
+  # Imports are deliberately deferred to break circular imports between
+  # traitlets.log and traitlets.config, and to keep optional dependencies
+  # (argcomplete) and slow stdlib imports out of the import path.
+  "PLC0415", # `import` should be at the top-level of a file
   "PLW2901", # `for` loop variable `path` overwritten by assignment target
   # https://github.com/astral-sh/ruff/issues/8796#issuecomment-1825907715
   "PT001", "PT02", "PT009"
@@ -237,8 +249,8 @@ isort.required-imports = ["from __future__ import annotations"]
 # S301 `pickle` and modules that wrap..."
 # PGH003 Use specific rule codes when ignoring type issues
 # RUF059 Unpacked variable is never used (e.g. `out, err = capsys.readouterr()`)
-# PLW0108 Lambda may be unnecessary
-# B024 Abstract base class without abstract methods (test fixtures)
+# PLW0108 Lambda may be unnecessary (tests use lambdas as Callable trait values)
+# B024 Abstract base class without abstract methods (mimics downstream code)
 "tests/*" = ["B011", "F841", "C408", "E402", "T201", "B007", "N802",
                        "B018", "S301", "ARG", "PGH003", "RUF059", "PLW0108", "B024"]
 "traitlets/config/application.py" = ["T201"]

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -910,6 +910,9 @@ class _CallbackWrapper:
 
     The comparison operator __eq__ is implemented to enable removal of wrapped
     callbacks.
+
+    __hash__ is deliberately left unset: instances compare equal to the callback
+    they wrap, so no hash could stay consistent with __eq__.
     """
 
     def __init__(self, cb: t.Any) -> None:
@@ -2624,7 +2627,7 @@ class Int(TraitType[G, S]):
             # allow casting integer-valued numbers to int
             # allows for more concise assignment like `4e9` which is a float
             try:
-                int_value = int(value)
+                int_value = int(value)  # type:ignore[call-overload]
                 if int_value == value:
                     value = int_value
             except Exception:

--- a/traitlets/utils/warnings.py
+++ b/traitlets/utils/warnings.py
@@ -45,7 +45,7 @@ def deprecated_method(method: t.Any, cls: t.Any, method_name: str, msg: str) -> 
         warnings.warn_explicit(warn_msg, DeprecationWarning, fname, lineno)
 
 
-_deprecations_shown = set()
+_deprecations_shown: set[tuple[str, str, int]] = set()
 
 
 def should_warn(key: t.Any) -> bool:


### PR DESCRIPTION
Bump every pre-commit hook to a current release, including the mdformat repo move from executablebooks to hukkin, mypy v2.3.0 and ruff v0.15.22, then fix what the newer tools surface:

- mypy 2.0 narrowed the `int()` overloads, so `Int.validate` needs a `call-overload` ignore. Older versions report that ignore as unused, so require mypy>=2.0 rather than >=1.20; the reveal_type assertions in tests/test_typing.py still pass on 2.x.
- Annotate `_deprecations_shown` in utils/warnings.py.
- Document why `_CallbackWrapper` deliberately leaves `__hash__` unset.
- Reformat CHANGELOG.md (stray double spaces, bracket escaping).
- Ignore ruff PLC0415, since traitlets defers imports to break cycles and to keep optional/slow imports off the import path, and repo-review PP006, since the published extras stay the source of truth.
- Set pytest log_level = "info".