### PR TITLE
Add a document of 'best practices' on designing with traitlets

### DIFF
--- a/docs/source/best-practices.md
+++ b/docs/source/best-practices.md
@@ -1,6 +1,6 @@
-# Tips for using Traitlets
+# Best Practices
 
-A collection of useful design tips for using traitlets in your
+A collection of useful design tips & best practices for using traitlets in your
 application or library.
 
 ## Avoid using "pure config" objects

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ the configuration machinery.
     trait_types
     defining_traits
     api
-    tips
+    best-practices
     config
     config-api
     utils

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ the configuration machinery.
     trait_types
     defining_traits
     api
+    tips
     config
     config-api
     utils

--- a/docs/source/tips.md
+++ b/docs/source/tips.md
@@ -14,36 +14,24 @@ So instead of:
 
 ```python
 class SpawnerConfig(LoggingConfigurable):
-    some_config = Unicode(
-        "",
-        config=True
-    )
+    some_config = Unicode("", config=True)
 
-    some_other_config = Unicode(
-        "default",
-        config=True
-    )
+    some_other_config = Unicode("default", config=True)
+
 
 class Spawner:
     def spawn(self, config: SpawnerConfig):
         print(config.some_config)
         # Do things with config
-
 ```
 
 Prefer:
 
 ```python
 class Spawner(LoggingConfigurable):
-    some_config = Unicode(
-        "",
-        config=True
-    )
+    some_config = Unicode("", config=True)
 
-    some_other_config = Unicode(
-        "default",
-        config=True
-    )
+    some_other_config = Unicode("default", config=True)
 
     def spawn(self):
         print(self.some_config)

--- a/docs/source/tips.md
+++ b/docs/source/tips.md
@@ -1,0 +1,50 @@
+# Tips for using Traitlets
+
+A collection of useful design tips for using traitlets in your
+application or library.
+
+## Avoid using "pure config" objects
+
+Put your traitlets config directly on the classes that are doing the work,
+rather than creating separate classes just for holding configuration. This
+keeps configuration close to the code it is configuring, and helps with
+discoverability as well.
+
+So instead of:
+
+```python
+class SpawnerConfig(LoggingConfigurable):
+    some_config = Unicode(
+        "",
+        config=True
+    )
+
+    some_other_config = Unicode(
+        "default",
+        config=True
+    )
+
+class Spawner:
+    def spawn(self, config: SpawnerConfig):
+        print(config.some_config)
+        # Do things with config
+
+```
+
+Prefer:
+
+```python
+class Spawner(LoggingConfigurable):
+    some_config = Unicode(
+        "",
+        config=True
+    )
+
+    some_other_config = Unicode(
+        "default",
+        config=True
+    )
+
+    def spawn(self):
+        print(self.some_config)
+```


### PR DESCRIPTION
The Jupyter ecosystem uses traitlets a lot, but there's not a lot of 'design documentation' that tells you how to design your applications to use traitlets. This is the start that at least provides a collection of tips for folks