### PR TITLE
Replace napoleon with numpydoc for docstring parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage.xml
 .cache
 htmlcov
 docs/source/CHANGELOG.md
+docs/source/changelog.md

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,9 +43,11 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.napoleon",
+    "numpydoc",
 ]
 github_project_url = "https://github.com/ipython/traitlets"
+
+numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ test = [
 ]
 docs = [
     "myst-parser",
+    "numpydoc",
     "pydata-sphinx-theme",
     "sphinx"
 ]


### PR DESCRIPTION
This PR switches the documentation build from using Sphinx's napoleon extension to numpydoc for parsing NumPy-style docstrings.