### PR TITLE
Drop type:ignore comments made unused by argcomplete 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         files: "^traitlets"
         stages: [manual]
         args: ["--install-types", "--non-interactive"]
-        additional_dependencies: ["argcomplete>=3.1"]
+        additional_dependencies: ["argcomplete>=3.7"]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: "v1.10.0"

--- a/traitlets/config/argcomplete_config.py
+++ b/traitlets/config/argcomplete_config.py
@@ -45,7 +45,7 @@ def get_argcomplete_cwords() -> list[str] | None:
             _cword_suffix,
             comp_words,
             _last_wordbreak_pos,
-        ) = argcomplete.split_line(comp_line, comp_point)  # type:ignore[attr-defined,no-untyped-call]
+        ) = argcomplete.split_line(comp_line, comp_point)  # type:ignore[attr-defined]
     except ModuleNotFoundError:
         return None
 
@@ -73,7 +73,7 @@ def increment_argcomplete_index() -> None:
         os.environ["_ARGCOMPLETE"] = str(int(os.environ["_ARGCOMPLETE"]) + 1)
     except Exception:
         try:
-            argcomplete.debug("Unable to increment $_ARGCOMPLETE", os.environ["_ARGCOMPLETE"])  # type:ignore[attr-defined,no-untyped-call]
+            argcomplete.debug("Unable to increment $_ARGCOMPLETE", os.environ["_ARGCOMPLETE"])  # type:ignore[attr-defined]
         except (KeyError, ModuleNotFoundError):
             pass
 
@@ -194,7 +194,7 @@ class ExtendedCompletionFinder(CompletionFinder):
         # Instead, check if comp_words only consists of the script,
         # if so check if any subcommands start with cword_prefix.
         if self.subcommands and len(comp_words) == 1:
-            argcomplete.debug("Adding subcommands for", cword_prefix)  # type:ignore[attr-defined,no-untyped-call]
+            argcomplete.debug("Adding subcommands for", cword_prefix)  # type:ignore[attr-defined]
             completions.extend(subc for subc in self.subcommands if subc.startswith(cword_prefix))
 
         return completions

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -1133,7 +1133,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
 
         from . import argcomplete_config
 
-        finder = argcomplete_config.ExtendedCompletionFinder()  # type:ignore[no-untyped-call]
+        finder = argcomplete_config.ExtendedCompletionFinder()
         finder.config_classes = classes
         finder.subcommands = list(subcommands or [])
         # for ease of testing, pass through self._argcomplete_kwargs if set


### PR DESCRIPTION
## Summary

The `Test Lint` job on `main` has been failing: argcomplete 3.7 ships inline annotations for `split_line()`, `debug()` and `CompletionFinder.__call__`, so the `no-untyped-call` ignores around those calls are now reported as `unused-ignore` and mypy exits non-zero.

(For the record, `packaging` was not involved — I confirmed the suite passes with `packaging` 26.3, and reverting argcomplete to 3.6.2 makes mypy clean again.)

## Changes

- Removed the `no-untyped-call` code from three ignores in `traitlets/config/argcomplete_config.py` (the `attr-defined` code is still needed and stays).
- Removed the whole ignore on `ExtendedCompletionFinder()` in `traitlets/config/loader.py`.
- Floored the mypy pre-commit hook's `argcomplete` dependency at `>=3.7` (was `>=3.1`), so the check means the same thing locally and in CI — on an older argcomplete the ignores would be required again.

The `no-untyped-call` ignores on `super()._get_completions` / `_get_option_completions` are untouched: those private methods are still unannotated.

## Verification

mypy clean over 24 source files and 706 tests passing against argcomplete 3.7.2. `Test Lint` is green on this branch.

https://claude.ai/code/session_0141ZmpAbm5FVsds8iNEotpp