### PR TITLE
Skip CI tests for claude/* branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches-ignore:
+      - "claude/**"
   pull_request:
   schedule:
     - cron: "0 8 * * *"


### PR DESCRIPTION
## Summary
Updated the GitHub Actions test workflow to skip running tests on branches matching the `claude/*` pattern.

## Changes
- Added `branches-ignore` configuration to the `push` trigger in the Tests workflow
- Excludes any branches prefixed with `claude/` from triggering test runs on push events

## Details
This prevents unnecessary test runs on temporary or experimental branches following the `claude/*` naming convention, reducing CI resource usage while still running tests on all pull requests and scheduled runs.

https://claude.ai/code/session_01GhDHijG4Yq4A6wbEBxfV7U