### PR TITLE
Warn on unrecognized Configurable kwargs with UserWarning

### DIFF
--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -2841,9 +2841,11 @@ def test_configurable_unrecognized_args_user_warning():
     user = [w for w in caught if issubclass(w.category, UserWarning)]
     assert user
     assert "Passing unrecognized arguments" in str(user[0].message)
-    assert not any(issubclass(w.category, DeprecationWarning) and
-                   "Passing unrecognized arguments" in str(w.message)
-                   for w in caught)
+    assert not any(
+        issubclass(w.category, DeprecationWarning)
+        and "Passing unrecognized arguments" in str(w.message)
+        for w in caught
+    )
 
 
 def test_default_mro():

--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -2829,6 +2829,23 @@ def test_super_bad_args():
     assert not hasattr(obj, "b")
 
 
+def test_configurable_unrecognized_args_user_warning():
+    """Configurable should surface unknown kwargs as UserWarning (#926)."""
+    import warnings
+
+    from traitlets.config.configurable import Configurable
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Configurable(not_a_trait=1)
+    user = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert user
+    assert "Passing unrecognized arguments" in str(user[0].message)
+    assert not any(issubclass(w.category, DeprecationWarning) and
+                   "Passing unrecognized arguments" in str(w.message)
+                   for w in caught)
+
+
 def test_default_mro():
     """Verify that default values follow mro"""
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1399,7 +1399,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
                 f"{e}\n"
                 "This is deprecated in traitlets 4.2."
                 "This error will be raised in a future release of traitlets.",
-                DeprecationWarning,
+                UserWarning,
                 stacklevel=2,
             )
 


### PR DESCRIPTION
Fixes #926.

`HasTraits.__init__` already warns when leftover kwargs are passed through to `object.__init__`. The warning used `DeprecationWarning` at `stacklevel=2`, so for `Configurable` subclasses the reported frame is `Configurable.__init__` and IPython hides it.

@minrk noted that this is always a bug in the calling code and that `UserWarning` is appropriate. This switches the category so the message is visible by default, including for `Configurable` / `IPython.embed()` typos.