### PR TITLE
Skip config loading for Configurables with no matching config

### DIFF
--- a/traitlets/config/configurable.py
+++ b/traitlets/config/configurable.py
@@ -171,12 +171,15 @@ class Configurable(HasTraits):
     ) -> None:
         """load traits from a Config object"""
 
+        my_config = self._find_my_config(cfg)
+        if not my_config:
+            # Nothing in the config applies to this instance; avoid the cost of
+            # computing traits() and entering hold_trait_notifications() for the
+            # many leaf Configurables that carry no matching config.
+            return
+
         if traits is None:
             traits = self.traits(config=True)
-        if section_names is None:
-            section_names = self.section_names()
-
-        my_config = self._find_my_config(cfg)
 
         # hold trait notifications until after all config has been loaded
         with self.hold_trait_notifications():


### PR DESCRIPTION
Configurable._load_config computed traits(config=True) and entered hold_trait_notifications() unconditionally, even for the many leaf Configurables in an Application graph whose config has no keys matching the instance. It now computes my_config first and returns early when it is empty, before doing any of that work.

Also removes a dead `section_names = self.section_names()` local that was computed (section_names() walks the MRO with issubclass checks, twice per instance) but never used — _find_my_config recomputes it internally. The section_names parameter is kept in the signature for backward compatibility.