### PR TITLE
Let UseEnum select a member by value, not only by name or number

### DIFF
--- a/tests/test_traitlets_enum.py
+++ b/tests/test_traitlets_enum.py
@@ -34,6 +34,18 @@ class CSColor(enum.Enum):
     YeLLoW = 4
 
 
+class StrColor(str, enum.Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+class ShadowedColor(str, enum.Enum):
+    # A member name that collides with a different member's value
+    red = "green"
+    green = "blue"
+
+
 color_choices = ["red", "Green", "BLUE", "YeLLoW"]
 
 
@@ -128,6 +140,33 @@ class TestUseEnum(unittest.TestCase):
             example = self.Example()
             with self.assertRaises(TraitError):
                 example.color = value
+
+    def test_assign_str_enum_value(self):
+        # -- CONVERT: value (as string) => Enum value (item)
+        class Example(HasTraits):
+            color = UseEnum(StrColor)
+
+        for enum_item in StrColor.__members__.values():
+            example = Example()
+            example.color = enum_item.value
+            self.assertIs(example.color, enum_item)
+
+    def test_assign_str_enum_name_wins_over_value(self):
+        # -- A name lookup must keep taking precedence over a value lookup
+        class Example(HasTraits):
+            color = UseEnum(ShadowedColor)
+
+        example = Example()
+        example.color = "green"
+        self.assertIs(example.color, ShadowedColor.green)
+
+    def test_assign_bad_str_enum_value__raises_error(self):
+        class Example(HasTraits):
+            color = UseEnum(StrColor)
+
+        example = Example()
+        with self.assertRaises(TraitError):
+            example.color = "purple"
 
     def test_ctor_without_default_value(self):
         # -- IMPLICIT: default_value = Color.red (first enum-value)

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -4275,6 +4275,15 @@ class UseEnum(TraitType[t.Any, t.Any]):
             value = value.replace(self.name_prefix, "", 1)
         return self.enum_class.__members__.get(value, default)
 
+    def select_by_value(self, value: t.Any, default: t.Any = Undefined) -> t.Any:
+        """Selects enum-value by using its value-constant."""
+        enum_members = self.enum_class.__members__
+        for enum_item in enum_members.values():
+            if enum_item.value == value:
+                return enum_item
+        # -- NOT FOUND:
+        return default
+
     def validate(self, obj: t.Any, value: t.Any) -> t.Any:
         if isinstance(value, self.enum_class):
             return value
@@ -4286,6 +4295,11 @@ class UseEnum(TraitType[t.Any, t.Any]):
         elif isinstance(value, str):
             # -- CONVERT: name or scoped_name (as string) => enum_value (item)
             value2 = self.select_by_name(value)
+            if value2 is not Undefined:
+                return value2
+            # -- CONVERT: value (as string) => enum_value (item), for str-based enums
+            # whose member names differ from their values
+            value2 = self.select_by_value(value)
             if value2 is not Undefined:
                 return value2
         elif value is None:


### PR DESCRIPTION
Closes #827

`UseEnum` resolves a member from its name, its scoped name, or (for int-valued enums) its number. There is no lookup by value, so a `str`-based enum whose member names differ from their values cannot be set by value:

```python
class Color(str, enum.Enum):
    RED = "red"
    GREEN = "green"
    BLUE = "blue"

class MyEntity(HasTraits):
    color = UseEnum(Color, default_value=Color.BLUE)

MyEntity().color = "GREEN"   # fine, that is the member name
MyEntity().color = "green"   # TraitError, though it is Color.GREEN's value
```

```
TraitError: The 'color' trait of a MyEntity instance expected any of
['RED', 'BLUE', 'GREEN'], not the str 'green'.
```

The docstring example hides this because its member names are lowercase and equal to nothing else, so `"green"` happens to match a name. Give the members conventional uppercase names and the string form stops working entirely.

`select_by_value` is the non-numeric counterpart of the existing `select_by_number`, and the string branch of `validate` now falls back to it.

The change is additive. Name lookup is still attempted first, so every string that resolved before resolves to the same member; the new lookup only runs where a `TraitError` was previously raised. There is a test using an enum whose member name shadows a different member's value, so the precedence is pinned rather than incidental.

One thing worth a second opinion: `info()` still lists only member names, so the error text for a genuinely bad value reads `expected any of ['RED', 'BLUE', 'GREEN']` even though values are now accepted too. Widening it would change message text that downstream suites may match on, so I left it alone. Happy to include it if you'd rather they agree.



---

🤖🍆 Prepared with the help of an AI coding agent, marked as the contributing guide asks agents to do. Reviewed and tested by me.
