### PR TITLE
Name the offending key when per_key_traits rejects a value

### DIFF
--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -1961,6 +1961,35 @@ class TestInstanceFullyValidatedDict(TraitTestBase):
     _bad_values = [{"foo": 0, "bar": 1}, {"foo": "0", "bar": "1"}, {"foo": 0, 0: "1"}]
 
 
+def test_dict_per_key_traits_error_names_key():
+    """A `per_key_traits` failure should say which key was rejected."""
+
+    class Foo(HasTraits):
+        bar = Dict(per_key_traits={"this": Unicode(), "that": Int()})
+
+    with pytest.raises(TraitError) as excinfo:
+        Foo().bar = {"this": "ok", "that": "not an int"}
+
+    message = str(excinfo.value)
+    assert "at key 'that'" in message
+    assert "'bar' trait" in message
+    assert "an int" in message
+
+
+def test_dict_value_trait_error_does_not_name_a_key():
+    """A uniform `value_trait` failure still reports against the trait as a whole."""
+
+    class Foo(HasTraits):
+        bar = Dict(value_trait=Int())
+
+    with pytest.raises(TraitError) as excinfo:
+        Foo().bar = {"this": "not an int"}
+
+    message = str(excinfo.value)
+    assert message.startswith("Values of the 'bar' trait")
+    assert "at key" not in message
+
+
 def test_dict_default_value():
     """Check that the `{}` default value of the Dict traitlet constructor is
     actually copied."""

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -3995,6 +3995,16 @@ class Dict(Instance["dict[K, V]"]):
         )
         raise TraitError(e)
 
+    def per_key_element_error(
+        self, obj: t.Any, key: t.Any, element: t.Any, validator: t.Any
+    ) -> None:
+        """Raise a TraitError naming the key whose `per_key_traits` entry rejected a value."""
+        e = (
+            f"Value at key {key!r} of the '{self.name}' trait of {class_of(obj)} instance"
+            f" must be {validator.info()}, but a value of {repr_type(element)} was specified."
+        )
+        raise TraitError(e)
+
     def validate(self, obj: t.Any, value: t.Any) -> dict[K, V] | None:
         value = super().validate(obj, value)
         if value is None:
@@ -4020,6 +4030,8 @@ class Dict(Instance["dict[K, V]"]):
                 try:
                     v = active_value_trait._validate(obj, v)
                 except TraitError:
+                    if key in per_key_override:
+                        self.per_key_element_error(obj, key, v, active_value_trait)
                     self.element_error(obj, v, active_value_trait, "Values")
             validated[key] = v
 


### PR DESCRIPTION
Closes #920

A `Dict` configured with `per_key_traits` reports failures against the trait as a whole, so the message names the trait but never the key that was actually invalid:

```python
class Foo(HasTraits):
    bar = Dict(per_key_traits={"this": Unicode(), "that": Dict()})

Foo().bar = {"this": "valid", "that": False}
```

```
TraitError: Values of the 'bar' trait of a Foo instance must be a dict, but a
value of False <class 'bool'> was specified.
```

With more than one per-key trait configured, that leaves the caller to work out which key the message is about. Failures routed through a `per_key_traits` entry now name it:

```
TraitError: Value at key 'that' of the 'bar' trait of a Foo instance must be a
dict, but a value of False <class 'bool'> was specified.
```

Only the per-key path changes: it goes through a new `per_key_element_error` rather than `element_error`, so a uniform `value_trait` failure still reports against the trait as a whole. There's a test asserting that, since the wording of these messages is the sort of thing downstream test suites match on.

### Not addressed here

The issue also mentions nested dicts. Those are still misreported, and the cause is separate from the key naming:

```python
bar = Dict(per_key_traits={"that": Dict(per_key_traits={"that": Unicode()})})
Foo().bar = {"that": {"that": 3}}
# Value at key 'that' ... must be a dict, but a value of {'that': 3} <class 'dict'> was specified.
```

The value *is* a dict. The inner trait raises an accurate error, and the outer `validate_elements` discards it and substitutes its own. `TraitType.error` already has a chaining protocol for exactly this (child errors carrying `(value, info, *traits)`), which `Dict.validate_elements` bypasses.

Routing per-key failures through that protocol would fix the nested case, but it changes a shared error contract and the composed message shape, so it seemed worth agreeing on separately rather than folding into this one. Happy to do it in a follow-up if you'd like it, in whichever direction you prefer.



---

🤖🍆 Prepared with the help of an AI coding agent, marked as the contributing guide asks agents to do. Reviewed and tested by me.
