### PR TITLE
Remove hatch --lf fallback that could mask test failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,8 +59,7 @@ jobs:
         with:
           dependency_type: minimum
       - name: Run the unit tests
-        run: |
-          hatch run test:nowarn || hatch -v run test:nowarn --lf
+        run: hatch run test:nowarn
 
   test_lint:
     name: Test Lint
@@ -96,8 +95,7 @@ jobs:
         with:
           dependency_type: pre
       - name: Run the tests
-        run: |
-          hatch run test:nowarn || hatch run test:nowarn --lf
+        run: hatch run test:nowarn
 
   make_sdist:
     name: Make SDist


### PR DESCRIPTION
## Summary
- Removes the `hatch run test:nowarn || hatch run test:nowarn --lf` fallback in the CI test workflow's Base Setup and Prereleases jobs.
- This pattern is wrong: if the first run fails without writing `lastfailed` data (e.g. a Python segfault), the `--lf` rerun silently runs nothing (or the wrong set of tests) and can report success, hiding a real failure.

## Test plan
- CI running `hatch run test:nowarn` directly on this PR.