### PR TITLE
Add scoped singleton registries to SingletonConfigurable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, html, json]
+        language_version: system
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: "1.20.0"

--- a/docs/source/config-api.rst
+++ b/docs/source/config-api.rst
@@ -9,6 +9,9 @@ Traitlets config API reference
 .. autoclass:: SingletonConfigurable
     :members:
 
+.. autoclass:: SingletonScope
+    :members:
+
 .. autoclass:: LoggingConfigurable
     :members:
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -73,6 +73,203 @@ Singletons: :class:`~traitlets.config.SingletonConfigurable`
     of a given singleton class, but the :meth:`instance` method will always
     return the same one.
 
+Singleton scopes
+----------------
+
+.. versionadded:: 5.17
+
+By default :meth:`~traitlets.config.SingletonConfigurable.instance` resolves
+against a single, process-global registry. A :class:`~traitlets.config.SingletonScope`
+provides an isolated registry that is active only for a dynamic extent (the
+current thread or :mod:`asyncio` task), leaving the global one untouched. This is
+useful when you need to run code that internally calls ``.instance()`` — code you
+do not control — against a fresh set of singletons, for example in a test or when
+serving concurrent requests.
+
+Create a scope from the base class whose subtree it should cover with
+:meth:`~traitlets.config.SingletonConfigurable.scope`, then activate it as a
+context manager:
+
+.. sourcecode:: python
+
+    a = MyApp.instance()  # process-global instance
+
+    scope = MyApp.scope()  # covers MyApp and its subclasses
+    with scope():
+        third_party_function()  # its internal MyApp.instance() calls...
+        b = MyApp.instance()  # ...resolve to this fresh instance
+        assert b is not a
+    assert MyApp.instance() is a  # global untouched, exception-safe
+
+    scope.get(MyApp)  # -> b, retrieve what was created in-scope
+    with scope():  # re-entering resumes the same registry
+        assert MyApp.instance() is b
+
+Key semantics:
+
+- **Coverage is defined by the base class.** ``Foo.scope()`` only intercepts
+  ``.instance()`` for ``Foo`` and its subclasses; unrelated singletons keep
+  resolving against the global registry. Pick a narrower base to limit the blast
+  radius, or ``SingletonConfigurable`` itself for a complete blank slate (see
+  below).
+- **No fallback to the global.** Inside a scope, the first ``.instance()`` call
+  creates a fresh instance registered in the scope; :meth:`instance` never reads,
+  creates, or mutates the process-global ``_instance``, and
+  :meth:`~traitlets.config.SingletonConfigurable.initialized` is ``False`` until
+  that first in-scope creation.
+- **Pre-seeding.** :meth:`~traitlets.config.SingletonScope.add` registers an
+  instance you built yourself, so that ``.instance()`` returns *that* object
+  inside the scope (see :ref:`singleton-scope-injection`).
+- **Nesting and propagation.** Scopes nest; the innermost active scope covering a
+  class wins, and blocks restore in LIFO order (even on exceptions). Because the
+  active scope lives in a :class:`~contextvars.ContextVar`, an :mod:`asyncio` task
+  created inside a scope inherits it. A new :class:`threading.Thread` started
+  inside a scope inherits it only when :data:`sys.flags.thread_inherit_context`
+  is set (see the caveat below); otherwise the thread falls through to the global
+  registry.
+- **Direct construction is never intercepted.** ``MyApp()`` always builds a new,
+  unregistered object, in or out of a scope.
+
+.. warning::
+
+   **Free-threaded builds inherit the scope in child threads.** Whether a newly
+   started :class:`threading.Thread` inherits the parent's active scope is
+   governed by :data:`sys.flags.thread_inherit_context`. On the default
+   GIL-enabled build this flag is *false*, so a child thread starts with an empty
+   :class:`~contextvars.Context` and its ``.instance()`` calls fall through to the
+   process-global registry. On the free-threaded build (e.g. ``3.14t``) the flag
+   defaults to *true*, so a child thread starts with a copy of the parent's
+   context and therefore resolves ``.instance()`` **within** the parent's scope.
+   (The same is true on any build launched with ``-X thread_inherit_context=1``.)
+
+   Do not rely on child threads escaping a scope. Activating a scope while this
+   flag is enabled emits a :class:`RuntimeWarning`. If you need per-thread
+   isolation, have each thread activate its *own* scope rather than depending on
+   non-inheritance — that pattern (below) works identically on both builds.
+
+Giving each worker thread its own isolated singleton works on every build: have
+every thread activate its own scope. Any ``.instance()`` calls made by that
+thread — directly or deep inside code it calls — then resolve to a per-thread
+instance, while the process-global singleton is left untouched:
+
+.. sourcecode:: python
+
+    import threading
+    from traitlets.config import SingletonConfigurable
+
+
+    class MyApp(SingletonConfigurable):
+        pass
+
+
+    seen = {}
+
+
+    def worker(name):
+        scope = MyApp.scope()  # a fresh registry, private to this thread
+        with scope():  # activate it for this thread's extent
+            app = MyApp.instance()  # created once, here...
+            assert MyApp.instance() is app  # ...and reused within the thread
+            seen[name] = app
+
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # each thread got its own distinct instance
+    assert len({id(app) for app in seen.values()}) == 3
+    # and none of them is the process-global singleton
+    assert all(app is not MyApp.instance() for app in seen.values())
+
+A complete blank slate
+**********************
+
+.. versionadded:: 5.17
+
+Because coverage is just ``issubclass(cls, base)``, scoping the root class —
+:class:`~traitlets.config.SingletonConfigurable` itself — covers *every*
+singleton in the process at once. This gives you a clean-room registry in which
+no singleton has been created yet, which is what you usually want when running a
+test, or any self-contained piece of work, in full isolation:
+
+.. sourcecode:: python
+
+    from traitlets.config import SingletonConfigurable
+
+
+    class Foo(SingletonConfigurable):
+        pass
+
+
+    class Bar(SingletonConfigurable):
+        pass
+
+
+    foo, bar = Foo.instance(), Bar.instance()  # process-global instances
+
+    with SingletonConfigurable.scope()():  # covers every singleton
+        # nothing has been created in here yet
+        assert not Foo.initialized()
+        assert not Bar.initialized()
+
+        assert Foo.instance() is not foo  # every subtree resolves fresh
+        assert Bar.instance() is not bar
+
+    # the process-global registry was never read, created, or mutated
+    assert Foo.instance() is foo
+    assert Bar.instance() is bar
+
+Note the double call: ``SingletonConfigurable.scope()`` *builds* the scope and
+``()`` *activates* it. Bind it to a name if you want to inspect the registry
+afterwards or re-enter it later::
+
+    blank = SingletonConfigurable.scope()
+    with blank():
+        ...
+    blank.get(Foo)  # what was created inside
+
+Since this covers everything, it is the widest possible blast radius: prefer a
+narrower base when you only need to isolate one subtree.
+
+.. _singleton-scope-injection:
+
+Injecting a specific instance
+*****************************
+
+.. versionadded:: 5.17
+
+Inside a scope, the first ``.instance()`` call constructs a fresh object of the
+class it was called on. When you need ``.instance()`` to hand back a *particular*
+object instead — a test double, a subclass, or something built by a factory —
+pre-seed the registry with :meth:`~traitlets.config.SingletonScope.add`. This is
+the only way to control *which* object uncontrolled code receives:
+
+.. sourcecode:: python
+
+    class App(SingletonConfigurable):
+        pass
+
+
+    class FakeApp(App):  # a stand-in used only by the test
+        pass
+
+
+    fake = FakeApp()
+
+    scope = App.scope()
+    scope.add(fake)  # register before anything resolves
+    with scope():
+        third_party_function()  # its internal App.instance() returns `fake`
+        assert App.instance() is fake
+
+``add`` writes through to the singleton ancestors of the instance's class, the
+same way the classic global path does, so the object is also returned when
+resolving via a parent class (``App.instance()`` above, not just
+``FakeApp.instance()``).
+
 Having described these main concepts, we can now state the main idea in our
 configuration system: *"configuration" allows the default values of class
 attributes to be controlled on a class by class basis*. Thus all instances of

--- a/tests/config/test_configurable.py
+++ b/tests/config/test_configurable.py
@@ -4,14 +4,23 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
 
+import asyncio
 import logging
+import sys
+import threading
+import warnings
 from unittest import TestCase
 
 import pytest
 
 from tests._warnings import expected_warnings
 from traitlets.config.application import Application
-from traitlets.config.configurable import Configurable, LoggingConfigurable, SingletonConfigurable
+from traitlets.config.configurable import (
+    Configurable,
+    LoggingConfigurable,
+    MultipleInstanceError,
+    SingletonConfigurable,
+)
 from traitlets.config.loader import Config
 from traitlets.log import get_logger
 from traitlets.traitlets import (
@@ -333,6 +342,260 @@ class TestSingletonConfigurable(TestCase):
         self.assertEqual(bam, Bam._instance)
         self.assertEqual(bam, Bar._instance)
         self.assertEqual(SingletonConfigurable._instance, None)
+
+
+class TestSingletonScope(TestCase):
+    def test_isolation(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        a = MyApp.instance()
+        scope = MyApp.scope()
+        with scope():
+            b = MyApp.instance()
+            self.assertIsNot(b, a)
+            self.assertIs(MyApp.instance(), b)
+
+        self.assertIs(MyApp.instance(), a)
+        self.assertIs(MyApp._instance, a)
+
+    def test_lazy_creation_uncontrolled_code(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        def third_party():
+            return MyApp.instance()
+
+        scope = MyApp.scope()
+        with scope():
+            b = third_party()
+            self.assertIs(scope.get(MyApp), b)
+
+    def test_no_global_side_effects(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        scope = MyApp.scope()
+        with scope():
+            MyApp.instance()
+
+        self.assertIsNone(MyApp._instance)
+        self.assertIs(MyApp.initialized(), False)
+
+    def test_initialized_false_before_creation_in_scope(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        MyApp.instance()
+        self.assertIs(MyApp.initialized(), True)
+
+        scope = MyApp.scope()
+        with scope():
+            self.assertIs(MyApp.initialized(), False)
+            MyApp.instance()
+            self.assertIs(MyApp.initialized(), True)
+
+    def test_reentry(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        scope = MyApp.scope()
+        with scope():
+            b = MyApp.instance()
+
+        with scope():
+            self.assertIs(MyApp.instance(), b)
+
+    def test_preseeding(self):
+        class Bar(SingletonConfigurable):
+            pass
+
+        class Bam(Bar):
+            pass
+
+        existing = Bam()
+        scope = Bar.scope()
+        scope.add(existing)
+        with scope():
+            self.assertIs(Bam.instance(), existing)
+            self.assertIs(Bar.instance(), existing)
+
+    def test_blank_slate_scope_covers_every_singleton(self):
+        """SingletonConfigurable.scope() isolates every singleton at once."""
+
+        class Alpha(SingletonConfigurable):
+            pass
+
+        class Beta(SingletonConfigurable):
+            pass
+
+        alpha, beta = Alpha.instance(), Beta.instance()
+
+        scope = SingletonConfigurable.scope()
+        self.assertTrue(scope.covers(Alpha))
+        self.assertTrue(scope.covers(Beta))
+
+        with scope():
+            # a clean room: nothing has been created in here yet
+            self.assertFalse(Alpha.initialized())
+            self.assertFalse(Beta.initialized())
+
+            in_alpha, in_beta = Alpha.instance(), Beta.instance()
+            self.assertIsNot(in_alpha, alpha)
+            self.assertIsNot(in_beta, beta)
+            self.assertIsInstance(in_alpha, Alpha)
+            self.assertIsInstance(in_beta, Beta)
+
+        # the process-global registry is untouched
+        self.assertIs(Alpha.instance(), alpha)
+        self.assertIs(Beta.instance(), beta)
+
+    def test_blast_radius(self):
+        class Foo(SingletonConfigurable):
+            pass
+
+        class Baz(SingletonConfigurable):
+            pass
+
+        scope = Foo.scope()
+        with scope():
+            Foo.instance()
+            self.assertIsNone(Foo._instance)
+
+            baz = Baz.instance()
+            self.assertIs(Baz._instance, baz)
+            self.assertIsNone(scope.get(Baz))
+
+    def test_nesting(self):
+        class Outer(SingletonConfigurable):
+            pass
+
+        outer_scope = Outer.scope()
+        inner_scope = Outer.scope()
+
+        with outer_scope():
+            o = Outer.instance()
+
+            with inner_scope():
+                i = Outer.instance()
+                self.assertIsNot(i, o)
+
+            self.assertIs(Outer.instance(), o)
+
+            try:
+                with inner_scope():
+                    raise RuntimeError("boom")
+            except RuntimeError:
+                pass
+
+            self.assertIs(Outer.instance(), o)
+
+    def test_mro_parity_in_scope(self):
+        class Bar(SingletonConfigurable):
+            pass
+
+        class Bam(Bar):
+            pass
+
+        scope1 = Bar.scope()
+        with scope1():
+            bam = Bam.instance()
+            self.assertIs(Bar.instance(), bam)
+
+        scope2 = Bar.scope()
+        with scope2():
+            Bar.instance()
+            with self.assertRaises(MultipleInstanceError):
+                Bam.instance()
+
+    def test_clear_instance_in_scope(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        a = MyApp.instance()
+        scope = MyApp.scope()
+        with scope():
+            b = MyApp.instance()
+            MyApp.clear_instance()
+            self.assertIsNone(scope.get(MyApp))
+            self.assertIs(MyApp._instance, a)
+
+            c = MyApp.instance()
+            self.assertIsNot(c, b)
+
+    @pytest.mark.skipif(
+        bool(getattr(sys.flags, "thread_inherit_context", 0)),
+        reason="When thread_inherit_context is enabled (the default on the "
+        "free-threaded build, e.g. 3.14t), a new threading.Thread starts with a "
+        "copy of the parent's contextvars.Context, so an active scope propagates "
+        "to child threads instead of falling through to the global registry.",
+    )
+    def test_thread_isolation(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        a = MyApp.instance()
+        scope = MyApp.scope()
+        results = {}
+        with scope():
+            b = MyApp.instance()
+
+            def target():
+                results["thread"] = MyApp.instance()
+
+            thread = threading.Thread(target=target)
+            thread.start()
+            thread.join()
+
+            self.assertIsNot(results["thread"], b)
+            self.assertIs(results["thread"], a)
+            self.assertIs(MyApp._instance, a)
+
+    def test_async_propagation(self):
+        class MyApp(SingletonConfigurable):
+            pass
+
+        scope = MyApp.scope()
+
+        async def coro():
+            return MyApp.instance()
+
+        async def main():
+            with scope():
+                b = MyApp.instance()
+                task = asyncio.create_task(coro())
+                result = await task
+                self.assertIs(result, b)
+
+        asyncio.run(main())
+
+    def test_free_threading_warning(self):
+        from unittest import mock
+
+        from traitlets.config import configurable
+
+        class MyApp(SingletonConfigurable):
+            pass
+
+        scope = MyApp.scope()
+
+        # When thread_inherit_context is enabled (the default on free-threaded
+        # builds) child threads inherit the scope, so activating one warns.
+        with (
+            mock.patch.object(configurable, "_threads_inherit_context", return_value=True),
+            pytest.warns(RuntimeWarning, match="thread_inherit_context"),
+            scope(),
+        ):
+            pass
+
+        # When it is disabled, activating a scope is silent.
+        with (
+            mock.patch.object(configurable, "_threads_inherit_context", return_value=False),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("error")
+            with scope():
+                pass
 
 
 class TestLoggingConfigurable(TestCase):

--- a/traitlets/config/__init__.py
+++ b/traitlets/config/__init__.py
@@ -16,5 +16,6 @@ __all__ = [  # noqa: F405
     "LoggingConfigurable",
     "MultipleInstanceError",
     "SingletonConfigurable",
+    "SingletonScope",
     "configurable",
 ]

--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -4,8 +4,11 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
 
+import contextlib
 import logging
+import sys
 import typing as t
+from contextvars import ContextVar
 from copy import deepcopy
 from textwrap import dedent
 
@@ -514,6 +517,106 @@ class LoggingConfigurable(Configurable):
         return logger.handlers[0]
 
 
+CT = t.TypeVar("CT", bound="SingletonConfigurable")
+
+
+_active_scopes: ContextVar[tuple[SingletonScope, ...]] = ContextVar("singleton_scopes", default=())
+
+
+def _threads_inherit_context() -> bool:
+    """Whether a new :class:`threading.Thread` inherits the caller's context.
+
+    Governed by :data:`sys.flags.thread_inherit_context`: false by default on the
+    GIL build, true by default on the free-threaded build (e.g. ``3.14t``) and on
+    any build launched with ``-X thread_inherit_context=1``. When true, an active
+    :class:`SingletonScope` propagates into threads started while it is active.
+    """
+    return bool(getattr(sys.flags, "thread_inherit_context", 0))
+
+
+class SingletonScope:
+    """An isolated singleton registry, activated for a dynamic extent.
+
+    While active (``with scope():``), :meth:`SingletonConfigurable.instance`
+    on any subclass of ``base`` resolves within this registry — creating
+    fresh instances on first use — in the current thread/async task.
+    Re-enterable: the registry persists across activations.
+
+    .. warning::
+
+        The scope lives in a :class:`~contextvars.ContextVar`. On builds where
+        :data:`sys.flags.thread_inherit_context` is enabled — the default on the
+        free-threaded build (e.g. ``3.14t``) — a :class:`threading.Thread`
+        started while the scope is active inherits a copy of the parent context
+        and resolves ``.instance()`` within the scope instead of the
+        process-global registry. Activating a scope under that flag emits a
+        :class:`RuntimeWarning`. For per-thread isolation, activate a fresh scope
+        inside each thread rather than relying on non-inheritance.
+
+    Scope ``SingletonConfigurable`` itself for a complete blank slate covering
+    every singleton in the process.
+
+    .. versionadded:: 5.17
+    """
+
+    def __init__(self, base: type[SingletonConfigurable]) -> None:
+        self.base = base
+        self._instances: dict[type, SingletonConfigurable] = {}
+
+    def covers(self, cls: type) -> bool:
+        """Whether ``cls`` resolves within this scope.
+
+        .. versionadded:: 5.17
+        """
+        return issubclass(cls, self.base)
+
+    def get(self, cls: type[CT]) -> CT | None:
+        """Registered instance for ``cls``, emulating class-attribute
+        inheritance: walk ``cls.__mro__`` and return the first hit.
+
+        .. versionadded:: 5.17
+        """
+        for klass in cls.__mro__:
+            if klass in self._instances:
+                return t.cast("CT", self._instances[klass])
+        return None
+
+    def add(self, inst: SingletonConfigurable) -> None:
+        """Pre-seed the registry with an instance you built yourself, so that
+        ``.instance()`` returns *that* object inside the scope.
+
+        Writes through to the singleton parents of ``type(inst)``, the same way
+        the classic global path does, so a subclass instance is also returned
+        when resolving via an ancestor class. This is the only way to control
+        *which* object in-scope ``.instance()`` calls receive, since they
+        otherwise construct a fresh one.
+
+        .. versionadded:: 5.17
+        """
+        for subclass in type(inst)._walk_mro():
+            self._instances[subclass] = inst
+
+    @contextlib.contextmanager
+    def __call__(self) -> t.Generator[SingletonScope, None, None]:
+        if _threads_inherit_context():
+            warnings.warn(
+                "A SingletonScope is being activated while thread_inherit_context "
+                "is enabled (the default on the free-threaded build, e.g. 3.14t). "
+                "A threading.Thread started while this scope is active inherits a "
+                "copy of the parent context, so its .instance() calls resolve "
+                "within this scope instead of falling through to the process-global "
+                "registry. Activate a fresh scope inside each thread if you need "
+                "per-thread isolation.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        token = _active_scopes.set((*_active_scopes.get(), self))
+        try:
+            yield self
+        finally:
+            _active_scopes.reset(token)
+
+
 class SingletonConfigurable(LoggingConfigurable):
     """A configurable that only allows one instance.
 
@@ -540,8 +643,41 @@ class SingletonConfigurable(LoggingConfigurable):
                 yield subclass
 
     @classmethod
+    def scope(cls) -> SingletonScope:
+        """Create a scope covering this class and its subclasses.
+
+        The returned :class:`SingletonScope` is not active yet; call it to
+        activate it for a dynamic extent (``with MyApp.scope()() as scope:``, or
+        bind it first to inspect or re-enter it later). Called on
+        ``SingletonConfigurable`` itself, it covers every singleton in the
+        process.
+
+        .. versionadded:: 5.17
+        """
+        return SingletonScope(cls)
+
+    @classmethod
+    def _current_scope(cls) -> SingletonScope | None:
+        """The innermost active scope covering ``cls``, or None."""
+        for scope in reversed(_active_scopes.get()):
+            if scope.covers(cls):
+                return scope
+        return None
+
+    @classmethod
     def clear_instance(cls) -> None:
-        """unset _instance for this class and singleton parents."""
+        """unset _instance for this class and singleton parents.
+
+        .. versionchanged:: 5.17
+            Inside an active :class:`SingletonScope`, clears the scope's
+            registry instead, leaving the process-global ``_instance`` alone.
+        """
+        scope = cls._current_scope()
+        if scope is not None:
+            for klass in list(scope._instances):
+                if isinstance(scope._instances[klass], cls):
+                    del scope._instances[klass]
+            return
         if not cls.initialized():
             return
         for subclass in cls._walk_mro():
@@ -577,7 +713,26 @@ class SingletonConfigurable(LoggingConfigurable):
             >>> bam = Bam.instance()
             >>> bam == Bar.instance()
             True
+
+        .. versionchanged:: 5.17
+            Inside an active :class:`SingletonScope`, resolves against that
+            scope's registry — creating a fresh instance on first use — without
+            reading, creating, or mutating the process-global ``_instance``.
         """
+        scope = cls._current_scope()
+        if scope is not None:
+            if scope.get(cls) is None:
+                inst = cls(*args, **kwargs)
+                for subclass in cls._walk_mro():
+                    scope._instances[subclass] = inst
+            existing = scope.get(cls)
+            if isinstance(existing, cls):
+                return existing
+            raise MultipleInstanceError(
+                f"An incompatible sibling of '{cls.__name__}' is already instantiated"
+                f" as singleton: {type(existing).__name__}"
+            )
+
         # Create and save the instance
         if cls._instance is None:
             inst = cls(*args, **kwargs)
@@ -596,5 +751,13 @@ class SingletonConfigurable(LoggingConfigurable):
 
     @classmethod
     def initialized(cls) -> bool:
-        """Has an instance been created?"""
+        """Has an instance been created?
+
+        .. versionchanged:: 5.17
+            Inside an active :class:`SingletonScope`, reports whether an
+            instance exists *in that scope*, ignoring the process-global one.
+        """
+        scope = cls._current_scope()
+        if scope is not None:
+            return scope.get(cls) is not None
         return hasattr(cls, "_instance") and cls._instance is not None


### PR DESCRIPTION
Introduce SingletonScope, an isolated singleton registry activated for a dynamic extent (current thread / async task) via a contextvars.ContextVar. While active, instance() on any subclass of the scope's base resolves within the scope -- creating fresh instances on first use -- without ever reading, creating, or mutating the process-global _instance. The classic (no-scope) instance()/initialized()/clear_instance() paths are left textually unchanged; scoped resolution is prepended as an early branch.

- SingletonScope with covers()/get() (MRO-walk parity)/add() (write-through pre-seeding) and a re-enterable __call__ context manager
- SingletonConfigurable.scope() factory and _current_scope() helper
- Export SingletonScope from traitlets.config
- Tests covering isolation, lazy creation by uncontrolled code, no global side effects, initialized() semantics, re-entry, pre-seeding, blast radius, nesting/LIFO restore, MRO sibling MultipleInstanceError parity, in-scope clear_instance, thread isolation, and asyncio task propagation
- Docs: "Singleton scopes" section with usage/semantics and a per-thread singleton example