### PR TITLE
Make downstream tests conditional on fast tests passing

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,13 +1,9 @@
 name: Test downstream projects
 
+# Called from tests.yml once the fast test jobs have passed, so we don't spend
+# runner time on downstream projects when traitlets itself is broken.
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-
-concurrency:
-  group: downstream-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   ipython:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,18 @@ jobs:
           python_package_manager: "uv pip"
       - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
 
+  # Downstream projects are slow and only meaningful if traitlets itself is
+  # healthy, so hold them until every fast job has finished and passed.
+  downstream:
+    needs:
+      - tests
+      - test_minimum_versions
+      - test_lint
+      - test_docs
+      - test_prereleases
+      - test_sdist
+    uses: ./.github/workflows/downstream.yml
+
   check_links:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
Refactored the downstream project testing workflow to run only after all fast test jobs have completed successfully, reducing unnecessary CI runner usage when the main test suite fails.

## Key Changes
- Modified `.github/workflows/tests.yml` to add a new `downstream` job that depends on all fast test jobs (`tests`, `test_minimum_versions`, `test_lint`, `test_docs`, `test_prereleases`, `test_sdist`)
- Converted `.github/workflows/downstream.yml` from a standalone workflow triggered on push/pull_request to a reusable workflow called via `workflow_call`
- Removed the `on: push` and `on: pull_request` triggers from `downstream.yml`
- Removed the `concurrency` configuration from `downstream.yml` (no longer needed for a called workflow)

## Implementation Details
The downstream workflow is now invoked as a reusable workflow from the main tests workflow, ensuring it only runs after all prerequisite fast tests pass. This prevents wasting CI runner resources on downstream project testing when traitlets itself has test failures.

https://claude.ai/code/session_01SQAvW1A6CBxpneLgjm4qJu