### PR TITLE
support mock.patch.object on HasTraits

### DIFF
--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -12,7 +12,7 @@ import pathlib
 import pickle
 import re
 import typing as t
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 
@@ -3199,3 +3199,19 @@ def test_all_attribute():
     for name in traitlets.__all__:
         if name not in names:
             raise ValueError(f"{name} should be removed from __all__")
+
+
+def test_mock_patch():
+    class A(HasTraits):
+        trait = Unicode(default_value="default")
+
+    a = A()
+    # not set, restores default
+    with mock.patch.object(a, "trait", "patch"):
+        assert a.trait == "patch"
+    assert a.trait == "default"
+    # set, restores before state
+    a.trait = "set"
+    with mock.patch.object(a, "trait", "patch"):
+        assert a.trait == "patch"
+    assert a.trait == "set"

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -729,6 +729,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         if obj is None:
             return self
         else:
+            assert self.name is not None
             if obj._trait_values.get(self.name, None) is _DELETED:
                 # if _DELETED sentinel is set, behave as if attribute is not set
                 # otherwise delattr does weird things
@@ -768,6 +769,7 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         """
         delattr stores a sentinel so `hasattr` returns False
         """
+        assert self.name is not None
         obj._trait_values[self.name] = _DELETED
 
     def _validate(self, obj: t.Any, value: t.Any) -> G | None:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -537,6 +537,9 @@ else:
     V = TypeVar("V")
 
 
+_DELETED = object()
+
+
 # We use a type for the getter (G) and setter (G) because we allow
 # for traits to cast (for instance CInt will use G=int, S=t.Any)
 class TraitType(BaseDescriptor, t.Generic[G, S]):
@@ -726,6 +729,10 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         if obj is None:
             return self
         else:
+            if obj._trait_values.get(self.name, None) is _DELETED:
+                # if _DELETED sentinel is set, behave as if attribute is not set
+                # otherwise delattr does weird things
+                raise AttributeError(self.name)
             return self.get(obj, cls)  # type:ignore[return-value]
 
     def set(self, obj: HasTraits, value: S) -> None:
@@ -756,6 +763,12 @@ class TraitType(BaseDescriptor, t.Generic[G, S]):
         if self.read_only:
             raise TraitError(f'The "{self.name}" trait is read-only.')
         self.set(obj, value)
+
+    def __delete__(self, obj: HasTraits) -> None:
+        """
+        delattr stores a sentinel so `hasattr` returns False
+        """
+        obj._trait_values[self.name] = _DELETED
 
     def _validate(self, obj: t.Any, value: t.Any) -> G | None:
         if value is None and self.allow_none:


### PR DESCRIPTION
`mock.patch.object` requires allowing `delattr(has_traits, "trait")` to work and `hasattr(has_traits, "trait")` to be False afterward.

This fixes mock.patch.object on HasTraits objects, with a previously failing test.

Without this patch, test fails with:

```
    def __exit__(self, *exc_info):
        """Undo the patch."""
        if not self.is_started:
            return

        if self.is_local and self.temp_original is not DEFAULT:
            setattr(self.target, self.attribute, self.temp_original)
        else:
>           delattr(self.target, self.attribute)
E           AttributeError: __delete__
```

Initially, I had it just clear the state without the sentinel (could be useful for restoring defaults, for example), but in that case `hasattr(obj, 'trait')` returns True and mock.patch doesn't restore the before-patch value, it always returns to the default state.

I think the logic in unittest.mock is wrong in how it decides whether to set the original value back, but this is what we need to work with the current standard library.